### PR TITLE
feat: human-oversight signal to return control when project is complete

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -2240,7 +2240,7 @@ def _tui_main(stdscr, config: dict):
         if cached_return_to_human:
             banner_row = msg_row + 1 if msg_active else msg_row
             if banner_row < height:
-                banner = " *** HUMAN OVERSIGHT: planner signals no work remains — target=0, agents finishing ***"
+                banner = " *** human-oversight signalled: no work remains — target=0, agents finishing ***"
                 _addstr(stdscr, banner_row, 0, banner[:width], curses.color_pair(2) | curses.A_BOLD)
 
         stdscr.refresh()

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -649,6 +649,14 @@ def get_return_to_human(config: dict) -> bool:
         return False
 
 
+def clear_return_to_human(config: dict) -> None:
+    """Remove the return-to-human signal from the sentinel issue."""
+    try:
+        coordination(config, "clear-human-oversight")
+    except subprocess.TimeoutExpired:
+        pass
+
+
 @dataclasses.dataclass
 class GHItem:
     """An issue or PR for TUI display."""
@@ -1865,9 +1873,19 @@ def _tui_main(stdscr, config: dict):
     blocked_deps_fetch_time = 0.0
     cached_lock_status: str | None = None  # "locked" or "unlocked"
     lock_fetch_time = 0.0
-    cached_return_to_human = False
+    # Check for pre-existing human-oversight signal synchronously at startup.
+    # If it was already set before this TUI session, we honour it (target=0, banner)
+    # but do NOT send SIGUSR1 — the human restarted pod intentionally.
+    try:
+        cached_return_to_human = get_return_to_human(config)
+    except Exception:
+        cached_return_to_human = False
     return_to_human_fetch_time = 0.0
-    _acted_on_return_to_human = False  # True once TUI has reacted (set target=0, sent finish)
+    # _acted_on_return_to_human: True once this session has already sent SIGUSR1.
+    # Set True at startup when signal was pre-existing so we skip the SIGUSR1 burst.
+    _acted_on_return_to_human = cached_return_to_human
+    if cached_return_to_human:
+        write_target(0)
     CACHE_SECS = 30  # Refresh interval for GitHub API data
 
     # Background fetch infrastructure: all GH/coordination calls run in daemon
@@ -2226,6 +2244,8 @@ def _tui_main(stdscr, config: dict):
                 input_mode = ""
         else:
             footer_text = " [a]dd  [f]inish  [k]ill  [o]pen  [!]force  [L]ock  [q]uit  [Q]uit all  ↑↓/1-9"
+            if cached_return_to_human:
+                footer_text = " [r]esume work  " + footer_text.lstrip()
 
         if footer_row2 < height:
             _addstr(stdscr, footer_row2, 0, footer_text[:width], curses.A_DIM)
@@ -2370,6 +2390,17 @@ def _tui_main(stdscr, config: dict):
                     message = f"Force quota {label} for {agent.short_id}"
                 except (OSError, json.JSONDecodeError) as e:
                     message = f"Failed to toggle force: {e}"
+                message_time = time.time()
+        elif ch == ord("r") or ch == ord("R"):
+            # Clear human-oversight signal and resume normal operation
+            if cached_return_to_human:
+                try:
+                    clear_return_to_human(config)
+                    cached_return_to_human = False
+                    _acted_on_return_to_human = False
+                    message = "Human-oversight signal cleared. Adjust target with [a]/[+] to resume."
+                except Exception as e:
+                    message = f"Failed to clear signal: {e}"
                 message_time = time.time()
         elif ch == ord("l") or ch == ord("L"):
             # Toggle planner lock

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -640,6 +640,15 @@ def get_queue_depth(config: dict) -> int:
         return 0
 
 
+def get_return_to_human(config: dict) -> bool:
+    """Check whether a planner has signalled human-oversight on the sentinel issue."""
+    try:
+        r = coordination(config, "check-human-oversight")
+        return r.stdout.strip() == "true"
+    except subprocess.TimeoutExpired:
+        return False
+
+
 @dataclasses.dataclass
 class GHItem:
     """An issue or PR for TUI display."""
@@ -1856,11 +1865,15 @@ def _tui_main(stdscr, config: dict):
     blocked_deps_fetch_time = 0.0
     cached_lock_status: str | None = None  # "locked" or "unlocked"
     lock_fetch_time = 0.0
