### PR TITLE
feat: enable auto-merge and squash merge during pod init

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -2537,6 +2537,23 @@ def _ensure_github_labels():
         print("  warning: could not ensure GitHub labels (gh CLI not available)")
 
 
+def _ensure_repo_merge_settings():
+    """Enable auto-merge and squash merge on the GitHub repo (best effort)."""
+    try:
+        r = subprocess.run(
+            ["gh", "repo", "edit", "--enable-auto-merge", "--enable-squash-merge"],
+            capture_output=True, text=True, timeout=15,
+            cwd=str(PROJECT_DIR),
+        )
+        if r.returncode == 0:
+            print("  enabled auto-merge and squash merge on GitHub repo")
+        else:
+            print("  warning: could not enable auto-merge/squash-merge "
+                  "(may need admin access — enable manually in repo Settings → General)")
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        print("  warning: could not configure repo merge settings (gh CLI not available)")
+
+
 def cmd_init(args):
     """Bootstrap .pod/ in the current git repo."""
     # Verify we're in a git repo
@@ -2571,6 +2588,9 @@ def cmd_init(args):
 
     # Ensure required GitHub labels exist
     _ensure_github_labels()
+
+    # GitHub repo merge settings (required for coordination create-pr auto-merge to work)
+    _ensure_repo_merge_settings()
 
     print("pod init complete.")
 


### PR DESCRIPTION
`coordination create-pr` enables auto-merge per-PR via `gh pr merge --auto --squash`, but this silently fails if the GitHub repo doesn't have auto-merge enabled in its settings. The `gh pr merge` call logs a warning but continues, leaving PRs unmerged.

This PR adds `_ensure_repo_merge_settings()` to `pod init` so that:
- Auto-merge is enabled on the GitHub repo (required for `gh pr merge --auto` to work)
- Squash merge is enabled (the merge strategy used by `coordination create-pr`)

Both settings are configured at project bootstrap time, so they're in place before any agents run.

Fixes the root cause of PRs submitted by agents not being merged automatically.

🤖 Prepared with Claude Code