### PR TITLE
fix: prevent worktree leaks when build cache cleanup exceeds timeout

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1890,16 +1890,56 @@ def copy_build_cache(wt_dir: str, config: dict):
 
 
 def cleanup_worktree(wt_dir: str, branch: str):
-    """Remove worktree and delete branch."""
+    """Remove worktree and delete branch.
+
+    Removes the build cache directory (e.g. `.lake`) explicitly before
+    invoking `git worktree remove`. On projects that rsync a large build
+    cache into each worktree (Lean/Mathlib `.lake/` is multiple GB of
+    small olean files), letting `git worktree remove` walk and unlink the
+    whole tree reliably exceeds its timeout. When the timeout fires the
+    subprocess is abandoned mid-walk, `TimeoutExpired` escapes the
+    caller, and the worktree leaks on disk — over hundreds of sessions
+    that grows `worktrees/` unboundedly.
+
+    We also swallow `TimeoutExpired` at every subprocess call so a slow
+    cleanup can never crash the agent loop, and fall back to an
+    in-process rmtree + `git worktree prune` if git still times out.
+    """
     if os.path.isdir(wt_dir):
-        subprocess.run(
-            ["git", "-C", str(PROJECT_DIR), "worktree", "remove", "--force", wt_dir],
-            capture_output=True, timeout=30,
+        build_cache = _reload_config_value(
+            "project", "build_cache_dir", default=".lake"
         )
-    subprocess.run(
-        ["git", "branch", "-D", branch],
-        capture_output=True, timeout=10, cwd=str(PROJECT_DIR),
-    )
+        cache_path = os.path.join(wt_dir, build_cache)
+        if os.path.isdir(cache_path):
+            try:
+                shutil.rmtree(cache_path, ignore_errors=True)
+            except Exception as e:
+                log(f"cleanup_worktree: rmtree {cache_path} failed: {e}")
+
+        try:
+            subprocess.run(
+                ["git", "-C", str(PROJECT_DIR), "worktree", "remove",
+                 "--force", wt_dir],
+                capture_output=True, timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            log(f"cleanup_worktree: git worktree remove timed out: {wt_dir}")
+            try:
+                shutil.rmtree(wt_dir, ignore_errors=True)
+                subprocess.run(
+                    ["git", "-C", str(PROJECT_DIR), "worktree", "prune"],
+                    capture_output=True, timeout=30,
+                )
+            except Exception as e:
+                log(f"cleanup_worktree: fallback cleanup failed: {e}")
+
+    try:
+        subprocess.run(
+            ["git", "branch", "-D", branch],
+            capture_output=True, timeout=10, cwd=str(PROJECT_DIR),
+        )
+    except subprocess.TimeoutExpired:
+        log(f"cleanup_worktree: git branch -D timed out: {branch}")
 
 
 def _log_credential_state(session_uuid: str, claude_config_dir: Path | None = None):


### PR DESCRIPTION
## Problem

On projects using `copy_build_cache = true` (e.g. Lean/Mathlib with a multi-GB `.lake/` directory), `cleanup_worktree` routinely leaks worktrees on disk. One real instance: a single project's `worktrees/` reached **143G across 86 directories**, most of them zombies from agents that had long since exited.

The bug chain:

1. `[worker_types.work]` uses `copy_build_cache = true`, so `setup_worktree` rsyncs the main repo's `.lake/` into the new worktree at startup (already gigabytes).
2. The agent builds more during its session, so at exit time `.lake/` is 2–10G of many small olean files.
3. `cleanup_worktree` calls `git worktree remove --force` with `timeout=30`. On APFS, walking and unlinking millions of tiny files takes minutes, not seconds.
4. At 30s, Python's `subprocess.run` raises `TimeoutExpired`. This exception **is not caught** inside `cleanup_worktree` or at any of its five call sites, so it propagates out of the agent loop.
5. Two bad outcomes simultaneously:
   - The `rm` inside git is abandoned mid-walk. The worktree is left partially populated on disk and git's `.git/worktrees/<name>/` admin state may or may not be cleaned.
   - The unhandled exception unwinds the caller's cleanup path. The next agent spawn creates a fresh `worktrees/<new-id>/` and the old one is never revisited.

Repeat over hundreds of sessions and `worktrees/` grows without bound.

## Fix

Four changes, in order of importance:

1. **Delete the configured build cache directory in-process with `shutil.rmtree` before invoking git.** This is the structural fix: nothing is racing the rmtree, so the slow part is no longer under a subprocess timeout. By the time `git worktree remove` runs, the worktree is small (just the source checkout) and git finishes quickly. The cache dir name is read via `_reload_config_value("project", "build_cache_dir", default=".lake")`, symmetric with how `copy_build_cache` reads the same key when rsyncing in.

2. **Bump the `git worktree remove` timeout from 30s → 120s** as belt-and-braces headroom for the remaining source checkout.

3. **Catch `TimeoutExpired` at every subprocess call** so a slow cleanup can never propagate up and crash the agent loop. Each call site logs the timeout and continues.

4. **Fallback path when git itself times out:** in-process `shutil.rmtree(wt_dir)` followed by `git worktree prune` to reconcile git's admin state, guaranteeing the next `setup_worktree` starts from a clean slate — no orphan on disk, no stale entry in `.git/worktrees/`.

## What this does not fix

- **Non-build-cache bloat.** Dead worktrees where cleanup never ran at all (crashes, `pod kill`, reboots mid-session) still leave source checkouts behind. A separate `pod prune-worktrees` subcommand that walks `worktrees/` and cross-references `.pod/agents/*.json` would handle that — happy to do as a follow-up PR if desired.
- **The upfront rsync cost.** Every new worktree still starts by copying gigabytes of `.lake`. That's a deliberate speed tradeoff and orthogonal to the leak.

## Test plan

- [x] `python3 -m py_compile pod/cli.py`
- [ ] Manual: run an agent session in a Lean project, confirm cleanup completes and `worktrees/<id>/` is fully removed
- [ ] Manual: verify `.pod/pod.log` shows no `TimeoutExpired` on cleanup paths

🤖 Prepared with Claude Code