+    cached_return_to_human = False
+    return_to_human_fetch_time = 0.0
+    _acted_on_return_to_human = False  # True once TUI has reacted (set target=0, sent finish)
     CACHE_SECS = 30  # Refresh interval for GitHub API data
 
     # Background fetch infrastructure: all GH/coordination calls run in daemon
     # threads so the TUI never blocks on network I/O.
-    _bg_data: dict = {"queue": None, "items": None, "blocked_deps": None, "lock_status": None}
+    _bg_data: dict = {"queue": None, "items": None, "blocked_deps": None, "lock_status": None,
+                      "return_to_human": None}
     _bg_active: set = set()
     _bg_mutex = threading.Lock()
 
@@ -1944,6 +1957,10 @@ def _tui_main(stdscr, config: dict):
         if now - blocked_deps_fetch_time > CACHE_SECS:
             _bg_fetch("blocked_deps", fetch_blocked_deps)
             blocked_deps_fetch_time = now
+        # Human-oversight signal: planner labels sentinel issue when no work remains.
+        if not _acted_on_return_to_human and now - return_to_human_fetch_time > CACHE_SECS:
+            _bg_fetch("return_to_human", get_return_to_human, config)
+            return_to_human_fetch_time = now
         # Lock status: check agent state first (cheap), fall back to background API
         if now - lock_fetch_time > CACHE_SECS:
             lock_fetch_time = now
@@ -1964,6 +1981,22 @@ def _tui_main(stdscr, config: dict):
                 cached_blocked_deps = _bg_data["blocked_deps"]
             if _bg_data["lock_status"] is not None:
                 cached_lock_status = _bg_data["lock_status"]
+            if _bg_data["return_to_human"] is not None:
+                cached_return_to_human = _bg_data["return_to_human"]
+
+        # React to human-oversight signal: set target=0 and gracefully finish all agents.
+        # Only act once per TUI session (idempotent).
+        if cached_return_to_human and not _acted_on_return_to_human:
+            _acted_on_return_to_human = True
+            write_target(0)
+            for a in agents:
+                if a.pid > 0 and a.status not in ("stopped", "dead") and _pid_is_valid(a.pid, a.pid_start_time):
+                    try:
+                        os.kill(a.pid, signal.SIGUSR1)
+                    except (ProcessLookupError, OSError):
+                        pass
+            message = "Planner signalled: no work remains. Target set to 0; agents finishing."
+            message_time = now
 
         # Auto-spawn agents to maintain target (only if no agents are finishing).
         target = read_target()
@@ -2085,7 +2118,7 @@ def _tui_main(stdscr, config: dict):
         # --- Issues/PRs panel ---
         # Row budget: 3 top (header+sep+colhdr) + rendered agents + 3 bottom (sep+help+msg)
         agents_end = 3 + agents_rendered
-        footer_fixed = 3  # separator + help + message
+        footer_fixed = 4 if cached_return_to_human else 3  # separator + help + message [+ banner]
         avail_for_items = height - agents_end - footer_fixed
         # Need: 1 blank + 1 separator + 1 header + at least 1 item row = 4
         items_shown = 0
@@ -2198,10 +2231,17 @@ def _tui_main(stdscr, config: dict):
             _addstr(stdscr, footer_row2, 0, footer_text[:width], curses.A_DIM)
 
         # --- Message line ---
-        if message and time.time() - message_time < 3:
-            msg_row = footer_row2 + 1
-            if msg_row < height:
-                _addstr(stdscr, msg_row, 0, f" {message}"[:width], curses.A_BOLD)
+        msg_active = bool(message and time.time() - message_time < 3)
+        msg_row = footer_row2 + 1
+        if msg_active and msg_row < height:
+            _addstr(stdscr, msg_row, 0, f" {message}"[:width], curses.A_BOLD)
+
+        # --- Human-oversight banner (persistent) ---
+        if cached_return_to_human:
+            banner_row = msg_row + 1 if msg_active else msg_row
+            if banner_row < height:
+                banner = " *** HUMAN OVERSIGHT: planner signals no work remains — target=0, agents finishing ***"
+                _addstr(stdscr, banner_row, 0, banner[:width], curses.color_pair(2) | curses.A_BOLD)
 
         stdscr.refresh()
 

