### PR TITLE
fix: prevent double agent spawn when pressing 'a'

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -2242,6 +2242,7 @@ def _tui_main(stdscr, config: dict):
             spawn_agent(config)
             cur_target = read_target()
             write_target((cur_target or running) + 1)
+            last_auto_spawn_time = time.time()
             message = "Launched 1 agent"
             message_time = time.time()
         elif ch == ord("f") or ch == ord("F"):


### PR DESCRIPTION
## Summary
- When pressing `a` with no agents running, two agents were created instead of one
- The `a` key handler spawns an agent and sets `target=1`, but didn't reset `last_auto_spawn_time`
- On the next loop iteration, auto-spawn sees `target=1, running=0` (new agent not yet registered) and `last_auto_spawn_time=0.0`, so the 5-second cooldown check passes and spawns a duplicate

Fix: reset `last_auto_spawn_time` after manual spawn so the auto-spawn cooldown is respected.

🤖 Prepared with Claude Code