### PR TITLE
fix: auto-create required GitHub labels

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -2496,6 +2496,47 @@ def _populate_claude_config():
     shutil.copytree(str(src), str(dst))
 
 
+REQUIRED_LABELS = {
+    "agent-plan": "1D76DB",
+    "claimed": "FBCA04",
+    "blocked": "B60205",
+    "has-pr": "5319E7",
+    "replan": "D93F0B",
+    "coordination": "0E8A16",
+}
+
+
+def _ensure_github_labels():
+    """Create any missing GitHub labels required by pod."""
+    try:
+        r = subprocess.run(
+            ["gh", "label", "list", "--limit", "100", "--json", "name", "--jq", ".[].name"],
+            capture_output=True, text=True, timeout=15,
+            cwd=str(PROJECT_DIR),
+        )
+        if r.returncode != 0:
+            print("  warning: could not list labels (gh CLI issue)")
+            return
+        existing = set(r.stdout.strip().splitlines())
+        created = []
+        for label, color in REQUIRED_LABELS.items():
+            if label not in existing:
+                cr = subprocess.run(
+                    ["gh", "label", "create", label, "--color", color,
+                     "--description", "pod coordination"],
+                    capture_output=True, text=True, timeout=15,
+                    cwd=str(PROJECT_DIR),
+                )
+                if cr.returncode == 0:
+                    created.append(label)
+        if created:
+            print(f"  created GitHub labels: {', '.join(created)}")
+        else:
+            print("  GitHub labels already exist")
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        print("  warning: could not ensure GitHub labels (gh CLI not available)")
+
+
 def cmd_init(args):
     """Bootstrap .pod/ in the current git repo."""
     # Verify we're in a git repo
@@ -2527,6 +2568,10 @@ def cmd_init(args):
     ISOLATED_CONFIG_DIR = pod_dir / "claude-config"
     _populate_claude_config()
     print(f"  populated {ISOLATED_CONFIG_DIR.relative_to(git_root)}/")
+
+    # Ensure required GitHub labels exist
+    _ensure_github_labels()
+
     print("pod init complete.")
 
 

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -83,6 +83,32 @@ die() { echo "error: $*" >&2; exit 1; }
 gh auth status --hostname github.com >/dev/null 2>&1 || \
     die "gh CLI not authenticated — run 'gh auth login' first"
 
+# Ensure required labels exist (idempotent).
+# Runs once per repo per shell session (cached via /tmp flag file).
+_ensure_labels_flag="/tmp/pod-labels-ensured-${REPO_SLUG}"
+_ensure_labels() {
+    [[ -f "$_ensure_labels_flag" ]] && return
+    local -A required_labels=(
+        [agent-plan]="1D76DB"
+        [claimed]="FBCA04"
+        [blocked]="B60205"
+        [has-pr]="5319E7"
+        [replan]="D93F0B"
+        [coordination]="0E8A16"
+    )
+    local existing
+    existing="$(gh label list --repo "$REPO" --limit 100 --json name --jq '.[].name')"
+    for label in "${!required_labels[@]}"; do
+        if ! echo "$existing" | grep -qx "$label"; then
+            gh label create "$label" --repo "$REPO" \
+                --color "${required_labels[$label]}" \
+                --description "pod coordination" 2>/dev/null || true
+        fi
+    done
+    touch "$_ensure_labels_flag"
+}
+_ensure_labels
+
 # Helper: get unclaimed issues as JSON array
 # Optional arg: extra label to filter by (e.g. "feature", "review")
 _unclaimed_issues() {


### PR DESCRIPTION
## Summary
- `pod init` now creates the 6 required GitHub labels (agent-plan, claimed, blocked, has-pr, replan, coordination) if they don't exist
- The coordination script also ensures labels exist on first run (cached per session via /tmp flag file)
- Previously, repos without these labels caused `gh issue create --label coordination` to fail silently, making the planner lock sentinel issue creation fail, which made dispatch return None indefinitely — agents would cycle between `waiting_dispatch` and `dispatch` forever

## Test plan
- [ ] Run `pod init` on a fresh repo with no pod labels — labels should be created
- [ ] Run `pod init` on a repo that already has the labels — should print "already exist"
- [ ] Run `pod add` after init — agent should dispatch successfully

🤖 Prepared with Claude Code