### PR TITLE
feat: Codex backend support (parser + launcher + config)

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1168,7 +1168,8 @@ def fetch_blocked_deps() -> dict[int, list[int]]:
 # JSONL Monitor (runs as a thread inside agent process)
 # ---------------------------------------------------------------------------
 
-def jsonl_monitor(jsonl_path: str, state: AgentState, stop: threading.Event):
+def jsonl_monitor(jsonl_path: str, state: AgentState, stop: threading.Event,
+                  backend: str = "claude"):
     """Poll JSONL file and update agent state. Runs in a daemon thread."""
     pos = 0
     while not stop.is_set():
@@ -1185,13 +1186,73 @@ def jsonl_monitor(jsonl_path: str, state: AgentState, stop: threading.Event):
                     if not line.endswith(b"\n"):
                         break  # Partial line — retry next poll
                     pos += len(line)
-                    _parse_jsonl_line(line, state)
+                    _parse_jsonl_line(line, state, backend)
         except OSError:
             pass
         stop.wait(1)
 
 
-def _parse_jsonl_line(line: bytes, state: AgentState):
+def _parse_jsonl_line(line: bytes, state: AgentState, backend: str = "claude"):
+    """Dispatch JSONL parsing to the appropriate backend parser."""
+    if backend == "codex":
+        _parse_codex_jsonl_line(line, state)
+    else:
+        _parse_claude_jsonl_line(line, state)
+
+
+def _parse_codex_jsonl_line(line: bytes, state: AgentState):
+    """Parse one JSONL line from Codex --json stdout and update state.
+
+    Codex stdout event types (verified from codex exec --json v0.104.0):
+      thread.started   → capture backend_session_id for resume
+      turn.completed   → token usage
+      item.completed   → agent_message (text), command_execution (tool output)
+    """
+    try:
+        d = json.loads(line)
+    except json.JSONDecodeError:
+        return
+
+    t = d.get("type")
+
+    if t == "thread.started":
+        # Capture Codex thread id for resume; do NOT overwrite state.uuid
+        if not state.backend_session_id:
+            state.backend_session_id = d.get("thread_id", "")
+        state.last_activity = time.time()
+
+    elif t == "turn.completed":
+        usage = d.get("usage", {})
+        state.tokens_in += usage.get("input_tokens", 0)
+        state.cache_read += usage.get("cached_input_tokens", 0)
+        state.tokens_out += usage.get("output_tokens", 0)
+        # Codex has no cache_creation_input_tokens equivalent
+        state.last_activity = time.time()
+
+    elif t == "item.completed":
+        item = d.get("item", {})
+        itype = item.get("type")
+        if itype == "agent_message":
+            text = item.get("text", "").strip()
+            if text:
+                state.last_text = text[:200]
+                state.last_activity = time.time()
+        elif itype == "command_execution":
+            cmd = item.get("command", "")[:120]
+            state.last_text = f"[exec] {cmd}"
+            state.last_activity = time.time()
+            # Detect claim from coordination script output
+            output = item.get("aggregated_output", "")
+            m = re.search(r"Claimed issue #(\d+)", output)
+            if m:
+                state.claimed_issue = int(m.group(1))
+            # Detect PR creation from coordination create-pr
+            m2 = re.search(r"(?:coordination\s+create-pr\s+(?:--\S+\s+)*)(\d+)", cmd)
+            if m2:
+                state.pr_number = int(m2.group(1))
+
+
+def _parse_claude_jsonl_line(line: bytes, state: AgentState):
     """Parse one JSONL line and update state."""
     try:
         d = json.loads(line)
@@ -2671,7 +2732,8 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         jsonl_path = get_jsonl_path(wt_dir, session_uuid, claude_config_dir)
         stop_monitor = threading.Event()
         monitor_thread = threading.Thread(
-            target=jsonl_monitor, args=(jsonl_path, state, stop_monitor),
+            target=jsonl_monitor,
+            args=(jsonl_path, state, stop_monitor, _backend(config)),
             daemon=True,
         )
         monitor_thread.start()

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -2094,40 +2094,78 @@ def _pod_installed_files() -> list[str]:
     return result
 
 
-def install_agent_config(wt_dir: str):
-    """Install bundled commands, skills, and agent CLAUDE.md into worktree.
+def install_agent_config(wt_dir: str, backend: str = "claude"):
+    """Install bundled commands, skills, and agent instructions into worktree.
 