--- a/pod/data/claude-config/commands/plan.md
+++ b/pod/data/claude-config/commands/plan.md
@@ -122,6 +122,17 @@ For each issue, write the plan body to `plans/<UUID-prefix>-N.md`, then post:
 coordination plan --label <feature|review|summarize|meditate> "title" < plans/<UUID-prefix>-N.md
 ```
 
+**If you created zero new issues** and the unclaimed queue is empty (no work
+for agents to do), signal that control should return to the human:
+```
+coordination human-oversight
+```
+This adds the `human-oversight` label to the sentinel issue. The pod TUI
+detects it, sets the agent target to 0, and gracefully finishes all running
+agents. Do this only when the project is genuinely complete or stalled with
+no actionable next steps — not simply because you happened not to create
+issues this pass.
+
 Then exit. Do NOT execute any code changes.
 
 **Note**: The planner lock is managed by `pod` — do NOT call

--- a/pod/data/claude-config/commands/plan.md
+++ b/pod/data/claude-config/commands/plan.md
@@ -122,16 +122,31 @@ For each issue, write the plan body to `plans/<UUID-prefix>-N.md`, then post:
 coordination plan --label <feature|review|summarize|meditate> "title" < plans/<UUID-prefix>-N.md
 ```
 
-**If you created zero new issues** and the unclaimed queue is empty (no work
-for agents to do), signal that control should return to the human:
+**If you created zero new issues** and all of the following are true, signal
+that control should return to the human:
+- No unclaimed issues in the queue
+- No claimed issues (no workers currently active)
+- No open PRs needing attention (failing CI, merge conflicts)
+
 ```
 coordination human-oversight
 ```
-This adds the `human-oversight` label to the sentinel issue. The pod TUI
+
+Verify with:
+```bash
+# All three must show zero / empty
+coordination queue-depth
+gh issue list --label claimed --state open --json number --jq 'length'
+gh pr list --state open --json number,mergeable,statusCheckRollup \
+  --jq '[.[] | select(.mergeable == "CONFLICTING" or (.statusCheckRollup | any(.conclusion == "FAILURE")))] | length'
+```
+
+This adds the `return-to-human` label to the sentinel issue. The pod TUI
 detects it, sets the agent target to 0, and gracefully finishes all running
