### PR TITLE
Make pod state files self-documenting

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -578,33 +578,46 @@ def read_all_agents() -> list[AgentState]:
     return agents
 
 
-def read_target() -> int | None:
-    """Read target agent count from .pod/target, or None if not set."""
+def _read_commented_int(path: Path) -> int | None:
+    """Read the first non-comment integer from a small state file."""
     try:
-        return int(TARGET_FILE.read_text().strip())
+        for line in path.read_text().splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            return int(stripped)
     except (OSError, ValueError):
         return None
+    return None
+
+
+def _write_commented_int(path: Path, value: int, comments: list[str]):
+    """Write a small state file with comment headers plus a numeric payload."""
+    header = "\n".join(f"# {comment}" for comment in comments)
+    path.write_text(f"{header}\n{max(0, value)}\n")
+
+
+def read_target() -> int | None:
+    """Read target agent count from .pod/target, or None if not set."""
+    return _read_commented_int(TARGET_FILE)
 
 
 def write_target(n: int):
     """Write target agent count to .pod/target."""
-    TARGET_FILE.write_text(str(max(0, n)))
+    _write_commented_int(TARGET_FILE, n, [
+        "User target agent count.",
+        "pod tries to keep this many agents running.",
+    ])
 
 
 def read_planner_target() -> int | None:
     """Read planner-recommended target from .pod/planner-target, or None if not set."""
-    try:
-        return int(PLANNER_TARGET_FILE.read_text().strip())
-    except (OSError, ValueError):
-        return None
+    return _read_commented_int(PLANNER_TARGET_FILE)
 
 
 def read_planner_min_queue() -> int | None:
     """Read planner-recommended min_queue from .pod/planner-min-queue, or None if not set."""
-    try:
-        return int(PLANNER_MIN_QUEUE_FILE.read_text().strip())
-    except (OSError, ValueError):
-        return None
+    return _read_commented_int(PLANNER_MIN_QUEUE_FILE)
 
 
 def get_effective_target() -> int | None:

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -846,7 +846,11 @@ cmd_set_target() {
         echo "error: .pod/ not found at $pod_dir" >&2
         return 1
     fi
-    printf '%d' "$n" > "$pod_dir/planner-target"
+    cat > "$pod_dir/planner-target" <<EOF
+# Planner advisory: cap effective target to this many agents.
+# Effective target is min(target, planner-target).
+$n
+EOF
     echo "Planner target set to $n"
 }
 
@@ -862,7 +866,11 @@ cmd_set_min_queue() {
         echo "error: .pod/ not found at $pod_dir" >&2
         return 1
     fi
-    printf '%d' "$n" > "$pod_dir/planner-min-queue"
+    cat > "$pod_dir/planner-min-queue" <<EOF
+# Planner advisory: lower queue_balance min_queue threshold.
+# Effective min_queue is max(1, min(config min_queue, planner-min-queue)).
+$n
+EOF
     echo "Planner min_queue set to $n"
 }
 

--- a/tests/test_state_files.py
+++ b/tests/test_state_files.py
@@ -1,0 +1,42 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pod import cli
+
+
+class StateFileTests(unittest.TestCase):
+    def test_write_target_is_self_documenting_and_round_trips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target"
+            with mock.patch.object(cli, "TARGET_FILE", target):
+                cli.write_target(8)
+                self.assertEqual(cli.read_target(), 8)
+                self.assertEqual(
+                    target.read_text(),
+                    "# User target agent count.\n"
+                    "# pod tries to keep this many agents running.\n"
+                    "8\n",
+                )
+
+    def test_reader_ignores_comments_and_blank_lines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "planner-target"
+            path.write_text(
+                "# Planner advisory.\n"
+                "\n"
+                "# Effective target is min(target, planner-target).\n"
+                "3\n"
+            )
+            self.assertEqual(cli._read_commented_int(path), 3)
+
+    def test_reader_rejects_invalid_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "planner-min-queue"
+            path.write_text("# comment only\nnot-an-int\n")
+            self.assertIsNone(cli._read_commented_int(path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make `.pod/target`, `.pod/planner-target`, and `.pod/planner-min-queue`
self-documenting by writing them with short comment headers, and teach pod
to ignore comment and blank lines when reading them.

## Changes

- add a small helper in `pod/cli.py` to read the first non-comment integer
  from a state file
- add a matching writer for documented integer state files
- update `write_target()` to write a commented `.pod/target`
- update `coordination set-target` and `coordination set-min-queue` to write
  commented planner advisory files
- add tests for round-tripping, comment skipping, and invalid payloads

## Why

These files are useful operational state, but their meaning is not obvious
from the filename alone. This makes them readable in-place without requiring
users to inspect the source.

## Testing

- `python -m unittest discover -s tests -v`
- `bash -n pod/data/coordination`