-    Merges the bundled agent-config/claude into the worktree's .claude/
-    directory so that Claude can find slash commands (/feature, /summarize,
-    etc.) and the agent-worker-flow skill.  The bundled agent CLAUDE.md is
-    appended to the project's existing CLAUDE.md so the agent gets both
-    project context and pod-specific instructions.
+    For Claude: merges agent-config/claude into .claude/ (commands, skills,
+    CLAUDE.md).
+    For Codex: installs AGENTS.md at worktree root. Skills are installed
+    into CODEX_HOME by _setup_codex_home(). Commands are read at launch
+    time by _worker_prompt() and delivered via stdin.
     """
-    data_config = _data_dir() / "agent-config" / "claude"
-    wt_claude = Path(wt_dir) / ".claude"
-    wt_claude.mkdir(parents=True, exist_ok=True)
+    data_config = _data_dir() / "agent-config" / backend
 
-    # Commands
-    src_cmds = data_config / "commands"
-    if src_cmds.is_dir():
-        dst_cmds = wt_claude / "commands"
-        shutil.copytree(str(src_cmds), str(dst_cmds), dirs_exist_ok=True)
+    if backend == "codex":
+        # Install AGENTS.md at worktree root
+        agent_md = data_config / "AGENTS.md"
+        if agent_md.is_file():
+            dst_md = Path(wt_dir) / "AGENTS.md"
+            existing = dst_md.read_text() if dst_md.is_file() else ""
+            agent_text = agent_md.read_text()
+            if agent_text not in existing:
+                with open(dst_md, "a") as f:
+                    f.write("\n\n" + agent_text)
+        # Skills and commands are handled by _setup_codex_home and
+        # _worker_prompt respectively — nothing else to install here.
+    else:
+        # Claude: install into .claude/
+        wt_claude = Path(wt_dir) / ".claude"
+        wt_claude.mkdir(parents=True, exist_ok=True)
 
-    # Skills
-    src_skills = data_config / "skills"
-    if src_skills.is_dir():
-        dst_skills = wt_claude / "skills"
-        shutil.copytree(str(src_skills), str(dst_skills), dirs_exist_ok=True)
+        # Commands
+        src_cmds = data_config / "commands"
+        if src_cmds.is_dir():
+            dst_cmds = wt_claude / "commands"
+            shutil.copytree(str(src_cmds), str(dst_cmds), dirs_exist_ok=True)
 
-    # Append agent CLAUDE.md to project CLAUDE.md
-    agent_md = data_config / "CLAUDE.md"
-    if agent_md.is_file():
-        dst_md = wt_claude / "CLAUDE.md"
-        existing = dst_md.read_text() if dst_md.is_file() else ""
-        agent_text = agent_md.read_text()
-        if agent_text not in existing:
-            with open(dst_md, "a") as f:
-                f.write("\n\n" + agent_text)
+        # Skills
+        src_skills = data_config / "skills"
+        if src_skills.is_dir():
+            dst_skills = wt_claude / "skills"
+            shutil.copytree(str(src_skills), str(dst_skills), dirs_exist_ok=True)
+
+        # Append agent CLAUDE.md to project CLAUDE.md
+        agent_md = data_config / "CLAUDE.md"
+        if agent_md.is_file():
+            dst_md = wt_claude / "CLAUDE.md"
+            existing = dst_md.read_text() if dst_md.is_file() else ""
+            agent_text = agent_md.read_text()
+            if agent_text not in existing:
+                with open(dst_md, "a") as f:
+                    f.write("\n\n" + agent_text)
+
+
+def _worker_prompt(config: dict, worker_type: str) -> str:
+    """Return the prompt text for a given worker type.
+
+    For Claude: returns the slash command name (e.g. "/work").
+    For Codex: reads the command template file and returns its full text,
+    since Codex has no slash command system.
+    """
+    backend = _backend(config)
+    worker_types = cfg_get(config, "worker_types", default={})
+    wt_cfg = worker_types.get(worker_type, {})
+    prompt = wt_cfg.get("prompt", f"/{worker_type}")
+
+    if backend == "codex" and prompt.startswith("/"):
+        # Slash command — resolve to the command template file body
+        cmd_name = prompt.lstrip("/")
+        cmd_file = _data_dir() / "agent-config" / "codex" / "commands" / f"{cmd_name}.md"
+        if cmd_file.is_file():
+            return cmd_file.read_text()
+        # Fallback: use the command name as-is
+        log(f"Warning: no Codex command template for '{cmd_name}', using raw prompt")
+    return prompt
 
 
 def copy_build_cache(wt_dir: str, config: dict):
@@ -2388,7 +2426,7 @@ def _log_credential_state(session_uuid: str, claude_config_dir: Path | None = No
 def launch_agent(config: dict, session_uuid: str, prompt: str,
                    wt_dir: str,
                    claude_config_dir: Path | None = None) -> subprocess.Popen:
-    """Launch claude in the worktree directory."""
+    """Launch agent subprocess (Claude or Codex) in the worktree directory."""
     # Re-read model from disk so config.toml edits take effect without restart.
     backend = _reload_config_value("agent", "backend", default="claude")
     model = _reload_config_value("agent", backend, "model", default="opus")
@@ -2396,35 +2434,59 @@ def launch_agent(config: dict, session_uuid: str, prompt: str,
     session_dir.mkdir(parents=True, exist_ok=True)
     stdout_path = session_dir / f"{session_uuid}.stdout"
 
-    # Determine JSONL dir for this worktree
-    jsonl_dir = _claude_projects_dir(claude_config_dir) / wt_dir.replace("/", "-")
-
-    # Check if we can resume an existing session
-    local_jsonl = jsonl_dir / f"{session_uuid}.jsonl"
-    claude_args = ["claude", "--model", model]
-    if local_jsonl.exists():
-        claude_args += ["--resume", session_uuid]
-    else:
-        claude_args += ["--session-id", session_uuid]
-    if claude_config_dir is not None:
-        claude_args += ["--dangerously-skip-permissions"]
-    claude_args += ["-p", prompt]
-
     env = dict(os.environ)
-    env["ANTHROPIC_API_KEY"] = ""  # Force subscription auth
     env["POD_SESSION_ID"] = session_uuid
-    env["POD_IS_RESUME"] = "1" if local_jsonl.exists() else "0"
     # Inject bundled data dir into PATH so agents find `coordination`
     env["PATH"] = str(_data_dir()) + os.pathsep + env.get("PATH", "")
-    if claude_config_dir is not None:
-        env["CLAUDE_CONFIG_DIR"] = str(claude_config_dir)
 
-    # Log credential state at launch for debugging account-swap issues
-    _log_credential_state(session_uuid, claude_config_dir)
+    stdin_pipe = None  # Only used for Codex (stdin prompt delivery)
+
+    if backend == "codex":
+        # --- Codex launch ---
+        codex_args = ["codex", "exec", "--json",
+                      "--dangerously-bypass-approvals-and-sandbox",
+                      "--skip-git-repo-check",
+                      "-m", model,
+                      "-C", wt_dir,
+                      "-"]  # Read prompt from stdin
+        env["OPENAI_API_KEY"] = ""  # Force subscription auth
+        env["POD_IS_RESUME"] = "0"
+
+        # Set up isolated CODEX_HOME if configured
+        codex_home = _setup_codex_home(config, wt_dir)
+        if codex_home:
+            env["CODEX_HOME"] = str(codex_home)
+
+        stdin_pipe = subprocess.PIPE
+        agent_args = codex_args
+    else:
+        # --- Claude launch (existing behavior) ---
+        jsonl_dir = _claude_projects_dir(claude_config_dir) / wt_dir.replace("/", "-")
+        local_jsonl = jsonl_dir / f"{session_uuid}.jsonl"
+
+        claude_args = ["claude", "--model", model]
+        if local_jsonl.exists():
+            claude_args += ["--resume", session_uuid]
+        else:
+            claude_args += ["--session-id", session_uuid]
+        if claude_config_dir is not None:
+            claude_args += ["--dangerously-skip-permissions"]
+        claude_args += ["-p", prompt]
+
+        env["ANTHROPIC_API_KEY"] = ""  # Force subscription auth
+        env["POD_IS_RESUME"] = "1" if local_jsonl.exists() else "0"
+        if claude_config_dir is not None:
+            env["CLAUDE_CONFIG_DIR"] = str(claude_config_dir)
+
+        # Log credential state at launch for debugging account-swap issues
+        _log_credential_state(session_uuid, claude_config_dir)
+
+        agent_args = claude_args
 
     stdout_fd = os.open(str(stdout_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
     proc = subprocess.Popen(
-        claude_args,
+        agent_args,
+        stdin=stdin_pipe,
         stdout=stdout_fd,
         stderr=subprocess.STDOUT,
         cwd=wt_dir,
@@ -2432,12 +2494,69 @@ def launch_agent(config: dict, session_uuid: str, prompt: str,
         start_new_session=True,  # Create process group for clean killing
     )
     os.close(stdout_fd)  # Child inherited it; parent no longer needs it
+
+    # For Codex, deliver prompt via stdin and close
+    if backend == "codex" and proc.stdin is not None:
+        try:
+            proc.stdin.write(prompt.encode())
+            proc.stdin.close()
+        except OSError:
+            pass  # Process may have exited immediately
+
     return proc
 
 
+def _setup_codex_home(config: dict, wt_dir: str) -> Path | None:
+    """Create an isolated CODEX_HOME directory for a Codex agent.
+
+    Sets up skills from the bundled agent-config/codex/ and symlinks
+    auth from ~/.codex/auth.json so the agent uses the user's login.
+    Returns the CODEX_HOME path, or None if isolation is disabled.
+    """
+    if not _backend_cfg(config, "isolated_config", default=True):
+        return None
+
+    codex_home = Path(wt_dir) / ".pod-codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+
+    # Symlink auth from user's global Codex config
+    real_codex = Path.home() / ".codex"
+    auth_link = codex_home / "auth.json"
+    auth_target = real_codex / "auth.json"
+    if auth_target.exists():
+        try:
+            auth_link.unlink(missing_ok=True)
+            auth_link.symlink_to(auth_target)
+        except FileExistsError:
+            pass
+
+    # Copy config.toml from user's global config if it exists
+    user_config = real_codex / "config.toml"
+    if user_config.exists():
+        dest_config = codex_home / "config.toml"
+        if not dest_config.exists():
+            shutil.copy2(str(user_config), str(dest_config))
+
+    # Install bundled skills
+    data_skills = _data_dir() / "agent-config" / "codex" / "skills"
+    if data_skills.is_dir():
+        dst_skills = codex_home / "skills"
+        shutil.copytree(str(data_skills), str(dst_skills), dirs_exist_ok=True)
+
+    return codex_home
+
+
 def get_jsonl_path(wt_dir: str, session_uuid: str,
-                   claude_config_dir: Path | None = None) -> str:
-    """Compute JSONL file path for a session."""
+                   claude_config_dir: Path | None = None,
+                   backend: str = "claude") -> str:
+    """Compute JSONL file path for a session.
+
+    For Claude: reads from ~/.claude/projects/{wt_dir}/{uuid}.jsonl
+    For Codex: reads from sessions/{uuid}.stdout (the --json stream)
+    """
+    if backend == "codex":
+        session_dir = PROJECT_DIR / "sessions"
+        return str(session_dir / f"{session_uuid}.stdout")
     jsonl_dir = _claude_projects_dir(claude_config_dir) / wt_dir.replace("/", "-")
     return str(jsonl_dir / f"{session_uuid}.jsonl")
 
@@ -2654,7 +2773,7 @@ def agent_process_main(config: dict, agent_id: str | None = None,
 
             consecutive_wait = 0  # Reset backoff on successful dispatch
             wt_config = worker_types.get(chosen_type, {})
-            prompt = wt_config.get("prompt", f"/{chosen_type}")
+            prompt = _worker_prompt(config, chosen_type)
             lock_name = wt_config.get("lock", "")
 
             state.worker_type = chosen_type
@@ -2723,13 +2842,14 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         state.branch = branch
         state.git_start = _git_rev(wt_dir)
 
-        install_agent_config(wt_dir)
+        install_agent_config(wt_dir, backend=_backend(config))
 
         if wt_config.get("copy_build_cache", wt_config.get("copy_lake_cache", False)):
             copy_build_cache(wt_dir, config)
 
         # --- Start JSONL monitor ---
-        jsonl_path = get_jsonl_path(wt_dir, session_uuid, claude_config_dir)
+        jsonl_path = get_jsonl_path(wt_dir, session_uuid, claude_config_dir,
+                                    backend=_backend(config))
         stop_monitor = threading.Event()
         monitor_thread = threading.Thread(
             target=jsonl_monitor,
@@ -2738,16 +2858,16 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         )
         monitor_thread.start()
 
-        # --- Launch claude ---
+        # --- Launch agent ---
         state.status = "running"
         state.write()
-        log(f"Agent {short_id}: launching claude session {session_uuid} in {wt_dir}")
+        log(f"Agent {short_id}: launching {_backend(config)} session {session_uuid} in {wt_dir}")
 
         try:
             _agent_proc = launch_agent(config, session_uuid, prompt, wt_dir,
                                         claude_config_dir)
         except (OSError, FileNotFoundError) as e:
-            log(f"Agent {short_id}: failed to launch claude: {e}")
+            log(f"Agent {short_id}: failed to launch {_backend(config)}: {e}")
             stop_monitor.set()
             cleanup_worktree(wt_dir, branch)
             if lock_name:

--- a/pod/data/agent-config/codex/AGENTS.md
+++ b/pod/data/agent-config/codex/AGENTS.md
@@ -1,0 +1,24 @@
+# Pod Agent Session
+
+You are running as an autonomous agent launched by `pod`. This is a
+non-interactive session via `codex exec` — there is no human to answer
+questions. Never ask for confirmation or approval. Just do the work.
+
+Each agent runs in its own git worktree on its own branch, coordinating
+via GitHub issues, labels, and PRs. The `coordination` script is already
+on your PATH — just run it directly (e.g. `coordination orient`,
+`coordination claim 42`). Do NOT search for it or try to locate it.
+
+Session UUID is available as `$POD_SESSION_ID`.
+
+## Agent Types
+
+- **Planners**: create work items as GitHub issues, then exit
+- **Workers**: claim and execute issues using the `agent-worker-flow` skill
+
+See the `agent-worker-flow` skill for the full workflow.
+
+## Off-limits Files
+
+Agents must not modify the project's top-level AGENTS.md or roadmap file
+(`PLAN.md`). PRs touching these files are rejected by `coordination create-pr`.

--- a/pod/data/agent-config/codex/commands/feature.md
+++ b/pod/data/agent-config/codex/commands/feature.md
@@ -1,0 +1,25 @@
+# Execute a Feature Work Item
+
+You are a **feature** (implementation) session. Your job is to claim and execute
+a pre-planned implementation work item from the issue queue.
+
+**First, read the `agent-worker-flow` skill** for the standard
+claim/branch/verify/publish workflow. This document only covers what is specific
+to implementation sessions.
+
+## Claiming Your Issue
+
+Use `coordination list-unclaimed --label feature` to find work for this session type.
+The priority order in the worker skill still applies — check for PR-fix issues first.
+
+## Executing Implementation Work
+
+Follow the plan's deliverables. For new implementations, follow the development
+cycle described in the project's CLAUDE.md.
+
+After each coherent chunk of changes, build, test, and commit following the
+project's conventions. Each commit must compile and pass tests.
+
+## Reflect
+
+Run `/reflect` before finishing.

--- a/pod/data/agent-config/codex/commands/meditate.md
+++ b/pod/data/agent-config/codex/commands/meditate.md
@@ -1,0 +1,64 @@
+# Execute a Meditate Work Item
+
+You are a **meditate** (self-improvement) session. Your job is to improve the
+agent workflow by updating skills, commands, and tooling based on accumulated
+experience.
+
+**First, read the `agent-worker-flow` skill** for the standard
+claim/branch/verify/publish workflow. This document only covers what is specific
+to meditate sessions.
+
+## Claiming Your Issue
+
+Use `coordination list-unclaimed --label meditate` to find work for this session type.
+
+## The Meditate Task
+
+The issue body will describe the specific focus — common themes include:
+- Consolidating frequently-seen struggle patterns into new or updated skills
+- Updating workflow commands that have become stale
+- Researching better approaches to recurring challenges
+- Improving the coordination tooling based on pain points in recent progress entries
+
+### Step 1: Survey recent struggles
+
+Read the last 20 entries in `progress/` (sorted by filename, most recent last).
+Look for:
+- Repeated failure patterns (tried N approaches, gave up)
+- "Couldn't figure out" or "blocked by" notes
+- Similar mistakes appearing in multiple sessions
+- Complaints or workarounds that suggest missing guidance
+
+### Step 2: Read existing skills
+
+Read the relevant SKILL.md files (both project-level in `.claude/skills/` and
+config-level) to understand what guidance already exists and where the gaps are.
+
+### Step 3: Update or create skills
+
+Read the `acquiring-skills` skill before writing any new skill.
+
+For each gap or recurring struggle:
+- If it fits in an existing skill, add a new section to that SKILL.md
+- If it's a new topic area, create a new skill
+
+### Step 4: Update commands if stale
+
+Read the command files. If any contain guidance that contradicts recent experience
+or refers to obsolete workflows, update them.
+
+### Step 5: Commit and publish
+
+Each skill update should be its own commit. Command updates are a separate commit.
+Write a clear progress entry documenting what changed and why.
+
+## Constraints
+
+- Do NOT modify the project's top-level CLAUDE.md or roadmap files
+- Only commit skill and command changes (plus progress entry)
+- No code changes — this is workflow, not implementation
+
+## Reflect
+
+Run `/reflect`. If it suggests further improvements beyond what you already did,
+capture them in a meditate issue for the next session.

--- a/pod/data/agent-config/codex/commands/plan.md
+++ b/pod/data/agent-config/codex/commands/plan.md
@@ -1,0 +1,182 @@
+# Plan a Work Item
+
+You are a **planner** session. Your job is to create well-scoped, atomic work
+items as GitHub issues, then exit. You do NOT execute any code changes.
+
+## Step 1: Orient
+
+1. `git fetch origin master`
+2. `coordination orient` — see open issues (claimed and unclaimed), PRs, attention items
+3. Read the last 5 files in `progress/` (sorted by filename) to understand recent work
+4. Read the project's roadmap document to understand current phase
+5. Record quality metrics as described in the project's CLAUDE.md
+
+## Step 1b: Check for human oversight directives
+
+Before creating any new work, check for open `human-oversight` issues:
+```
+gh issue list --label human-oversight --state open --json number,title,labels \
+    --jq '.[] | select(.labels | all(.name != "has-pr")) | "#\(.number) \(.title)"'
+```
+
+These are direct instructions from the project owner. Treat them as highest priority:
+- **Do not create issues that overlap with or supersede a `human-oversight` issue**
+- **Do not close `human-oversight` issues** — only the owner closes them
+- **Do not add `replan` to `human-oversight` issues** — they stay open until done
+- If a `human-oversight` issue is already claimed, continue to Step 2 (workers are on it)
+- If unclaimed, prioritise creating any supporting infrastructure issues first, then exit
+  — the next worker will claim the directive itself
+
+## Step 2: Merge ready PRs
+
+Before anything else, merge all open PRs that are mergeable with passing CI:
+```bash
+gh pr list --state open \
+  --json number,mergeable,statusCheckRollup \
+  --jq '.[] | select(
+    .mergeable == "MERGEABLE" and
+    (.statusCheckRollup | length > 0) and
+    (.statusCheckRollup | all(.conclusion != "FAILURE" and .conclusion != "CANCELLED"))
+  ) | .number' \
+| xargs -I{} gh pr merge {} --squash --delete-branch
+```
+
+Never skip this step. Downstream agents are blocked on `main` until merged PRs land.
+
+## Step 3: Triage `replan` issues (before creating new work)
+
+Fetch the list:
+```
+gh issue list --label replan --state open --json number,title,body \
+    --jq '.[] | "### #\(.number) \(.title)\n\(.body)\n"'
+```
+
+Process **all** replan issues before creating any new issues.
+For each, exactly one of:
+- **Work already done** (a subsequent PR merged it): close with a note
+- **Plan stale / approach changed**: create a corrected replacement issue, close original linking forward
+- **Partial progress**: create issue for remaining deliverables, close original linking forward
+- **Still valid, body still accurate**: remove the `replan` label (`gh issue edit N --remove-label replan`) to re-open for workers
+- **Still valid, body stale**: update the issue body with current state, then remove the `replan` label
+
+**Never delegate replan triage to a worker** — that is the planner's job.
+
+## Step 4: Create fix issues for broken PRs
+
+Check for PRs with merge conflicts or failing CI:
+```bash
+gh pr list --state open --json number,title,mergeable,statusCheckRollup \
+  --jq '.[] | select(
+    .mergeable == "CONFLICTING" or
+    (.statusCheckRollup | any(.conclusion == "FAILURE"))
+  ) | "#\(.number) \(.title) \(if .mergeable == "CONFLICTING" then "[CONFLICTS]" else "[CI FAILED]" end)"'
+```
+
+For each broken PR, check if a fix issue already exists:
+```bash
+gh issue list --label agent-plan --state open --json number,title \
+  --jq '.[].title' | grep -i "PR #N"
+```
+
+If no fix issue exists, **create one immediately** using `coordination plan`.
+These fix issues take priority over all new feature work.
+
+## Step 5: Understand existing plans
+
+Read the **full body** of every open `agent-plan` issue:
+```
+gh issue list --label agent-plan --state open --limit 20 \
+    --json number,title,body --jq '.[] | "### #\(.number) \(.title)\n\(.body)\n"'
+```
+
+Understand what's already planned at the **deliverable level**, not just the title.
+Your work item MUST NOT overlap with any existing issue's deliverables.
+
+## Step 6: Write new issues
+
+Work types: **`feature`**, **`review`**, **`summarize`**, **`meditate`**.
+Target roughly 2:1 feature:review during implementation; 1:1 during cleanup.
+
+**Summarize trigger**: when 10+ PRs merged since last summarize issue closed.
+**Meditate trigger**: when 15+ PRs merged since last meditate issue closed.
+
+Each issue body MUST be **self-contained**:
+- **Current state**, **Deliverables**, **Context**, **Verification**
+
+**Sizing**: max 3 deliverables, ~2 files, ~200 lines. Over 300 lines → split.
+When in doubt, split. Each issue must have a single logical concern.
+
+**Stage granularity**: If the project roadmap has "stages" or "phases", **never
+create an issue that spans multiple stages**. Each issue belongs to exactly one
+stage.
+
+Within a stage, maximise parallelism: if the stage contains independent items
+(e.g., "transcribe all pages", "formalise each definition"), create a **separate
+issue per item** (or per small batch of items) so workers can execute them
+concurrently. If the PLAN.md gives explicit parallelisation instructions for a
+stage, follow them. The goal is many small, independent issues — not one large
+issue per stage.
+
+If you cannot yet determine the scope of a stage because it depends on earlier
+output (e.g., item discovery), create the issue for the whole stage but include
+a note in the body: **"This issue needs decomposition: once the prerequisite is
+complete, the claiming worker should
+`coordination skip N 'needs decomposition into per-item sub-issues'` so the
+planner can create properly-scoped sub-issues."** This keeps issue creation under
+planner locking and overlap protection. Never ask workers to create issues directly.
+
+**Critical-path issues**: When you create an issue that blocks all other planned
+work (e.g., the first issue in a sequential pipeline, or a bottleneck that many
+blocked issues depend on), use `--critical-path` when posting it:
+```
+coordination plan --label feature --critical-path "title" < plans/body.md
+```
+This tells the dispatcher to assign a worker immediately, bypassing the normal
+queue-size threshold. Use sparingly — only for genuine pipeline bottlenecks where
+no other useful work can proceed until this issue is done.
+
+**Queue health**: keep <3 unclaimed → create unblocked work.
+No transitive blocking. Keep work types mixed.
+
+After writing, re-fetch open issues to check for overlap:
+```
+gh issue list --label agent-plan --state open --limit 20 \
+    --json number,title --jq '.[].title'
+```
+
+## Step 7: Post and exit
+
+For each issue, write the plan body to `plans/<UUID-prefix>-N.md`, then post:
+```
+coordination plan --label <feature|review|summarize|meditate> "title" < plans/<UUID-prefix>-N.md
+```
+
+**Adjusting agent pool size**: After assessing the project state, use these
+commands to tell the dispatcher what you think is appropriate:
+- `coordination set-target N` — recommend N agents for this project (pod uses
+  min of your recommendation and the user's configured maximum)
+- `coordination set-min-queue N` — recommend min_queue of N (pod uses min of
+  your recommendation and the config value, floored at 1)
+
+Set target based on how much parallelisable work exists. Set min_queue based on
+how far ahead you want planning to stay (typically 2-3 during active development,
+1 during sequential bottlenecks).
+
+**If you created zero new issues** but work is still in-flight (claimed issues,
+open PRs, blocked issues): set target to the number of currently claimed issues
+(workers already running) and set min_queue to 1.
+
+**If zero new issues AND nothing in-flight** (no unclaimed, no claimed, no
+broken PRs): `coordination return-to-human` (signals the pod TUI to stop
+spawning agents). Verify all three are zero first:
+```bash
+coordination queue-depth
+gh issue list --label claimed --state open --json number --jq 'length'
+gh pr list --state open --json number,mergeable,statusCheckRollup \
+  --jq '[.[] | select(.mergeable == "CONFLICTING" or (.statusCheckRollup | any(.conclusion == "FAILURE")))] | length'
+```
+
+Then exit. Do NOT execute any code changes.
+
+**Note**: The planner lock is managed by `pod` — do NOT call
+`coordination lock-planner` or `coordination unlock-planner` yourself.

--- a/pod/data/agent-config/codex/commands/reflect.md
+++ b/pod/data/agent-config/codex/commands/reflect.md
@@ -1,0 +1,41 @@
+# Self-Reflection Command
+
+Review the current conversation and identify areas where you **genuinely struggled** and where additional prompting would have prevented the issue.
+
+**Important:** Distinguish between:
+- **Successful adaptation** - You figured it out, learned, and completed the task effectively
+- **Actual struggles** - You made repeated mistakes, needed user correction, or failed to meet expectations
+
+## Areas to Consider
+
+- Tool usage and efficiency
+- Understanding the repository layout and conventions
+- Following expected workflows for this project
+- Interpreting test results, diagnostics, or error messages
+- Understanding user expectations or requirements
+- Following instructions in CLAUDE.md files (global or project-specific)
+
+## For Each ACTUAL Struggle
+
+**Only propose additions if:**
+1. The struggle caused real problems or required user intervention
+2. Clearer prompting would have prevented the issue
+3. The issue is likely to recur without guidance
+
+**For each qualifying struggle:**
+1. Explain what happened and why it was problematic
+2. Determine whether this is a project-specific or general issue
+3. Propose specific, concise additions to the appropriate file:
+   - Project-specific issues → `.claude/CLAUDE.md` or `.claude/skills/`
+   - Agent workflow issues → config-dir skills or commands
+
+## Recognize Success
+
+**If you successfully adapted and completed tasks without issues:**
+- Acknowledge what went well
+- Note that no additional prompting is needed
+- **Don't propose changes just to document everything**
+
+**Avoid prompt bloat** - only add guidance for genuine gaps, not successful exploration and learning.
+
+Present your findings, celebrating successes and only proposing improvements where truly needed.

--- a/pod/data/agent-config/codex/commands/review.md
+++ b/pod/data/agent-config/codex/commands/review.md
@@ -1,0 +1,49 @@
+# Execute a Review Work Item
+
+You are a **review** session. Your job is to claim and execute a pre-planned review
+work item from the issue queue.
+
+**First, read the `agent-worker-flow` skill** for the standard
+claim/branch/verify/publish workflow. This document only covers what is specific
+to review sessions.
+
+## Claiming Your Issue
+
+Use `coordination list-unclaimed --label review` to find work for this session type.
+
+## Review Focus Areas
+
+Each session should pick **one or two** focus areas and go deep, rather than
+superficially covering everything. The issue body will specify what to focus on.
+Rotate through these areas across sessions:
+
+**Refactoring and code improvement** (top priority):
+- Can code be simplified? Are there redundant steps?
+- Would extracting a function/lemma improve readability or enable reuse?
+- Are there generally useful constructions worth upstreaming?
+
+**Slop detection**:
+- Dead code, duplicated logic, verbose comments, unused imports
+- Other signs of AI-generated bloat
+
+**Idioms and best practices**:
+- Are newer APIs or language features being used where appropriate?
+- Opportunities to improve type safety, remove unsafe operations
+
+**Toolchain**:
+- Check if a newer stable toolchain release is available; upgrade if tests pass
+
+**File size and organization**:
+- Files over 500 lines are candidates for splitting; never let a file grow past 1000
+
+**Security**:
+- Check for new issues in recent code, verify past fixes
+
+## Updating Skills
+
+When you discover a recurring pattern or encounter a situation not covered by
+existing skills, update the relevant skill file or create a new one.
+
+## Reflect
+
+Run `/reflect` before finishing.

--- a/pod/data/agent-config/codex/commands/summarize.md
+++ b/pod/data/agent-config/codex/commands/summarize.md
@@ -1,0 +1,54 @@
+# Execute a Summarize Work Item
+
+You are a **summarize** session. Your job is to produce an accurate summary of
+project progress that honestly identifies both achievements and limitations.
+
+**First, read the `agent-worker-flow` skill** for the standard
+claim/branch/verify/publish workflow. This document only covers what is specific
+to summarize sessions.
+
+## Claiming Your Issue
+
+Use `coordination list-unclaimed --label summarize` to find work for this session type.
+
+## The Summary Task
+
+### Step 1: Read the project specification
+
+Find and read the top-level specification/roadmap document to understand the
+project's intended goals. This is the ground truth against which you measure progress.
+
+### Step 2: Read the current progress document
+
+Understand what the project currently claims to have achieved.
+
+### Step 3: Survey recent work
+
+- Read the last 15 entries in `progress/` (sorted by filename, most recent last)
+- Fetch titles of PRs merged since the last `summarize` issue was closed
+
+### Step 4: Inspect the codebase
+
+- List source files and read their module-level docstrings
+- Read key top-level declarations/signatures (not full implementations)
+- Record current quality metrics as described in the project's CLAUDE.md
+
+### Step 5: Produce an updated progress document
+
+Write an updated progress document that:
+
+- **Accurately reflects** current quality metrics and phase
+- **Describes the architecture structurally** (layers, relationships)
+- **Identifies flaws and limitations honestly** (scope restrictions,
+  remaining work, gaps between goals and achievements)
+- **Is honest in its framing** — don't overstate what has been achieved
+
+## Constraints
+
+- Do NOT modify any code or implementation files
+- Commit ONLY the progress document changes
+- The progress entry should note what changed and why
+
+## Reflect
+
+Run `/reflect` before finishing.

--- a/pod/data/agent-config/codex/commands/work.md
+++ b/pod/data/agent-config/codex/commands/work.md
@@ -1,0 +1,16 @@
+# Execute a Work Item
+
+You are a **work** (meta) session. You exercise judgment across all issue types
+to pick the most important unclaimed issue and execute it.
+
+**Note**: Pod does not call `/work` by default — it dispatches directly to
+`/feature`, `/review`, `/summarize`, or `/meditate` based on issue labels.
+`/work` exists as a manual escape hatch.
+
+## What to Do
+
+1. Run `coordination list-unclaimed` to see all unclaimed issues (all labels)
+2. Read the issue bodies to understand what's available
+3. Based on your own judgment, select the most important one
+4. Identify its label (`feature`, `review`, `summarize`, or `meditate`)
+5. Execute the appropriate sub-command (`/feature`, `/review`, `/summarize`, `/meditate`)

--- a/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: agent-worker-flow
+description: Standard claim/branch/verify/publish workflow for pod agent sessions. Read this skill at the start of any feature, review, summarize, or meditate session.
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# Standard Worker Flow for Pod Agent Sessions
+
+This skill covers the shared workflow used by all pod worker agents.
+Session-specific commands reference this skill rather than duplicating it.
+
+## Coordination Reference
+
+The `coordination` script handles all GitHub-based multi-agent coordination.
+Session UUID is available as `$POD_SESSION_ID` (exported by `pod`).
+The `gh` CLI defaults to the current repo, so `--repo` is not needed.
+
+| Command | What it does |
+|---------|-------------|
+| `coordination orient` | List unclaimed/claimed issues, open PRs, PRs needing attention |
+| `coordination plan [--label L] "title"` | Create GitHub issue with agent-plan + optional label; body from stdin |
+| `coordination create-pr N [--partial] ["title"]` | Push branch, create PR closing issue #N, enable auto-merge, swap `claimed` → `has-pr`. With `--partial`: adds `replan` label. |
+| `coordination claim-fix N` | Comment on failing PR #N claiming fix (30min cooldown) |
+| `coordination close-pr N "reason"` | Comment reason and close PR #N |
+| `coordination list-unclaimed [--label L]` | List unclaimed agent-plan issues (FIFO order); optional label filter |
+| `coordination queue-depth [L]` | Count of unclaimed issues; optional label for per-type count |
+| `coordination claim N` | Claim issue #N — adds `claimed` label + comment, detects races |
+| `coordination skip N "reason"` | Mark claimed issue as needing replan — removes `claimed`, adds `replan` label |
+| `coordination add-dep N M` | Add `depends-on: #M` to issue #N's body; adds `blocked` label if #M is open |
+| `coordination check-blocked` | Unblock issues whose `depends-on` dependencies are all closed |
+| `coordination release-stale-claims [SECS]` | Release claimed issues with no PR after SECS seconds (default 4h); **manual use only** |
+| `coordination lock-planner` | Acquire advisory planner lock (20min TTL) |
+| `coordination unlock-planner` | Release planner lock early |
+| `coordination critical-path-depth [L]` | Count unclaimed critical-path issues; optional label filter |
+| `coordination set-target N` | Planner sets recommended target agent count |
+| `coordination set-min-queue N` | Planner sets recommended min_queue |
+
+**Issue lifecycle**: planner creates issue (label: `agent-plan`) →
+worker claims it (adds label: `claimed`) → worker creates PR closing it
+(label swaps to `has-pr`) → auto-merge squash-merges.
+Issues marked `replan` (by skip or partial completion) are handled by the next planner.
+Issues with `has-pr` are excluded from `list-unclaimed` and `queue-depth`.
+
+**Partial completion**: worker uses `--partial` → label swaps to
+`replan`. A planner creates a new issue for remaining work, then closes
+the `replan` issue with a link to the new one.
+
+**Dependencies**: Issues can declare `depends-on: #N` in their body.
+`coordination plan` auto-adds the `blocked` label if any dependency is
+open. `check-blocked` (run by `pod` each loop) removes `blocked` when
+all dependencies close. Blocked issues are excluded from
+`list-unclaimed` and `queue-depth`.
+
+**Branch naming**: `agent/<first-8-chars-of-UUID>`
+**Plan files**: `plans/<UUID-prefix>.md`
+**Progress files**: `progress/<UTC-timestamp>_<UUID-prefix>.md`
+
+## Step 1: Claim a Work Item
+
+```
+coordination orient
+```
+
+**Priority order:**
+0. **Human oversight directives first**: Check for open `human-oversight` issues before
+   anything else. These are direct instructions from the project owner and take absolute
+   precedence over all other work:
+   ```
+   coordination list-unclaimed --label human-oversight
+   ```
+   If any are open and unclaimed, claim the oldest one immediately.
+   **These issues cannot be skipped or refused because you disagree with the approach.**
+   The only valid exit from a `human-oversight` issue is completing it, or posting a
+   comment explaining a genuine technical blocker (e.g. a missing dependency), then
+   using `coordination skip` with that reason. Do not `skip` because you think a
+   different approach is better — that is the owner's call, not yours.
+1. **PRs needing attention**: merge conflicts or failing CI. Check if any
+   unclaimed issue references that PR (title containing "rebase PR #N" or "fix PR #N").
+   Claim that first — unblocking broken PRs beats starting new work.
+2. **Oldest unclaimed issue** of your type:
+   ```
+   coordination list-unclaimed --label <your-label>
+   ```
+
+If the queue is empty, write a brief progress note and exit.
+
+```
+coordination claim <issue-number>
+```
+
+**You MUST check the output.** If it says `CLAIM FAILED`, you MUST NOT work
+on that issue — pick a different one. Only proceed if the output says
+`Claimed issue #N`. Read the full issue body:
+```
+gh issue view <N> --json body --jq .body
+```
+
+## Step 2: Set Up
+
+```bash
+git checkout -b agent/<first-8-chars-of-session-UUID>
+git rev-parse HEAD      # record starting commit
+```
+
+Record any project-specific quality metrics (e.g. sorry count, test coverage)
+as described in the project's CLAUDE.md.
+
+## Step 3: Codebase Orientation
+
+Read the specific files mentioned in the plan/issue. Understand the current state
+of code you'll be modifying. Don't read progress history — the issue body provides
+that context.
+
+## Step 4: Verify Assumptions
+
+Check that the plan's assumptions still hold:
+- Quality metrics match what the issue says
+- Files mentioned in the issue still exist and haven't been restructured
+- No recently merged PR invalidates the plan
+
+If stale:
+```
+coordination skip <issue-number> "reason: <what changed>"
+```
+Go back to Step 1 and try the next issue.
+
+**PR fix plans**: If the plan asks you to fix a broken PR, use judgement. If the
+PR is low quality or not worth salvaging:
+```
+coordination close-pr <pr-number> "reason: <why not worth fixing>"
+```
+
+## Step 4b: Assess Scope
+
+After orienting but **before writing code**, check whether the task fits
+in a single session. Warning signs it doesn't:
+
+- Target file is 500+ lines and you need to understand most of it
+- The work naturally splits into independent sub-lemmas or sub-tasks
+- Difficulty feels higher than the issue says
+
+**If so, decompose immediately** — don't attempt the whole thing first.
+
+```bash
+# Create sub-issues, then skip the parent
+echo "body..." | coordination plan --label feature "Sub-task 1: ..."
+echo "body..." | coordination plan --label feature "Sub-task 2: ..."
+coordination add-dep <sub2> <sub1>   # if ordering matters
+coordination skip <parent> "Decomposed into #X, #Y — too large for single session"
+```
+
+Then claim one of the sub-issues and work on that instead.
+A good decomposition is more valuable than a failed heroic attempt.
+
+## Step 5: Execute
+
+After each coherent chunk of changes:
+- Build and test using the project's build commands (see project CLAUDE.md)
+- Commit with conventional prefixes: `feat:`, `fix:`, `refactor:`, `test:`, `doc:`, `chore:`
+
+Each commit must compile. One logical change per commit.
+
+**Commit early, create PRs early.** Sessions can terminate at any time.
+Pushed-but-not-PR'd work is effectively lost — nobody will find it.
+
+- Commit after every compiling milestone. Don't wait for the full feature.
+- WIP commits are fine: `feat: WIP prove helper_lemma (2/4 sorries remain)`
+- If 20+ minutes have passed without a commit, stop and commit now.
+- Use `coordination create-pr N --partial` as soon as you have useful
+  progress, even if incomplete. This saves the work as a visible PR.
+
+**Failure handling:**
+- Build fails on pre-existing issue → log and work around
+- Stuck after 3 fundamentally different attempts → decompose into sub-issues (Step 4b)
+- 3 consecutive iterations with no commits → end session, document blockers
+  (does not apply to review or self-improvement sessions)
+- If `/second-opinion` or `/reflect` is unavailable, skip and note in progress entry
+
+## Step 5b: Context Health
+
+**If conversation compaction occurs:**
+1. Finish your current sub-task (get to compiling state)
+2. Commit what you have
+3. Skip remaining deliverables — do NOT start new work
+4. Go directly to Step 6 then Step 7 with `--partial`
+
+Commit early and often. Each commit is a checkpoint.
+
+## Step 6: Verify
+
+Build and test the project. Compare quality metrics with the starting values.
+Review your diff: `git diff <starting-commit>..HEAD`.
+Use `/second-opinion` if available.
+
+## Step 7: Publish
+
+Write a progress entry to `progress/<UTC-timestamp>_<UUID-prefix>.md`:
+- Date/time (UTC), session type, what was accomplished
+- Decisions made, key patterns discovered
+- What remains, quality metric deltas
+
+**Full completion:**
+```bash
+git push -u origin <branch>
+coordination create-pr <issue-number>
+```
+
+**Partial completion** (did NOT complete all deliverables):
+- Progress entry lists: completed deliverables, NOT-completed deliverables and why,
+  whether unfinished work needs a new issue
+- Use `--partial`:
+  ```
+  coordination create-pr <N> --partial "feat: what was actually done"
+  ```
+
+**If you only closed a bad PR** (no code changes):
+```bash
+gh issue close <N> --comment "Closed PR #M as not worth salvaging. See progress entry."
+```
+
+## Step 8: Reflect
+
+Run `/reflect`. If it suggests improvements to skills or commands, make those
+changes and commit before finishing. Do NOT modify the project's top-level
+CLAUDE.md or roadmap files — those are off-limits to agents.


### PR DESCRIPTION
PRs 3+4 of 5 for Codex backend support. Adds the full Codex agent lifecycle.

## Codex JSONL parser (PR 3)
- `_parse_codex_jsonl_line()` handles `thread.started` (captures `backend_session_id`), `turn.completed` (token usage), `item.completed` (agent messages + command output with claim detection)
- `_parse_jsonl_line()` dispatches to Claude or Codex parser based on backend
- `jsonl_monitor()` accepts backend parameter
- Parser verified against captured `codex exec --json` v0.104.0 output

## Codex launcher (PR 4)
- `launch_agent()` dispatches to Claude or Codex CLI based on `[agent] backend`
- Codex: `codex exec --json --dangerously-bypass-approvals-and-sandbox -m <model> -C <wt_dir> -` with prompt piped via stdin
- Sets `OPENAI_API_KEY=""` to force subscription auth
- Creates isolated `CODEX_HOME` per agent (via `_setup_codex_home`) with symlinked auth and bundled skills
- `get_jsonl_path()` returns `.stdout` path for Codex (the live `--json` stream)

## Config and commands
- `install_agent_config()` is backend-aware: Claude gets `.claude/`, Codex gets `AGENTS.md` at worktree root
- `_worker_prompt()` returns slash command name for Claude, full command template body for Codex
- Bundled `pod/data/agent-config/codex/` with AGENTS.md, commands/, and skills/

## What's left (PR 5)
End-to-end test with a real Codex project.

🤖 Prepared with Claude Code