-agents. Do this only when the project is genuinely complete or stalled with
-no actionable next steps — not simply because you happened not to create
-issues this pass.
+agents. The human can clear this signal and resume via the `[r]` key in the
+TUI. Do this only when the project is genuinely complete or stalled with no
+actionable next steps — not simply because you happened not to create issues
+this pass.
 
 Then exit. Do NOT execute any code changes.
 

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -93,7 +93,7 @@ _ensure_labels() {
     local existing
     existing="$(gh label list --repo "$REPO" --limit 100 --json name --jq '.[].name')"
     local label color
-    for pair in agent-plan:1D76DB claimed:FBCA04 blocked:B60205 has-pr:5319E7 replan:D93F0B coordination:0E8A16 human-oversight:CC317C return-to-human:E4A400; do
+    for pair in agent-plan:1D76DB claimed:FBCA04 blocked:B60205 has-pr:5319E7 replan:D93F0B coordination:0E8A16 human-oversight:CC317C; do
         label="${pair%%:*}"
         color="${pair##*:}"
         if ! echo "$existing" | grep -qx "$label"; then
@@ -725,12 +725,12 @@ cmd_check_blocked() {
 
 # --- human-oversight ---
 # Called by a planner when it determines there is no work left to plan and the
-# project is complete. Adds the label "return-to-human" to the sentinel issue.
+# project is complete. Adds the label "human-oversight" to the sentinel issue.
 # The pod TUI monitors this label and responds by setting the agent target to 0
 # and gracefully finishing all running agents, returning control to the operator.
 cmd_human_oversight() {
     _resolve_planner_lock_issue
-    gh issue edit "$PLANNER_LOCK_ISSUE" --repo "$REPO" --add-label return-to-human
+    gh issue edit "$PLANNER_LOCK_ISSUE" --repo "$REPO" --add-label human-oversight
     echo "Human-oversight signal sent (label added to sentinel issue #$PLANNER_LOCK_ISSUE)"
 }
 
@@ -743,7 +743,7 @@ cmd_check_human_oversight() {
     local labels
     labels="$(gh issue view "$PLANNER_LOCK_ISSUE" --repo "$REPO" --json labels \
         --jq '[.labels[].name] | join(",")')"
-    if echo "$labels" | grep -qw 'return-to-human'; then
+    if echo "$labels" | grep -qw 'human-oversight'; then
         echo "true"
         return 0
     else

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -20,7 +20,8 @@
 #   coordination lock-planner                 — acquire advisory planner lock (20min TTL)
 #   coordination unlock-planner               — release planner lock early
 #   coordination human-oversight              — planner signals no work remains; TUI sets target=0 and finishes agents
-#   coordination check-human-oversight        — check if human-oversight signal is set on sentinel (exits 0 if set)
+#   coordination check-human-oversight        — check if return-to-human signal is set on sentinel (exits 0 if set)
+#   coordination clear-human-oversight        — remove return-to-human signal (e.g. to resume work after completion)
 
 set -euo pipefail
 
@@ -93,7 +94,7 @@ _ensure_labels() {
     local existing
     existing="$(gh label list --repo "$REPO" --limit 100 --json name --jq '.[].name')"
     local label color
-    for pair in agent-plan:1D76DB claimed:FBCA04 blocked:B60205 has-pr:5319E7 replan:D93F0B coordination:0E8A16 human-oversight:CC317C; do
+    for pair in agent-plan:1D76DB claimed:FBCA04 blocked:B60205 has-pr:5319E7 replan:D93F0B coordination:0E8A16 human-oversight:CC317C return-to-human:E4A400; do
         label="${pair%%:*}"
         color="${pair##*:}"
         if ! echo "$existing" | grep -qx "$label"; then
@@ -730,12 +731,12 @@ cmd_check_blocked() {
 # and gracefully finishing all running agents, returning control to the operator.
 cmd_human_oversight() {
     _resolve_planner_lock_issue
-    gh issue edit "$PLANNER_LOCK_ISSUE" --repo "$REPO" --add-label human-oversight
+    gh issue edit "$PLANNER_LOCK_ISSUE" --repo "$REPO" --add-label return-to-human
     echo "Human-oversight signal sent (label added to sentinel issue #$PLANNER_LOCK_ISSUE)"
 }
 
 # --- check-human-oversight ---
-# Read-only: check whether the human-oversight signal has been set on the sentinel issue.
+# Read-only: check whether the return-to-human signal has been set on the sentinel issue.
 # Prints "true" and exits 0 if the signal is set; prints "false" and exits 1 otherwise.
 # Used by the pod TUI to poll for the signal.
 cmd_check_human_oversight() {
@@ -743,13 +744,24 @@ cmd_check_human_oversight() {
     local labels
     labels="$(gh issue view "$PLANNER_LOCK_ISSUE" --repo "$REPO" --json labels \
         --jq '[.labels[].name] | join(",")')"
-    if echo "$labels" | grep -qw 'human-oversight'; then
+    if echo "$labels" | grep -qw 'return-to-human'; then
         echo "true"
         return 0
     else
         echo "false"
         return 1
     fi
+}
+
+# --- clear-human-oversight ---
+# Remove the return-to-human signal from the sentinel issue.
+# Use this to resume pod operation after inspecting a completed project, or when
+# the signal was set in error. The TUI also exposes this via the 'r' keypress.
+cmd_clear_human_oversight() {
+    _resolve_planner_lock_issue
+    gh issue edit "$PLANNER_LOCK_ISSUE" --repo "$REPO" --remove-label return-to-human \
+        2>/dev/null || true
+    echo "Human-oversight signal cleared (label removed from sentinel issue #$PLANNER_LOCK_ISSUE)"
 }
 
 # --- dispatch ---
@@ -772,6 +784,7 @@ case "${1:-}" in
     force-unlock-planner)   cmd_force_unlock_planner ;;
     human-oversight)        cmd_human_oversight ;;
     check-human-oversight)  cmd_check_human_oversight ;;
+    clear-human-oversight)  cmd_clear_human_oversight ;;
     *)               die "unknown command: ${1:-}
-Usage: coordination {orient|plan [--label L]|create-pr|claim-fix|close-pr|list-unclaimed [--label L]|queue-depth [L]|claim|skip|add-dep|check-blocked|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner|human-oversight|check-human-oversight}" ;;
+Usage: coordination {orient|plan [--label L]|create-pr|claim-fix|close-pr|list-unclaimed [--label L]|queue-depth [L]|claim|skip|add-dep|check-blocked|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner|human-oversight|check-human-oversight|clear-human-oversight}" ;;
 esac

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -19,6 +19,8 @@
 #   coordination release-stale-claims [SECS]  — release claimed issues with no activity for SECS seconds (default 14400 = 4h)
 #   coordination lock-planner                 — acquire advisory planner lock (20min TTL)
 #   coordination unlock-planner               — release planner lock early
+#   coordination human-oversight              — planner signals no work remains; TUI sets target=0 and finishes agents
+#   coordination check-human-oversight        — check if human-oversight signal is set on sentinel (exits 0 if set)
 
 set -euo pipefail
 
@@ -91,7 +93,7 @@ _ensure_labels() {
     local existing
     existing="$(gh label list --repo "$REPO" --limit 100 --json name --jq '.[].name')"
     local label color
-    for pair in agent-plan:1D76DB claimed:FBCA04 blocked:B60205 has-pr:5319E7 replan:D93F0B coordination:0E8A16 human-oversight:CC317C; do
+    for pair in agent-plan:1D76DB claimed:FBCA04 blocked:B60205 has-pr:5319E7 replan:D93F0B coordination:0E8A16 human-oversight:CC317C return-to-human:E4A400; do
         label="${pair%%:*}"
         color="${pair##*:}"
         if ! echo "$existing" | grep -qx "$label"; then
@@ -721,6 +723,35 @@ cmd_check_blocked() {
     done
 }
 
+# --- human-oversight ---
+# Called by a planner when it determines there is no work left to plan and the
+# project is complete. Adds the label "return-to-human" to the sentinel issue.
+# The pod TUI monitors this label and responds by setting the agent target to 0
+# and gracefully finishing all running agents, returning control to the operator.
+cmd_human_oversight() {
+    _resolve_planner_lock_issue
+    gh issue edit "$PLANNER_LOCK_ISSUE" --repo "$REPO" --add-label return-to-human
+    echo "Human-oversight signal sent (label added to sentinel issue #$PLANNER_LOCK_ISSUE)"
+}
+
+# --- check-human-oversight ---
+# Read-only: check whether the human-oversight signal has been set on the sentinel issue.
+# Prints "true" and exits 0 if the signal is set; prints "false" and exits 1 otherwise.
+# Used by the pod TUI to poll for the signal.
+cmd_check_human_oversight() {
+    _resolve_planner_lock_issue
+    local labels
+    labels="$(gh issue view "$PLANNER_LOCK_ISSUE" --repo "$REPO" --json labels \
+        --jq '[.labels[].name] | join(",")')"
+    if echo "$labels" | grep -qw 'return-to-human'; then
+        echo "true"
+        return 0
+    else
+        echo "false"
+        return 1
+    fi
+}
+
 # --- dispatch ---
 case "${1:-}" in
     orient)          cmd_orient ;;
@@ -739,6 +770,8 @@ case "${1:-}" in
     unlock-planner)         cmd_unlock_planner ;;
     lock-status)            cmd_lock_status ;;
     force-unlock-planner)   cmd_force_unlock_planner ;;
