### PR TITLE
fix: treat model quota check as tier comparison

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -702,9 +702,11 @@ def check_quota(config: dict, force: bool = False) -> bool:
         )
         if result.returncode != 0:
             return False
-        model = result.stdout.strip()
+        available = result.stdout.strip()
         required = cfg_get(config, "claude", "model", default="opus")
-        return model == required
+        # Model tier: higher-tier availability satisfies lower-tier requirements.
+        _MODEL_TIER = {"opus": 2, "sonnet": 1}
+        return _MODEL_TIER.get(available, 0) >= _MODEL_TIER.get(required, 0)
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return False
 


### PR DESCRIPTION
The quota check script outputs the best available model (`opus` or `sonnet`). Previously, `check_quota` did an exact string match against the configured model, so `model = "sonnet"` would fail whenever opus quota was available (the common case), causing the pod to wait indefinitely.

Now uses a tier comparison: opus (tier 2) >= sonnet (tier 1), so higher-tier availability satisfies lower-tier requirements.

🤖 Prepared with Claude Code