### PR TITLE
feat: include human-oversight issues in unclaimed queue without requiring agent-plan

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -670,28 +670,33 @@ class GHItem:
 
 
 def fetch_issues_and_prs() -> list[GHItem]:
-    """Fetch issues (agent-plan label, all states) and recent PRs from GitHub."""
+    """Fetch issues (agent-plan or human-oversight label, all states) and recent PRs from GitHub."""
     items: list[GHItem] = []
+    seen_open: set[int] = set()
     cwd = str(PROJECT_DIR)
 
     issue_json = "--json=number,title,labels,state,createdAt,updatedAt,closedAt"
     # All open issues (there should never be thousands of open ones)
-    try:
-        r = subprocess.run(
-            ["gh", "issue", "list", "--label", "agent-plan", "--state", "open",
-             "--limit", "500", issue_json],
-            capture_output=True, text=True, timeout=30, cwd=cwd,
-        )
-        if r.returncode == 0:
-            for iss in json.loads(r.stdout):
-                labels = [l["name"] for l in iss.get("labels", [])]
-                ts = iss.get("updatedAt") or iss.get("createdAt", "")
-                items.append(GHItem(
-                    kind="issue", number=iss["number"], title=iss["title"],
-                    labels=labels, ci_status="", state="open", timestamp=ts,
-                ))
-    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
-        pass
+    for label in ("agent-plan", "human-oversight"):
+        try:
+            r = subprocess.run(
+                ["gh", "issue", "list", "--label", label, "--state", "open",
+                 "--limit", "500", issue_json],
+                capture_output=True, text=True, timeout=30, cwd=cwd,
+            )
+            if r.returncode == 0:
+                for iss in json.loads(r.stdout):
+                    if iss["number"] in seen_open:
+                        continue
+                    seen_open.add(iss["number"])
+                    labels = [l["name"] for l in iss.get("labels", [])]
+                    ts = iss.get("updatedAt") or iss.get("createdAt", "")
+                    items.append(GHItem(
+                        kind="issue", number=iss["number"], title=iss["title"],
+                        labels=labels, ci_status="", state="open", timestamp=ts,
+                    ))
+        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+            pass
     # Recent closed issues (just enough for context; display logic drops these first anyway)
     try:
         r = subprocess.run(

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -109,14 +109,23 @@ _ensure_labels
 
 # Helper: get unclaimed issues as JSON array
 # Optional arg: extra label to filter by (e.g. "feature", "review")
+# Always includes human-oversight issues (even without agent-plan) when no extra label is given.
 _unclaimed_issues() {
     local extra_label="${1:-}"
-    local -a label_args=("--label" "agent-plan")
-    [[ -n "$extra_label" ]] && label_args+=("--label" "$extra_label")
-    gh issue list --repo "$REPO" "${label_args[@]}" --state open --limit 50 \
-        --json number,title,labels,createdAt \
-        --jq '[.[] | select(.labels | all(.name != "claimed") and all(.name != "blocked") and all(.name != "has-pr") and all(.name != "replan"))] |
-              sort_by(.createdAt)'
+    local filter='[.[] | select(.labels | all(.name != "claimed") and all(.name != "blocked") and all(.name != "has-pr") and all(.name != "replan"))] | sort_by(.createdAt)'
+    if [[ -n "$extra_label" ]]; then
+        gh issue list --repo "$REPO" --label agent-plan --label "$extra_label" --state open --limit 50 \
+            --json number,title,labels,createdAt \
+            --jq "$filter"
+    else
+        # Merge agent-plan issues with human-oversight issues, deduplicate by number
+        {
+            gh issue list --repo "$REPO" --label agent-plan --state open --limit 50 \
+                --json number,title,labels,createdAt
+            gh issue list --repo "$REPO" --label human-oversight --state open --limit 50 \
+                --json number,title,labels,createdAt
+        } | jq -s "add | unique_by(.number) | $filter"
+    fi
 }
 
 # --- orient ---


### PR DESCRIPTION
Human-injected `human-oversight` issues should be picked up by workers even if they don't also carry the `agent-plan` label. Currently, if you create a `human-oversight` issue without `agent-plan`, it won't appear in `list-unclaimed`, `queue-depth`, or the TUI.

## Changes

**`pod/data/coordination`** — `_unclaimed_issues`:  
When no extra label filter is given, run two queries (one for `agent-plan`, one for `human-oversight`) and merge them with `jq unique_by(.number)`. When a type-specific filter is given (e.g. `feature`), behaviour is unchanged — only `agent-plan` issues with that label are returned.

**`pod/cli.py`** — `fetch_issues_and_prs`:  
Loop over both `agent-plan` and `human-oversight` when fetching open issues, deduplicating by issue number so the TUI displays `human-oversight`-only issues.

🤖 Prepared with Claude Code