+    human-oversight)        cmd_human_oversight ;;
+    check-human-oversight)  cmd_check_human_oversight ;;
     *)               die "unknown command: ${1:-}
-Usage: coordination {orient|plan [--label L]|create-pr|claim-fix|close-pr|list-unclaimed [--label L]|queue-depth [L]|claim|skip|add-dep|check-blocked|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner}" ;;
+Usage: coordination {orient|plan [--label L]|create-pr|claim-fix|close-pr|list-unclaimed [--label L]|queue-depth [L]|claim|skip|add-dep|check-blocked|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner|human-oversight|check-human-oversight}" ;;
 esac


### PR DESCRIPTION
When a planner determines there is no work left to plan, it previously just
exited — causing pod to immediately spawn another planner, which also found
nothing to do, and so on indefinitely.

This PR adds a mechanism for planners to signal "I'm done, return control to
the human", which causes the TUI to stop spawning new agents.

## How it works

**Planner side** (`coordination human-oversight`):
- Adds the label `return-to-human` to the sentinel issue (the same one used
  for planner locking)
- Idempotent: adding a label that already exists is a no-op

**TUI side** (polls `coordination check-human-oversight` every 30s):
- On detection: sets target to 0 and sends SIGUSR1 to all running agents
  (graceful finish — agents complete their current work then stop)
- Shows a persistent yellow banner: `*** HUMAN OVERSIGHT: planner signals no work remains ***`
- Acts only once per TUI session (idempotent flag)

## New label

`return-to-human` (amber `E4A400`) is distinct from the existing
`human-oversight` label, which is used for active directives to agents.
`return-to-human` on the sentinel issue means "the work queue is empty and
the planner has nothing left to create".

## Project harness update needed

Project-level `CLAUDE.md` files need to instruct planners to call
`coordination human-oversight` when they determine no new issues are needed.
Example instruction to add to the planner prompt:

> When you complete a planning pass and determine there is no work left to
> create (queue is empty, all items complete, no blockers), call
> `coordination human-oversight` before exiting to signal pod to stop
> spawning agents.

🤖 Prepared with Claude Code