### PR TITLE
feat: add repair agent type for PR salvage (closes #23)

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -627,6 +627,7 @@ class AgentState:
     session_start: float = 0.0
     claimed_issue: int = 0
     pr_number: int = 0
+    repair_pr: int = 0             # PR currently claimed by this agent for repair
     git_start: str = ""
     tokens_in: int = 0
     tokens_out: int = 0
@@ -1482,15 +1483,27 @@ def _parse_codex_jsonl_line(line: bytes, state: AgentState):
             cmd = item.get("command", "")[:120]
             state.last_text = f"[exec] {cmd}"
             state.last_activity = time.time()
-            # Detect claim from coordination script output
+            # Detect issue claim from coordination script output
             output = item.get("aggregated_output", "")
             m = re.search(r"Claimed issue #(\d+)", output)
             if m:
                 state.claimed_issue = int(m.group(1))
+            # Detect PR repair claim from output (only on success — the command
+            # emits "Claimed PR #N for repair" only after race-detect passes)
+            m_pr_claim = re.search(r"Claimed PR #(\d+) for repair", output)
+            if m_pr_claim:
+                state.repair_pr = int(m_pr_claim.group(1))
             # Detect PR creation from coordination create-pr
             m2 = re.search(r"(?:coordination\s+create-pr\s+(?:--\S+\s+)*)(\d+)", cmd)
             if m2:
                 state.pr_number = int(m2.group(1))
+            # Detect repair-claim release (mark-pr-salvaged / close-pr-unsalvageable)
+            m_rel = re.search(
+                r"coordination\s+(?:mark-pr-salvaged|close-pr-unsalvageable)\s+(\d+)",
+                cmd,
+            )
+            if m_rel:
+                state.repair_pr = 0
 
 
 def _parse_claude_jsonl_line(line: bytes, state: AgentState):
@@ -1513,6 +1526,9 @@ def _parse_claude_jsonl_line(line: bytes, state: AgentState):
                         m = re.search(r"Claimed issue #(\d+)", result_text)
                         if m:
                             state.claimed_issue = int(m.group(1))
+                        m_pr = re.search(r"Claimed PR #(\d+) for repair", result_text)
+                        if m_pr:
+                            state.repair_pr = int(m_pr.group(1))
         return
 
     if msg_type != "assistant":
@@ -1541,10 +1557,19 @@ def _tool_detail(name: str, inp: dict, state: AgentState) -> str:
     if name == "Bash":
         desc = inp.get("description", "")
         cmd = inp.get("command", "")
-        # Detect coordination create-pr (claim is detected from tool results instead)
+        # Detect coordination create-pr (issue-claim is detected from tool results instead)
         m = re.search(r"(?:^|&&\s*|;\s*)(?:\./)?coordination\s+create-pr\s+(?:--\S+\s+)*(\d+)", cmd)
         if m:
             state.pr_number = int(m.group(1))
+        # Repair-claim release: mark-pr-salvaged / close-pr-unsalvageable
+        # clear the repair-claimed label, so we should clear our own tracking
+        # as soon as we see the command fire.
+        m_rel = re.search(
+            r"(?:^|&&\s*|;\s*)(?:\./)?coordination\s+(?:mark-pr-salvaged|close-pr-unsalvageable)\s+(\d+)",
+            cmd,
+        )
+        if m_rel:
+            state.repair_pr = 0
         if desc and cmd:
             return f"{desc}: {cmd}"
         return desc or cmd
@@ -2357,23 +2382,64 @@ def check_dead_pr_claimed_prs(config: dict):
     history = load_pr_claim_history()
     agents = read_all_agents()
     live_uuids = {a.uuid for a in agents if a.status not in ("dead", "stopped", "killed")}
+    # Also treat any PR actively tracked by a live agent's state.repair_pr as
+    # owned, even if the local history hasn't caught up yet (e.g. within the
+    # few-second window between label write and record_pr_claim).
+    live_repair_prs = {a.repair_pr for a in agents
+                        if a.repair_pr > 0 and a.uuid in live_uuids}
 
     now_epoch = time.time()
+    grace_seconds = 300  # 5 min — don't yank labels out from under fresh claims
     to_release: list[tuple[int, str]] = []  # (pr_num, reason)
 
     # 2. Labelled PRs: check live-session liveness via history + agent state.
     for pr_num in labelled:
+        if pr_num in live_repair_prs:
+            continue  # A live agent reports this PR as its repair_pr
         entry = history.get(str(pr_num))
         if not entry:
-            # Untracked: no local history. Release if no live agent is
-            # actively working on this PR (best-effort: we can't match agent
-            # to PR without pr_number in AgentState, so just release
-            # after a grace window). For safety, require the label to be
-            # older than the stale_seconds threshold — which we don't have
-            # without a claim comment, so just release immediately. The
-            # coordination script only adds the label via claim-pr-repair,
-            # which always writes history, so untracked label ⇒ leak.
-            to_release.append((pr_num, "untracked: no local claim history"))
+            # Untracked label. Could be a leak (label added by a failed
+            # claim run that died before record_pr_claim) or a very fresh
+            # claim whose record hasn't been written yet. Fetch the latest
+            # claim comment to distinguish, and only release if:
+            #  - the comment is older than the grace window, AND
+            #  - its owner session is not live.
+            try:
+                r = subprocess.run(
+                    ["gh", "api", "--paginate", f"repos/{repo}/issues/{pr_num}/comments",
+                     "--jq",
+                     '[.[] | select(.body | startswith("Claimed PR repair by session"))] '
+                     '| sort_by(.created_at) | last | {body, created_at}'],
+                    capture_output=True, text=True, timeout=30, cwd=cwd,
+                )
+                if r.returncode != 0:
+                    continue
+                blob = r.stdout.strip()
+                if not blob or blob == "null":
+                    # No claim comment at all — label is orphaned from a
+                    # failed claim attempt. Grace-release.
+                    to_release.append((pr_num, "orphaned label: no claim comment"))
+                    continue
+                cdata = json.loads(blob)
+            except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+                continue
+            import re as _re
+            m = _re.search(r'Claimed PR repair by session `([^`]+)`', cdata.get("body", ""))
+            if not m:
+                continue
+            owner_uuid = m.group(1)
+            try:
+                from datetime import datetime
+                created_at = cdata.get("created_at", "")
+                claim_ts = datetime.fromisoformat(created_at.replace("Z", "+00:00")).timestamp()
+            except (ValueError, TypeError):
+                continue
+            age = now_epoch - claim_ts
+            if age < grace_seconds:
+                continue  # Too fresh, might be a claim mid-write
+            if owner_uuid in live_uuids:
+                continue  # Owner is alive — leave their label alone
+            to_release.append((pr_num, f"untracked: owner {owner_uuid[:8]} not live (age {int(age)}s)"))
             continue
 
         owner_uuid = entry.get("session_uuid", "")
@@ -2382,7 +2448,7 @@ def check_dead_pr_claimed_prs(config: dict):
 
         claimed_at = entry.get("claimed_at", 0)
         age = now_epoch - claimed_at if claimed_at else stale_seconds + 1
-        if age < 300:  # 5 minute grace window for races
+        if age < grace_seconds:
             continue
         to_release.append((pr_num, f"owner {owner_uuid[:8]} no longer live (age {int(age)}s)"))
 
@@ -3327,6 +3393,7 @@ def agent_process_main(config: dict, agent_id: str | None = None,
 
         # --- Monitor until claude exits ---
         _last_tracked_issue = 0
+        _last_tracked_repair_pr = 0
         _stuck_first_detected = 0.0   # monotonic time of first stuck detection
         _stuck_kill_pending = False    # True after phase-1 detection, waiting for confirm
         _last_stuck_check = 0.0       # monotonic time of last health check
@@ -3341,6 +3408,15 @@ def agent_process_main(config: dict, agent_id: str | None = None,
             elif state.pr_number > 0 and state.claimed_issue > 0:
                 clear_claim(state.claimed_issue, session_uuid=state.uuid)
                 _last_tracked_issue = 0
+            # Track repair-PR claim lifecycle (parallel to issue-claim). A
+            # repair agent never has a claimed_issue, so these live on a
+            # separate branch keyed by state.repair_pr.
+            if state.repair_pr > 0 and state.repair_pr != _last_tracked_repair_pr:
+                record_pr_claim(state.repair_pr, state.uuid, state.short_id)
+                _last_tracked_repair_pr = state.repair_pr
+            elif state.repair_pr == 0 and _last_tracked_repair_pr > 0:
+                clear_pr_claim(_last_tracked_repair_pr, session_uuid=state.uuid)
+                _last_tracked_repair_pr = 0
 
             # --- Stuck-agent detection ---
             stuck_initial = _reload_config_value(

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -79,6 +79,7 @@ AGENTS_DIR = POD_DIR / "agents"
 CONFIG_PATH = POD_DIR / "config.toml"
 LOG_PATH = POD_DIR / "pod.log"
 CLAIM_HISTORY_PATH = POD_DIR / "claim-history.json"
+PR_CLAIM_HISTORY_PATH = POD_DIR / "pr-claim-history.json"
 ISOLATED_CONFIG_DIR = POD_DIR / "claude-config"
 TARGET_FILE = POD_DIR / "target"  # Target agent count (int, one per line)
 PLANNER_TARGET_FILE = POD_DIR / "planner-target"  # Planner-recommended target agent count
@@ -142,6 +143,13 @@ cache_create = 6.25
 strategy = "queue_balance"
 min_queue = 3                      # queue_balance: below this → planner-type
 
+[repair]
+# A PR is considered "stuck" if a required check has been IN_PROGRESS
+# longer than this many minutes. Used by `coordination list-pr-repair`.
+stuck_ci_minutes = 120
+# Maximum concurrent repair agents (spawned regardless of planner_target).
+concurrency_cap = 2
+
 [monitor]
 poll_interval = 2                  # Seconds between status updates
 jsonl_stale_warning = 300          # Warn if JSONL unchanged for this many seconds
@@ -163,6 +171,14 @@ copy_build_cache = false
 
 [worker_types.work]
 prompt = "/work"
+copy_build_cache = true
+
+# Repair agent: handles unhealthy PRs (merge conflicts, failed CI, stuck CI).
+# Only selected when `coordination list-pr-repair` reports candidates (see
+# `dispatch_queue_balance`). `copy_build_cache` is enabled so repair agents
+# can run the project's verification before pushing.
+[worker_types.repair]
+prompt = "/repair"
 copy_build_cache = true
 
 # Example additional worker type:
@@ -540,6 +556,58 @@ def clear_claim(issue: int, session_uuid: str | None = None):
             return  # Entry belongs to a different session — don't clobber
         entry["released"] = True
         _save_claim_history(history)
+
+
+# ---------------------------------------------------------------------------
+# PR claim history (for repair agents)
+# ---------------------------------------------------------------------------
+# Mirrors issue-claim-history but keyed by PR number. A repair agent claims
+# a PR via `coordination claim-pr-repair`, which records an entry here. The
+# housekeeping loop (check_dead_pr_claimed_prs) releases stale claims whose
+# owning session has died, to keep the `repair-claimed` label from leaking.
+
+def load_pr_claim_history() -> dict:
+    """Load {pr_num_str -> {session_uuid, short_id, claimed_at}}."""
+    try:
+        return json.loads(PR_CLAIM_HISTORY_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_pr_claim_history(history: dict):
+    tmp = PR_CLAIM_HISTORY_PATH.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(history, indent=2) + "\n")
+        tmp.rename(PR_CLAIM_HISTORY_PATH)
+    except OSError as e:
+        log(f"Failed to save PR claim history: {e}")
+
+
+def record_pr_claim(pr: int, session_uuid: str, short_id: str):
+    """Record that our session is repairing PR #pr. Reuses the issue-claim
+    filelock since writes are rare and concurrency is low."""
+    with _claim_history_filelock():
+        history = load_pr_claim_history()
+        history[str(pr)] = {
+            "session_uuid": session_uuid,
+            "short_id": short_id,
+            "claimed_at": time.time(),
+        }
+        _save_pr_claim_history(history)
+
+
+def clear_pr_claim(pr: int, session_uuid: str | None = None):
+    """Remove the PR-claim entry, compare-and-swap on session_uuid if given."""
+    with _claim_history_filelock():
+        history = load_pr_claim_history()
+        key = str(pr)
+        entry = history.get(key)
+        if not entry:
+            return
+        if session_uuid and entry.get("session_uuid") != session_uuid:
+            return
+        history.pop(key, None)
+        _save_pr_claim_history(history)
 
 
 # ---------------------------------------------------------------------------
@@ -1107,6 +1175,11 @@ def coordination(config: dict, *args, env_extra: dict | None = None,
         if rel not in pf:
             pf.append(rel)
     env["POD_PROTECTED_FILES"] = ":".join(pf)
+    # Pass repair-agent thresholds so the coordination script doesn't have to
+    # re-parse config.toml. Treated as advisory defaults — script may override
+    # for local testing by exporting these before calling.
+    stuck_ci_minutes = cfg_get(config, "repair", "stuck_ci_minutes", default=120)
+    env.setdefault("POD_STUCK_CI_MINUTES", str(stuck_ci_minutes))
     if env_extra:
         env.update(env_extra)
     return subprocess.run(
@@ -1496,18 +1569,47 @@ def _tool_detail(name: str, inp: dict, state: AgentState) -> str:
 # Dispatch Strategies
 # ---------------------------------------------------------------------------
 
+def _count_running_repair_agents(agents: list | None = None) -> int:
+    """Count live agents whose worker_type is 'repair'."""
+    if agents is None:
+        agents = read_all_agents()
+    return sum(1 for a in agents
+               if a.worker_type == "repair"
+               and a.status not in ("dead", "stopped", "killed"))
+
+
+def _list_pr_repair_count(config: dict) -> int:
+    """Return the number of PR-repair candidates, or 0 on error.
+
+    Calls `coordination list-pr-repair` and counts output lines.
+    """
+    try:
+        r = coordination(config, "list-pr-repair")
+    except (subprocess.TimeoutExpired, OSError):
+        return 0
+    if r.returncode != 0:
+        return 0
+    return sum(1 for line in r.stdout.splitlines() if line.strip())
+
+
 def _choose_draining(config: dict, draining: dict) -> str | None:
     """Pick a random draining worker type that has available work.
 
     For types with issue_label, check per-label queue depth via
     `coordination queue-depth <label>`. Shuffled so no type is
     systematically starved.
-    For types without issue_label, always consider them available.
+    For types without issue_label, always consider them available — except
+    `repair`, which is excluded here; repair dispatch is handled by the
+    short-circuit at the top of dispatch_queue_balance so that a generic
+    draining pass does not pick `repair` when no PRs need it.
     Returns None if no draining type has work.
     """
     items = list(draining.items())
     random.shuffle(items)
     for name, wt in items:
+        if name == "repair":
+            log("_choose_draining: skipping repair (handled by top-level short-circuit)")
+            continue
         issue_label = wt.get("issue_label", "")
         if issue_label:
             try:
@@ -1546,10 +1648,13 @@ def _choose_critical_path_draining(config: dict, draining: dict) -> str | None:
     Like _choose_draining but only considers critical-path issues.
     For typed workers (with issue_label), checks per-label critical-path depth.
     For untyped workers, checks global critical-path depth.
+    `repair` is excluded — it handles PRs, not critical-path issues.
     """
     items = list(draining.items())
     random.shuffle(items)
     for name, wt in items:
+        if name == "repair":
+            continue
         issue_label = wt.get("issue_label", "")
         if issue_label:
             if _get_critical_path_depth(config, issue_label) > 0:
@@ -1564,7 +1669,27 @@ def _choose_critical_path_draining(config: dict, draining: dict) -> str | None:
 def dispatch_queue_balance(config: dict, queue_depth: int,
                            worker_types: dict,
                            state: AgentState | None = None) -> str | None:
-    """Low queue → locked types (queue-filling), high queue → unlocked types (queue-draining)."""
+    """Low queue → locked types (queue-filling), high queue → unlocked types (queue-draining).
+
+    **Repair short-circuit**: before any filling/draining logic, if the
+    `repair` worker type is configured and `coordination list-pr-repair`
+    reports PR candidates with spare repair concurrency, dispatch `repair`.
+    This keeps repair orthogonal to `planner_target` and to queue depth.
+    """
+    # Repair short-circuit. Runs first so that unhealthy PRs are always
+    # addressed before new feature work is planned or drained.
+    if "repair" in worker_types:
+        candidates = _list_pr_repair_count(config)
+        running_repair = _count_running_repair_agents()
+        cap = cfg_get(config, "repair", "concurrency_cap", default=2)
+        if candidates > running_repair and running_repair < cap:
+            log(f"dispatch: repair short-circuit (candidates={candidates}, "
+                f"running_repair={running_repair}, cap={cap})")
+            return "repair"
+        elif candidates > 0:
+            log(f"dispatch: repair candidates={candidates} but running_repair={running_repair} "
+                f"already at/near cap={cap}, falling through")
+
     config_min_queue = cfg_get(config, "dispatch", "min_queue", default=3)
     planner_min_queue = read_planner_min_queue()
     if planner_min_queue is not None:
@@ -1572,7 +1697,9 @@ def dispatch_queue_balance(config: dict, queue_depth: int,
     else:
         min_queue = max(1, config_min_queue)
 
-    # Separate types into queue-filling (have locks) and queue-draining (no locks)
+    # Separate types into queue-filling (have locks) and queue-draining (no locks).
+    # `repair` is draining in principle but is handled exclusively by the
+    # short-circuit above, so _choose_draining skips it.
     filling = {k: v for k, v in worker_types.items() if v.get("lock")}
     draining = {k: v for k, v in worker_types.items() if not v.get("lock")}
 
@@ -2192,6 +2319,110 @@ def reconcile_untracked_github_claims():
 
     if released_count or backfilled_count:
         log(f"Reconcile: {backfilled_count} backfilled, {released_count} released")
+
+
+def check_dead_pr_claimed_prs(config: dict):
+    """Release `repair-claimed` labels on PRs whose owning session is dead.
+
+    Counterpart to check_dead_claimed_issues, but for the PR-claim namespace
+    used by repair agents. Unlike issue claims, repair claims are never
+    restarted — if the session died, we clear the claim and let a fresh
+    repair agent pick the PR up next time.
+
+    Also reconciles untracked `repair-claimed` labels (label present on GitHub
+    but no local history entry) and stale-by-time claims where the PID cannot
+    be resolved. Stale threshold defaults to 2× `repair.stuck_ci_minutes`.
+
+    Fail-closed: any gh / parsing error on a specific PR skips it.
+    """
+    repo = _get_repo()
+    cwd = str(PROJECT_DIR)
+    stuck_minutes = cfg_get(config, "repair", "stuck_ci_minutes", default=120)
+    stale_seconds = int(stuck_minutes) * 60 * 2
+
+    # 1. Find all open PRs carrying repair-claimed.
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "list", "--repo", repo, "--state", "open",
+             "--label", "repair-claimed", "--limit", "100",
+             "--json", "number"],
+            capture_output=True, text=True, timeout=30, cwd=cwd,
+        )
+        if r.returncode != 0:
+            return
+        labelled = {pr["number"] for pr in json.loads(r.stdout)}
+    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+        return
+
+    history = load_pr_claim_history()
+    agents = read_all_agents()
+    live_uuids = {a.uuid for a in agents if a.status not in ("dead", "stopped", "killed")}
+
+    now_epoch = time.time()
+    to_release: list[tuple[int, str]] = []  # (pr_num, reason)
+
+    # 2. Labelled PRs: check live-session liveness via history + agent state.
+    for pr_num in labelled:
+        entry = history.get(str(pr_num))
+        if not entry:
+            # Untracked: no local history. Release if no live agent is
+            # actively working on this PR (best-effort: we can't match agent
+            # to PR without pr_number in AgentState, so just release
+            # after a grace window). For safety, require the label to be
+            # older than the stale_seconds threshold — which we don't have
+            # without a claim comment, so just release immediately. The
+            # coordination script only adds the label via claim-pr-repair,
+            # which always writes history, so untracked label ⇒ leak.
+            to_release.append((pr_num, "untracked: no local claim history"))
+            continue
+
+        owner_uuid = entry.get("session_uuid", "")
+        if owner_uuid in live_uuids:
+            continue  # Still being worked on
+
+        claimed_at = entry.get("claimed_at", 0)
+        age = now_epoch - claimed_at if claimed_at else stale_seconds + 1
+        if age < 300:  # 5 minute grace window for races
+            continue
+        to_release.append((pr_num, f"owner {owner_uuid[:8]} no longer live (age {int(age)}s)"))
+
+    # 3. Issue the releases.
+    released = 0
+    for pr_num, reason in to_release:
+        try:
+            r = subprocess.run(
+                ["gh", "pr", "edit", str(pr_num), "--repo", repo,
+                 "--remove-label", "repair-claimed"],
+                capture_output=True, timeout=30, cwd=cwd,
+            )
+            if r.returncode != 0:
+                continue
+            subprocess.run(
+                ["gh", "pr", "comment", str(pr_num), "--repo", repo,
+                 "--body", f"Repair claim released by reconciler: {reason}."],
+                capture_output=True, timeout=30, cwd=cwd,
+            )
+            clear_pr_claim(pr_num)
+            released += 1
+            log(f"check_dead_pr_claimed_prs: released repair claim on PR #{pr_num} ({reason})")
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+
+    # 4. Clean history entries for PRs that no longer have the label
+    #    (claim was cleared by claim-pr-repair itself, or the PR merged/closed).
+    stale_history_keys = [
+        k for k in history
+        if int(k) not in labelled and (now_epoch - history[k].get("claimed_at", 0)) > 60
+    ]
+    if stale_history_keys:
+        with _claim_history_filelock():
+            h = load_pr_claim_history()
+            for k in stale_history_keys:
+                h.pop(k, None)
+            _save_pr_claim_history(h)
+
+    if released:
+        log(f"check_dead_pr_claimed_prs: released {released} stale repair claim(s)")
 
 
 # ---------------------------------------------------------------------------
@@ -2941,6 +3172,10 @@ def agent_process_main(config: dict, agent_id: str | None = None,
             except Exception:
                 pass
             try:
+                check_dead_pr_claimed_prs(config)
+            except Exception:
+                pass
+            try:
                 cleanup_stale_worktrees(config, verbose=True)
             except Exception:
                 pass
@@ -3390,6 +3625,10 @@ def _tui_main(stdscr, config: dict):
     blocked_deps_fetch_time = 0.0
     cached_lock_status: str | None = None  # "locked" or "unlocked"
     lock_fetch_time = 0.0
+    cached_repair_candidates: int = 0
+    repair_candidates_fetch_time = 0.0
+    # Whether the repair worker type is configured (avoid recomputing each tick).
+    repair_configured = "repair" in cfg_get(config, "worker_types", default={})
     # Check for pre-existing return-to-human signal synchronously at startup.
     # If it was already set before this TUI session, we honour it (target=0, banner)
     # but do NOT send SIGUSR1 — the human restarted pod intentionally.
@@ -3409,7 +3648,7 @@ def _tui_main(stdscr, config: dict):
     # Background fetch infrastructure: all GH/coordination calls run in daemon
     # threads so the TUI never blocks on network I/O.
     _bg_data: dict = {"queue": None, "items": None, "blocked_deps": None, "lock_status": None,
-                      "return_to_human": None}
+                      "return_to_human": None, "repair_candidates": None}
     _bg_active: set = set()
     _bg_mutex = threading.Lock()
 
@@ -3498,6 +3737,12 @@ def _tui_main(stdscr, config: dict):
         if not _acted_on_return_to_human and now - return_to_human_fetch_time > CACHE_SECS:
             _bg_fetch("return_to_human", get_return_to_human, config)
             return_to_human_fetch_time = now
+        # Repair candidates: count of PRs needing repair. Used by the
+        # auto-spawn override to expand `desired` beyond `target` when
+        # unhealthy PRs are present.
+        if repair_configured and now - repair_candidates_fetch_time > CACHE_SECS_SLOW:
+            _bg_fetch("repair_candidates", _list_pr_repair_count, config)
+            repair_candidates_fetch_time = now
         # Lock status: check agent state first (cheap), fall back to background API
         if now - lock_fetch_time > CACHE_SECS_SLOW:
             lock_fetch_time = now
@@ -3520,6 +3765,8 @@ def _tui_main(stdscr, config: dict):
                 cached_lock_status = _bg_data["lock_status"]
             if _bg_data["return_to_human"] is not None:
                 cached_return_to_human = _bg_data["return_to_human"]
+            if _bg_data["repair_candidates"] is not None:
+                cached_repair_candidates = _bg_data["repair_candidates"]
 
         # React to return-to-human signal: set target=0 and gracefully finish all agents.
         # Only act once per TUI session (idempotent).
@@ -3536,8 +3783,25 @@ def _tui_main(stdscr, config: dict):
             message_time = now
 
         # Auto-spawn agents to maintain target (only if no agents are finishing).
+        # Repair overflow: if there are PR repair candidates with spare
+        # concurrency, expand `desired` beyond `target` so a repair agent can
+        # spawn even when `planner_target` is 0. All spawns go through the
+        # same crash-loop guard below.
         target = get_effective_target()
-        if target is not None and running < target and now - last_auto_spawn_time > 5.0:
+        if target is None:
+            desired = 0
+        else:
+            desired = target
+            if repair_configured:
+                running_repair = _count_running_repair_agents(agents)
+                cap = cfg_get(config, "repair", "concurrency_cap", default=2)
+                repair_overflow = max(
+                    0,
+                    min(cached_repair_candidates - running_repair, cap - running_repair),
+                )
+                if repair_overflow > 0:
+                    desired = max(desired, running + repair_overflow)
+        if target is not None and running < desired and now - last_auto_spawn_time > 5.0:
             finishing_count = sum(1 for a in agents if a.status == "finishing")
             if finishing_count == 0:
                 if auto_spawn_paused:
@@ -3554,7 +3818,7 @@ def _tui_main(stdscr, config: dict):
                             "Pausing auto-spawn. Press 'a' to retry.")
                         auto_spawn_paused = True
                     else:
-                        n_to_spawn = target - running
+                        n_to_spawn = desired - running
                         for _ in range(n_to_spawn):
                             spawn_agent(config)
                         last_auto_spawn_time = now
@@ -4313,6 +4577,8 @@ REQUIRED_LABELS = {
     "replan": "D93F0B",
     "coordination": "0E8A16",
     "critical-path": "E11D48",
+    "repair-claimed": "7057FF",   # PR is claimed by a repair agent
+    "unsalvageable": "5C5C5C",    # PR closed by a repair agent as unsalvageable
 }
 
 

--- a/pod/data/agent-config/claude/CLAUDE.md
+++ b/pod/data/agent-config/claude/CLAUDE.md
@@ -16,9 +16,14 @@ Session UUID is available as `$POD_SESSION_ID`.
 - **Planners** (`/plan`): create work items as GitHub issues, then exit
 - **Workers** (`/feature`, `/review`, `/summarize`, `/meditate`): claim
   and execute issues using the `agent-worker-flow` skill
+- **Repair** (`/repair`): salvage unhealthy PRs (merge conflicts, failed
+  CI, stuck CI) using the `pr-repair-flow` skill. Dispatched by pod ahead
+  of planners and workers whenever `coordination list-pr-repair` reports
+  candidates. Two outcomes only: salvaged or abandoned (→ `replan` on the
+  linked issue). No escalation to humans.
 
-See your `/command` file and the `agent-worker-flow` skill for the full
-workflow.
+See your `/command` file and the relevant skill (`agent-worker-flow` or
+`pr-repair-flow`) for the full workflow.
 
 ## Off-limits Files
 

--- a/pod/data/agent-config/claude/commands/repair.md
+++ b/pod/data/agent-config/claude/commands/repair.md
@@ -1,0 +1,49 @@
+# Repair a Pull Request
+
+You are a **repair** session. Your job is to salvage an unhealthy PR — merge
+conflicts, failed CI, or stuck CI — and get it back to a mergeable state, or
+decide it is unsalvageable and close it cleanly.
+
+**First, read the `pr-repair-flow` skill.** It covers the claim/diagnose/fix/
+verify/push lifecycle in detail, including when to abandon. This command
+only covers what is specific to starting a repair session.
+
+## Pick a PR
+
+```
+coordination list-pr-repair
+```
+
+Output is one PR per line in priority order (`conflict` > `failed` > `stuck`).
+Claim the top one:
+
+```
+coordination claim-pr-repair <pr-number>
+```
+
+If the claim output says the PR was claimed by another session in the last
+30 minutes, skip it and try the next one. If every candidate is claimed,
+exit — a fresh dispatch will handle the work later.
+
+## Two Outcomes, No Escalation
+
+Repair has exactly two terminal states:
+
+1. **Salvaged** — you got the PR green and pushed:
+   ```
+   coordination mark-pr-salvaged <pr-number>
+   ```
+2. **Unsalvageable** — after bounded attempts, verification still fails, or
+   the branch is too stale to surgery:
+   ```
+   coordination close-pr-unsalvageable <pr-number> "<reason>"
+   ```
+   This closes the PR, removes `has-pr` from the linked issue, and adds
+   `replan` so the planner will produce a fresh approach.
+
+**Do not escalate to `human-oversight`.** The fix-or-abandon rule is
+non-negotiable: complex conflicts become re-implementations via `replan`,
+not human tickets.
+
+See the `pr-repair-flow` skill for retry budget, verification rules, and
+examples.

--- a/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
@@ -74,13 +74,15 @@ coordination orient
    comment explaining a genuine technical blocker (e.g. a missing dependency), then
    using `coordination skip` with that reason. Do not `skip` because you think a
    different approach is better — that is the owner's call, not yours.
-1. **PRs needing attention**: merge conflicts or failing CI. Check if any
-   unclaimed issue references that PR (title containing "rebase PR #N" or "fix PR #N").
-   Claim that first — unblocking broken PRs beats starting new work.
-2. **Oldest unclaimed issue** of your type:
+1. **Oldest unclaimed issue** of your type:
    ```
    coordination list-unclaimed --label <your-label>
    ```
+
+**Don't repair PRs from a worker session.** PR health (merge conflicts,
+failed CI, stuck CI) is the `repair` agent's responsibility; pod dispatches
+`/repair` automatically when `coordination list-pr-repair` reports
+candidates, ahead of `/plan` / `/work`. Focus on fresh issue work.
 
 If the queue is empty, write a brief progress note and exit.
 

--- a/pod/data/agent-config/claude/skills/pr-repair-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/pr-repair-flow/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: pr-repair-flow
+description: Standard PR-repair workflow for pod `repair` agent sessions. Covers claim/diagnose/fix/verify/push lifecycle and the fix-or-abandon principle.
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write
+---
+
+# PR Repair Flow for Pod Repair Agents
+
+This skill covers the workflow used by `/repair` sessions. Repair agents
+work on PRs, not on feature issues. Their job is to salvage unhealthy PRs
+(merge conflicts, failed CI, stuck CI) or close them cleanly when salvage
+is not worth doing.
+
+## Core Principle: Fix or Abandon
+
+Repair sessions have exactly two terminal outcomes:
+
+1. **Salvaged** — you pushed a green PR and called `coordination mark-pr-salvaged`.
+2. **Abandoned** — you called `coordination close-pr-unsalvageable` after a
+   bounded number of failed attempts. This removes `has-pr` from the linked
+   issue and adds `replan`, so a fresh plan can be produced.
+
+**There is no escalation to `human-oversight`.** Complex conflicts become
+re-implementations via `replan`, not human tickets. If verification keeps
+failing, abandon.
+
+## Coordination Commands
+
+| Command | Purpose |
+|---|---|
+| `coordination list-pr-repair` | Read-only list of PRs needing repair, priority-ordered (`conflict` > `failed` > `stuck`). No label writes. |
+| `coordination claim-pr-repair N` | Adds `repair-claimed` label + comment; 30 min cooldown. Fails if already claimed. |
+| `coordination mark-pr-salvaged N` | Clears `repair-claimed`, comments salvage summary. Call after a successful push. |
+| `coordination close-pr-unsalvageable N "reason"` | Closes PR, adds `unsalvageable`, removes `has-pr` on linked issue, adds `replan`. |
+
+PR repair claims live in a namespace distinct from issue claims. Pod's
+housekeeping loop runs `check_dead_pr_claimed_prs` every 10 minutes to
+release claims whose owning session has died.
+
+## Step 1: Claim a PR
+
+```
+coordination list-pr-repair
+```
+
+Pick the top line (priority order is conflict > failed > stuck). Parse the
+PR number out of `#<num> [<reason>] <title>` and claim it:
+
+```
+coordination claim-pr-repair <pr-number>
+```
+
+If the claim output says the PR was claimed by another session in the last
+30 minutes, move to the next candidate. If all candidates are claimed,
+exit — another dispatch will handle the work later.
+
+## Step 2: Check Out the PR Branch
+
+```bash
+gh pr checkout <pr-number>
+```
+
+Do **not** create a new branch. You are working on the existing PR's head
+branch. The PR will be updated by force-push when you're done.
+
+## Step 3: Diagnose
+
+Look at one thing at a time, in this order:
+
+1. `gh pr view <N> --json mergeable,statusCheckRollup,headRefName,baseRefName`
+2. If `mergeable == "CONFLICTING"`: `git fetch origin && git merge origin/<base>`
+   (or rebase) to surface the conflicting files.
+3. If any check conclusion is `FAILURE`: `gh pr checks <N>` then read the
+   failing job's log via `gh run view --log-failed`.
+4. If "stuck": the CI suite has been running past the configured threshold.
+   Usually this means a worker is hung or a runner was lost. Re-running
+   from a fresh commit (`git commit --allow-empty -m "kick CI"`) is a
+   reasonable first fix.
+
+## Step 4: Apply the Minimal Fix
+
+- **Merge conflicts**: resolve and commit. Prefer the cleaner of `merge` or
+  `rebase` — both produce the same end state but `merge` preserves the
+  original commits and is less fiddly if history is messy.
+- **Failing CI**: make the smallest change that makes the test pass. Do
+  **not** expand scope to refactoring or unrelated cleanup — that belongs
+  in separate issues.
+- **Stuck CI**: empty commit to trigger a re-run is usually enough. If it
+  sticks again, that's a signal to abandon.
+
+## Step 5: Verify
+
+Run the project's own verification — the same build/test flow a `/feature`
+session would run before opening a PR. See the project's top-level
+`CLAUDE.md` for the exact commands.
+
+**Verification is the arbiter.** Do not push until it passes locally.
+
+## Step 6: Push or Abandon
+
+**If verification passes:**
+```bash
+git push --force-with-lease
+coordination mark-pr-salvaged <pr-number>
+```
+Auto-merge (already set by `coordination create-pr`) will squash-merge the
+PR once the remote CI reports green. Exit the session.
+
+**If verification fails after at most 3 fix → verify cycles:**
+```
+coordination close-pr-unsalvageable <pr-number> "<reason>"
+```
+Valid reasons to abandon:
+- verification keeps failing despite targeted fixes
+- the branch is so stale that redoing the work is cheaper than conflict surgery
+- the implementation direction is wrong or has been superseded by other merged work
+- CI repair would require effectively reimplementing the feature from scratch
+
+Be specific in the reason — it goes on the closing comment and on the
+linked issue, and a future planner will read it when producing a replan.
+
+## Step 7: Exit
+
+Don't poll CI. Don't wait for auto-merge. The session ends once you've
+either marked salvaged or closed unsalvageable.
+
+## Labels You'll See
+
+- `repair-claimed` — set by `claim-pr-repair`, cleared by `mark-pr-salvaged`
+  / `close-pr-unsalvageable`, or by the housekeeping reconciler if the
+  claiming session dies.
+- `unsalvageable` — set by `close-pr-unsalvageable` on the PR for
+  observability. Not functional.
+
+There is intentionally no `needs-repair` label. Repair candidates are
+computed on demand by `list-pr-repair`; a label would drift out of sync.
+
+## What You Will Not Do
+
+- Open new issues (except as part of a `replan` comment if genuinely
+  helpful context).
+- Escalate to `human-oversight`.
+- Keep trying the same fix with minor variations past the 3-cycle budget.
+- Fight healthy in-progress CI (the stuck threshold already filters for
+  checks past the configured age).
+- Modify the project's top-level `.claude/CLAUDE.md` or roadmap files.

--- a/pod/data/agent-config/codex/AGENTS.md
+++ b/pod/data/agent-config/codex/AGENTS.md
@@ -15,8 +15,12 @@ Session UUID is available as `$POD_SESSION_ID`.
 
 - **Planners**: create work items as GitHub issues, then exit
 - **Workers**: claim and execute issues using the `agent-worker-flow` skill
+- **Repair**: salvage unhealthy PRs (merge conflicts, failed CI, stuck CI).
+  Two outcomes only: salvaged or abandoned via
+  `coordination close-pr-unsalvageable`. No escalation to humans.
 
-See the `agent-worker-flow` skill for the full workflow.
+See the `agent-worker-flow` skill (for workers) or the `/repair` command
+(for repair sessions) for the full workflow.
 
 ## Off-limits Files
 

--- a/pod/data/agent-config/codex/commands/repair.md
+++ b/pod/data/agent-config/codex/commands/repair.md
@@ -1,0 +1,39 @@
+# Repair a Pull Request
+
+You are a **repair** session. Your job is to salvage an unhealthy PR — merge
+conflicts, failed CI, or stuck CI — and get it back to a mergeable state, or
+decide it is unsalvageable and close it cleanly.
+
+## Pick a PR
+
+Run `coordination list-pr-repair`. Output is one PR per line in priority
+order: `conflict` > `failed` > `stuck`. Claim the top one with
+`coordination claim-pr-repair <pr-number>`.
+
+If every candidate is already claimed by another session in the last
+30 minutes, exit — a fresh dispatch will handle the work later.
+
+## Diagnose and Fix
+
+1. Check out the PR branch locally.
+2. Diagnose: merge conflict against base, failing check logs, stuck check.
+3. Apply the minimal fix:
+   - rebase / merge base and resolve conflicts
+   - targeted CI fix
+   - do **not** expand scope to unrelated cleanup
+4. Run the project's verification (same checks a `/feature` session runs).
+5. If verification passes: `git push --force-with-lease`, then
+   `coordination mark-pr-salvaged <pr-number>`, then exit.
+
+## Retry Budget
+
+You get at most 3 fix → verify cycles. Do not keep trying variations past
+that limit. Do not escalate to `human-oversight`. If verification keeps
+failing, abandon: `coordination close-pr-unsalvageable <pr-number> "<reason>"`.
+That closes the PR and marks the linked issue `replan`, so the planner will
+produce a fresh approach.
+
+## The Fix-or-Abandon Rule
+
+Exactly two terminal states: *salvaged* or *abandoned*. No human tickets.
+Complex conflicts become re-implementations via `replan`, not escalations.

--- a/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
@@ -74,13 +74,15 @@ coordination orient
    comment explaining a genuine technical blocker (e.g. a missing dependency), then
    using `coordination skip` with that reason. Do not `skip` because you think a
    different approach is better — that is the owner's call, not yours.
-1. **PRs needing attention**: merge conflicts or failing CI. Check if any
-   unclaimed issue references that PR (title containing "rebase PR #N" or "fix PR #N").
-   Claim that first — unblocking broken PRs beats starting new work.
-2. **Oldest unclaimed issue** of your type:
+1. **Oldest unclaimed issue** of your type:
    ```
    coordination list-unclaimed --label <your-label>
    ```
+
+**Don't repair PRs from a worker session.** PR health (merge conflicts,
+failed CI, stuck CI) is the `repair` agent's responsibility; pod dispatches
+`/repair` automatically when `coordination list-pr-repair` reports
+candidates, ahead of `/plan` / `/work`. Focus on fresh issue work.
 
 If the queue is empty, write a brief progress note and exit.
 

--- a/pod/data/agent-config/codex/skills/pr-repair-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/pr-repair-flow/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: pr-repair-flow
+description: Standard PR-repair workflow for pod `repair` agent sessions. Covers claim/diagnose/fix/verify/push lifecycle and the fix-or-abandon principle.
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write
+---
+
+# PR Repair Flow for Pod Repair Agents
+
+This skill covers the workflow used by `/repair` sessions. Repair agents
+work on PRs, not on feature issues. Their job is to salvage unhealthy PRs
+(merge conflicts, failed CI, stuck CI) or close them cleanly when salvage
+is not worth doing.
+
+## Core Principle: Fix or Abandon
+
+Repair sessions have exactly two terminal outcomes:
+
+1. **Salvaged** — you pushed a green PR and called `coordination mark-pr-salvaged`.
+2. **Abandoned** — you called `coordination close-pr-unsalvageable` after a
+   bounded number of failed attempts. This removes `has-pr` from the linked
+   issue and adds `replan`, so a fresh plan can be produced.
+
+**There is no escalation to `human-oversight`.** Complex conflicts become
+re-implementations via `replan`, not human tickets. If verification keeps
+failing, abandon.
+
+## Coordination Commands
+
+| Command | Purpose |
+|---|---|
+| `coordination list-pr-repair` | Read-only list of PRs needing repair, priority-ordered (`conflict` > `failed` > `stuck`). No label writes. |
+| `coordination claim-pr-repair N` | Adds `repair-claimed` label + comment; 30 min cooldown. Fails if already claimed. |
+| `coordination mark-pr-salvaged N` | Clears `repair-claimed`, comments salvage summary. Call after a successful push. |
+| `coordination close-pr-unsalvageable N "reason"` | Closes PR, adds `unsalvageable`, removes `has-pr` on linked issue, adds `replan`. |
+
+PR repair claims live in a namespace distinct from issue claims. Pod's
+housekeeping loop runs `check_dead_pr_claimed_prs` every 10 minutes to
+release claims whose owning session has died.
+
+## Step 1: Claim a PR
+
+```
+coordination list-pr-repair
+```
+
+Pick the top line (priority order is conflict > failed > stuck). Parse the
+PR number out of `#<num> [<reason>] <title>` and claim it:
+
+```
+coordination claim-pr-repair <pr-number>
+```
+
+If the claim output says the PR was claimed by another session in the last
+30 minutes, move to the next candidate. If all candidates are claimed,
+exit — another dispatch will handle the work later.
+
+## Step 2: Check Out the PR Branch
+
+```bash
+gh pr checkout <pr-number>
+```
+
+Do **not** create a new branch. You are working on the existing PR's head
+branch. The PR will be updated by force-push when you're done.
+
+## Step 3: Diagnose
+
+Look at one thing at a time, in this order:
+
+1. `gh pr view <N> --json mergeable,statusCheckRollup,headRefName,baseRefName`
+2. If `mergeable == "CONFLICTING"`: `git fetch origin && git merge origin/<base>`
+   (or rebase) to surface the conflicting files.
+3. If any check conclusion is `FAILURE`: `gh pr checks <N>` then read the
+   failing job's log via `gh run view --log-failed`.
+4. If "stuck": the CI suite has been running past the configured threshold.
+   Usually this means a worker is hung or a runner was lost. Re-running
+   from a fresh commit (`git commit --allow-empty -m "kick CI"`) is a
+   reasonable first fix.
+
+## Step 4: Apply the Minimal Fix
+
+- **Merge conflicts**: resolve and commit. Prefer the cleaner of `merge` or
+  `rebase` — both produce the same end state but `merge` preserves the
+  original commits and is less fiddly if history is messy.
+- **Failing CI**: make the smallest change that makes the test pass. Do
+  **not** expand scope to refactoring or unrelated cleanup — that belongs
+  in separate issues.
+- **Stuck CI**: empty commit to trigger a re-run is usually enough. If it
+  sticks again, that's a signal to abandon.
+
+## Step 5: Verify
+
+Run the project's own verification — the same build/test flow a `/feature`
+session would run before opening a PR. See the project's top-level
+`CLAUDE.md` for the exact commands.
+
+**Verification is the arbiter.** Do not push until it passes locally.
+
+## Step 6: Push or Abandon
+
+**If verification passes:**
+```bash
+git push --force-with-lease
+coordination mark-pr-salvaged <pr-number>
+```
+Auto-merge (already set by `coordination create-pr`) will squash-merge the
+PR once the remote CI reports green. Exit the session.
+
+**If verification fails after at most 3 fix → verify cycles:**
+```
+coordination close-pr-unsalvageable <pr-number> "<reason>"
+```
+Valid reasons to abandon:
+- verification keeps failing despite targeted fixes
+- the branch is so stale that redoing the work is cheaper than conflict surgery
+- the implementation direction is wrong or has been superseded by other merged work
+- CI repair would require effectively reimplementing the feature from scratch
+
+Be specific in the reason — it goes on the closing comment and on the
+linked issue, and a future planner will read it when producing a replan.
+
+## Step 7: Exit
+
+Don't poll CI. Don't wait for auto-merge. The session ends once you've
+either marked salvaged or closed unsalvageable.
+
+## Labels You'll See
+
+- `repair-claimed` — set by `claim-pr-repair`, cleared by `mark-pr-salvaged`
+  / `close-pr-unsalvageable`, or by the housekeeping reconciler if the
+  claiming session dies.
+- `unsalvageable` — set by `close-pr-unsalvageable` on the PR for
+  observability. Not functional.
+
+There is intentionally no `needs-repair` label. Repair candidates are
+computed on demand by `list-pr-repair`; a label would drift out of sync.
+
+## What You Will Not Do
+
+- Open new issues (except as part of a `replan` comment if genuinely
+  helpful context).
+- Escalate to `human-oversight`.
+- Keep trying the same fix with minor variations past the 3-cycle budget.
+- Fight healthy in-progress CI (the stuck threshold already filters for
+  checks past the configured age).
+- Modify the project's top-level `.claude/CLAUDE.md` or roadmap files.

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -10,6 +10,11 @@
 #   coordination create-pr N [--partial] ["title"] — push branch, create PR closing issue #N, enable auto-merge; rejects PRs touching protected files
 #   coordination claim-fix N                  — comment on failing PR #N claiming fix (30min cooldown)
 #   coordination close-pr N "reason"          — comment reason and close PR #N
+#   coordination list-pr-repair               — read-only: list PRs needing repair (conflict | failed CI | stuck CI)
+#   coordination claim-pr-repair N            — claim PR #N for repair (repair-claimed label + comment, 30min cooldown)
+#   coordination mark-pr-salvaged N           — clear repair-claimed on PR #N after a successful push
+#   coordination close-pr-unsalvageable N "reason"
+#                                              — close PR #N, mark linked issue replan (removes has-pr)
 #   coordination list-unclaimed [--label L]   — list unclaimed agent-plan issues (FIFO order); optional label filter
 #   coordination queue-depth [L]              — count of unclaimed agent-plan issues; optional label filter
 #   coordination critical-path-depth          — count of unclaimed critical-path issues
@@ -132,7 +137,7 @@ _ensure_labels() {
     local existing
     existing="$(gh label list --repo "$REPO" --limit 100 --json name --jq '.[].name')"
     local label color
-    for pair in agent-plan:1D76DB claimed:FBCA04 blocked:B60205 has-pr:5319E7 replan:D93F0B coordination:0E8A16 human-oversight:CC317C return-to-human:E4A400 critical-path:FF6600; do
+    for pair in agent-plan:1D76DB claimed:FBCA04 blocked:B60205 has-pr:5319E7 replan:D93F0B coordination:0E8A16 human-oversight:CC317C return-to-human:E4A400 critical-path:FF6600 repair-claimed:7057FF unsalvageable:5C5C5C; do
         label="${pair%%:*}"
         color="${pair##*:}"
         if ! echo "$existing" | grep -qx "$label"; then
@@ -460,6 +465,161 @@ cmd_close_pr() {
         grep -oE 'Closes #[0-9]+' | grep -oE '[0-9]+' | head -1)"
     if [[ -n "$linked_issue" ]]; then
         gh issue edit "$linked_issue" --repo "$REPO" --remove-label has-pr 2>/dev/null || true
+    fi
+}
+
+# --- PR repair ------------------------------------------------------------
+#
+# Repair commands operate on PRs (not issues) and use a claim namespace
+# distinct from issue `claimed`. See plans/repair-agent-type.md for the
+# overall design. The stuck-CI threshold is read from POD_STUCK_CI_MINUTES
+# (set by `pod` from `[repair].stuck_ci_minutes`, default 120).
+
+# --- list-pr-repair ---
+# Read-only enumerator of open PRs that need repair, in priority order:
+#   conflict → failed CI → stuck CI
+# Output: one PR per line as `#<num> [<reason>] <title>`.
+# Does NOT mutate any labels. Callers (claim-pr-repair / mark-pr-salvaged /
+# close-pr-unsalvageable) are responsible for any label writes.
+cmd_list_pr_repair() {
+    local stuck_minutes="${POD_STUCK_CI_MINUTES:-120}"
+    local stuck_seconds=$(( stuck_minutes * 60 ))
+    local now
+    now="$(date -u +%s)"
+
+    # One cheap list pass: mergeable + statusCheckRollup (without per-check
+    # ages). We'll fetch per-PR check ages only for PRs that already look
+    # suspect from this pass.
+    local prs_json
+    prs_json="$(gh pr list --repo "$REPO" --state open --limit 50 \
+        --json number,title,mergeable,statusCheckRollup,labels)"
+
+    # Conflicts (mergeable == CONFLICTING)
+    echo "$prs_json" | jq -r --arg reason conflict '
+        [.[] | select(.mergeable == "CONFLICTING")
+             | select((.labels // []) | all(.name != "repair-claimed"))]
+        | sort_by(.number)
+        | .[]
+        | "#\(.number) [\($reason)] \(.title)"
+    '
+
+    # Failed CI (any statusCheckRollup conclusion == FAILURE)
+    echo "$prs_json" | jq -r --arg reason failed '
+        [.[] | select(.mergeable != "CONFLICTING")
+             | select((.statusCheckRollup // []) | any(.conclusion == "FAILURE"))
+             | select((.labels // []) | all(.name != "repair-claimed"))]
+        | sort_by(.number)
+        | .[]
+        | "#\(.number) [\($reason)] \(.title)"
+    '
+
+    # Stuck CI: any IN_PROGRESS check older than stuck_seconds.
+    # Only considered for PRs that are otherwise healthy (not conflicting,
+    # no failed checks already).
+    local suspect_prs
+    suspect_prs="$(echo "$prs_json" | jq -r '
+        [.[] | select(.mergeable != "CONFLICTING")
+             | select((.statusCheckRollup // []) | all(.conclusion != "FAILURE"))
+             | select((.statusCheckRollup // []) | any(.status == "IN_PROGRESS"))
+             | select((.labels // []) | all(.name != "repair-claimed"))
+             | {number, title}]
+        | .[] | "\(.number)\t\(.title)"
+    ')"
+
+    if [[ -n "$suspect_prs" ]]; then
+        while IFS=$'\t' read -r pr_num pr_title; do
+            [[ -z "$pr_num" ]] && continue
+            # GraphQL for CheckRun.startedAt — it's the only rollup variant
+            # with a reliable start timestamp. StatusContext entries don't
+            # carry one; we treat them as not-stuck.
+            local started_json
+            started_json="$(gh api graphql \
+                -f query='query($owner:String!,$name:String!,$pr:Int!){
+                    repository(owner:$owner,name:$name){
+                        pullRequest(number:$pr){
+                            commits(last:1){nodes{commit{
+                                checkSuites(first:20){nodes{
+                                    checkRuns(first:50){nodes{status conclusion startedAt}}
+                                }}
+                            }}}
+                        }
+                    }
+                }' \
+                -F owner="${REPO%%/*}" -F name="${REPO##*/}" -F pr="$pr_num" \
+                --jq '[.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes[].checkRuns.nodes[]
+                       | select(.status == "IN_PROGRESS" and .startedAt != null)
+                       | .startedAt]' 2>/dev/null || echo "[]")"
+            local is_stuck
+            is_stuck="$(echo "$started_json" | jq -r --argjson now "$now" --argjson threshold "$stuck_seconds" '
+                any(. as $s | ($now - ($s | fromdateiso8601)) > $threshold)
+            ' 2>/dev/null || echo false)"
+            if [[ "$is_stuck" == "true" ]]; then
+                echo "#$pr_num [stuck] $pr_title"
+            fi
+        done <<< "$suspect_prs"
+    fi
+}
+
+# --- claim-pr-repair ---
+# Claim a PR for repair work. Comment + repair-claimed label; 30min cooldown
+# guard against another repair agent stomping in immediately.
+cmd_claim_pr_repair() {
+    local pr_num="${1:?usage: coordination claim-pr-repair N}"
+
+    # Cooldown: refuse if another session claimed this PR for repair in the last 30min
+    local recent_claim
+    recent_claim="$(gh api --paginate "repos/$REPO/issues/$pr_num/comments" \
+        --jq '[.[] | select(.body | test("Claimed PR repair by session")) |
+               select(.created_at > (now - 1800 | strftime("%Y-%m-%dT%H:%M:%SZ")))] |
+               length')"
+    if [[ "$recent_claim" -gt 0 ]]; then
+        echo "Another session claimed this PR for repair in the last 30 minutes. Skipping."
+        return 1
+    fi
+
+    # Add label BEFORE comment so `list-pr-repair` stops offering it promptly
+    gh pr edit "$pr_num" --repo "$REPO" --add-label repair-claimed 2>/dev/null || true
+    gh issue comment "$pr_num" --repo "$REPO" \
+        --body "Claimed PR repair by session \`$SESSION_ID\` on branch \`$BRANCH\`"
+}
+
+# --- mark-pr-salvaged ---
+# Clear the repair claim after a successful push. Does not close the PR —
+# auto-merge handles that once CI passes.
+cmd_mark_pr_salvaged() {
+    local pr_num="${1:?usage: coordination mark-pr-salvaged N}"
+    gh pr edit "$pr_num" --repo "$REPO" --remove-label repair-claimed 2>/dev/null || true
+    gh issue comment "$pr_num" --repo "$REPO" \
+        --body "Repair complete (session \`$SESSION_ID\`). Verification passed; pushed."
+}
+
+# --- close-pr-unsalvageable ---
+# Close PR with reason, remove has-pr from linked issue, add replan.
+# Clears the repair-claimed label and adds `unsalvageable` for observability.
+cmd_close_pr_unsalvageable() {
+    local pr_num="${1:?usage: coordination close-pr-unsalvageable N \"reason\"}"
+    local reason="${2:?usage: coordination close-pr-unsalvageable N \"reason\"}"
+
+    # Close with the reason as the closing comment
+    gh pr close "$pr_num" --repo "$REPO" \
+        --comment "Closing as unsalvageable: $reason (Session: \`$SESSION_ID\`)"
+
+    gh pr edit "$pr_num" --repo "$REPO" --add-label unsalvageable 2>/dev/null || true
+    gh pr edit "$pr_num" --repo "$REPO" --remove-label repair-claimed 2>/dev/null || true
+
+    # Restore linked issue to the planning queue. Add replan BEFORE removing
+    # has-pr so the issue is always labelled as something meaningful.
+    local linked_issue
+    linked_issue="$(gh pr view "$pr_num" --repo "$REPO" --json body --jq '.body' | \
+        grep -oE 'Closes #[0-9]+' | grep -oE '[0-9]+' | head -1)"
+    if [[ -n "$linked_issue" ]]; then
+        gh issue edit "$linked_issue" --repo "$REPO" --add-label replan 2>/dev/null || true
+        gh issue edit "$linked_issue" --repo "$REPO" --remove-label has-pr 2>/dev/null || true
+        gh issue comment "$linked_issue" --repo "$REPO" \
+            --body "PR #$pr_num closed as unsalvageable: $reason. Marked replan so a new plan can be produced."
+        echo "PR #$pr_num closed; linked issue #$linked_issue marked replan."
+    else
+        echo "PR #$pr_num closed; no linked issue found in PR body (looked for 'Closes #N')."
     fi
 }
 
@@ -888,6 +1048,10 @@ case "${1:-}" in
     create-pr)       shift; cmd_create_pr "$@" ;;
     claim-fix)       shift; cmd_claim_fix "$@" ;;
     close-pr)        shift; cmd_close_pr "$@" ;;
+    list-pr-repair)           cmd_list_pr_repair ;;
+    claim-pr-repair)          shift; cmd_claim_pr_repair "$@" ;;
+    mark-pr-salvaged)         shift; cmd_mark_pr_salvaged "$@" ;;
+    close-pr-unsalvageable)   shift; cmd_close_pr_unsalvageable "$@" ;;
     list-unclaimed)  shift; cmd_list_unclaimed "$@" ;;
     queue-depth)     shift; cmd_queue_depth "$@" ;;
     critical-path-depth)  shift; cmd_critical_path_depth "$@" ;;
@@ -907,5 +1071,5 @@ case "${1:-}" in
     set-target)          shift; cmd_set_target "$@" ;;
     set-min-queue)       shift; cmd_set_min_queue "$@" ;;
     *)               die "unknown command: ${1:-}
-Usage: coordination {orient|plan [--label L] [--critical-path]|create-pr|claim-fix|close-pr|list-unclaimed [--label L]|queue-depth [L]|critical-path-depth|claim|skip|add-dep|check-blocked|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner|return-to-human|check-return-to-human|clear-return-to-human|nothing-to-plan|set-target|set-min-queue}" ;;
+Usage: coordination {orient|plan [--label L] [--critical-path]|create-pr|claim-fix|close-pr|list-pr-repair|claim-pr-repair|mark-pr-salvaged|close-pr-unsalvageable|list-unclaimed [--label L]|queue-depth [L]|critical-path-depth|claim|skip|add-dep|check-blocked|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner|return-to-human|check-return-to-human|clear-return-to-human|nothing-to-plan|set-target|set-min-queue}" ;;
 esac

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -561,26 +561,62 @@ cmd_list_pr_repair() {
 }
 
 # --- claim-pr-repair ---
-# Claim a PR for repair work. Comment + repair-claimed label; 30min cooldown
-# guard against another repair agent stomping in immediately.
+# Claim a PR for repair work. Atomic: label + comment + race-detect, mirroring
+# cmd_claim's pattern. A 30-min cooldown catches repeat attempts by a different
+# session that hasn't seen the salvage/abandon outcome yet.
 cmd_claim_pr_repair() {
     local pr_num="${1:?usage: coordination claim-pr-repair N}"
 
-    # Cooldown: refuse if another session claimed this PR for repair in the last 30min
+    # Reject PRs already carrying repair-claimed by another session.
+    # (Label + recent comment means a live repair is in progress.)
+    local labels
+    labels="$(gh pr view "$pr_num" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")"
+    if echo "$labels" | grep -qw 'repair-claimed'; then
+        echo "CLAIM FAILED: PR #$pr_num is already repair-claimed."
+        return 1
+    fi
+
+    # Cooldown: refuse if another session claimed this PR for repair in the
+    # last 30 min (successful or not — avoids stampede on a flaky PR).
     local recent_claim
     recent_claim="$(gh api --paginate "repos/$REPO/issues/$pr_num/comments" \
         --jq '[.[] | select(.body | test("Claimed PR repair by session")) |
                select(.created_at > (now - 1800 | strftime("%Y-%m-%dT%H:%M:%SZ")))] |
                length')"
     if [[ "$recent_claim" -gt 0 ]]; then
-        echo "Another session claimed this PR for repair in the last 30 minutes. Skipping."
+        echo "CLAIM FAILED: PR #$pr_num was claimed for repair within the last 30 minutes."
         return 1
     fi
 
-    # Add label BEFORE comment so `list-pr-repair` stops offering it promptly
+    # Add label BEFORE comment so `list-pr-repair` stops offering it promptly.
     gh pr edit "$pr_num" --repo "$REPO" --add-label repair-claimed 2>/dev/null || true
     gh issue comment "$pr_num" --repo "$REPO" \
         --body "Claimed PR repair by session \`$SESSION_ID\` on branch \`$BRANCH\`"
+
+    # Race detection: wait briefly, then check for multiple recent claim
+    # comments. Lowest UUID wins — losers remove the label and exit.
+    sleep 2
+    local recent_claims
+    recent_claims="$(gh api --paginate "repos/$REPO/issues/$pr_num/comments" \
+        --jq '[.[] | select(.body | test("Claimed PR repair by session")) |
+               select(.created_at > (now - 60 | strftime("%Y-%m-%dT%H:%M:%SZ")))] |
+               length')"
+    if [[ "$recent_claims" -gt 1 ]]; then
+        local winner
+        winner="$(gh api --paginate "repos/$REPO/issues/$pr_num/comments" \
+            --jq '[.[] | select(.body | test("Claimed PR repair by session")) |
+                   select(.created_at > (now - 60 | strftime("%Y-%m-%dT%H:%M:%SZ")))] |
+                   sort_by(.body) | .[0].body |
+                   match("session `([^`]+)`") | .captures[0].string')"
+        if [[ "$winner" != "$SESSION_ID" ]]; then
+            echo "CLAIM FAILED: Race lost on PR #$pr_num — another session won."
+            # Don't remove the label — the winner needs it.
+            return 1
+        fi
+        echo "Race detected on PR #$pr_num — this session won."
+    fi
+
+    echo "Claimed PR #$pr_num for repair"
 }
 
 # --- mark-pr-salvaged ---
@@ -600,26 +636,54 @@ cmd_close_pr_unsalvageable() {
     local pr_num="${1:?usage: coordination close-pr-unsalvageable N \"reason\"}"
     local reason="${2:?usage: coordination close-pr-unsalvageable N \"reason\"}"
 
-    # Close with the reason as the closing comment
+    # Resolve linked issues BEFORE closing the PR. GitHub's
+    # `closingIssuesReferences` list handles every close-keyword variant
+    # (Closes/Fixes/Resolves, any case, same-repo and cross-repo), which a
+    # regex on the body does not.
+    local linked_issues
+    linked_issues="$(gh pr view "$pr_num" --repo "$REPO" \
+        --json closingIssuesReferences \
+        --jq '[.closingIssuesReferences[] | select(.number != null) | .number] | .[]' 2>/dev/null || echo "")"
+
+    # Close with the reason as the closing comment.
     gh pr close "$pr_num" --repo "$REPO" \
         --comment "Closing as unsalvageable: $reason (Session: \`$SESSION_ID\`)"
 
     gh pr edit "$pr_num" --repo "$REPO" --add-label unsalvageable 2>/dev/null || true
     gh pr edit "$pr_num" --repo "$REPO" --remove-label repair-claimed 2>/dev/null || true
 
-    # Restore linked issue to the planning queue. Add replan BEFORE removing
-    # has-pr so the issue is always labelled as something meaningful.
-    local linked_issue
-    linked_issue="$(gh pr view "$pr_num" --repo "$REPO" --json body --jq '.body' | \
-        grep -oE 'Closes #[0-9]+' | grep -oE '[0-9]+' | head -1)"
-    if [[ -n "$linked_issue" ]]; then
-        gh issue edit "$linked_issue" --repo "$REPO" --add-label replan 2>/dev/null || true
-        gh issue edit "$linked_issue" --repo "$REPO" --remove-label has-pr 2>/dev/null || true
-        gh issue comment "$linked_issue" --repo "$REPO" \
-            --body "PR #$pr_num closed as unsalvageable: $reason. Marked replan so a new plan can be produced."
-        echo "PR #$pr_num closed; linked issue #$linked_issue marked replan."
+    if [[ -n "$linked_issues" ]]; then
+        local updated=()
+        while IFS= read -r issue_num; do
+            [[ -z "$issue_num" ]] && continue
+            # Add replan BEFORE removing has-pr so the issue is always
+            # carrying a meaningful label.
+            gh issue edit "$issue_num" --repo "$REPO" --add-label replan 2>/dev/null || true
+            gh issue edit "$issue_num" --repo "$REPO" --remove-label has-pr 2>/dev/null || true
+            gh issue comment "$issue_num" --repo "$REPO" \
+                --body "PR #$pr_num closed as unsalvageable: $reason. Marked replan so a new plan can be produced."
+            updated+=("#$issue_num")
+        done <<< "$linked_issues"
+        echo "PR #$pr_num closed; linked issue(s) marked replan: ${updated[*]}"
     else
-        echo "PR #$pr_num closed; no linked issue found in PR body (looked for 'Closes #N')."
+        # Fallback: grep the body for close-keywords if the GraphQL list was
+        # empty (some PRs reference issues in ways GitHub's parser misses).
+        local fallback_issues
+        fallback_issues="$(gh pr view "$pr_num" --repo "$REPO" --json body --jq '.body' \
+            | grep -oiE '(closes|closed|close|fixes|fixed|fix|resolves|resolved|resolve)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' | sort -u)"
+        if [[ -n "$fallback_issues" ]]; then
+            while IFS= read -r issue_num; do
+                [[ -z "$issue_num" ]] && continue
+                gh issue edit "$issue_num" --repo "$REPO" --add-label replan 2>/dev/null || true
+                gh issue edit "$issue_num" --repo "$REPO" --remove-label has-pr 2>/dev/null || true
+                gh issue comment "$issue_num" --repo "$REPO" \
+                    --body "PR #$pr_num closed as unsalvageable: $reason. Marked replan so a new plan can be produced."
+            done <<< "$fallback_issues"
+            echo "PR #$pr_num closed; fallback-resolved issue(s) marked replan: $fallback_issues"
+        else
+            echo "PR #$pr_num closed; no linked issue found (closingIssuesReferences empty, body grep empty)."
+        fi
     fi
 }
 

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -481,17 +481,23 @@ cmd_close_pr() {
 # Output: one PR per line as `#<num> [<reason>] <title>`.
 # Does NOT mutate any labels. Callers (claim-pr-repair / mark-pr-salvaged /
 # close-pr-unsalvageable) are responsible for any label writes.
+#
+# Covers both rollup variants:
+#   - CheckRun       (GitHub Actions etc.)   uses `.status` / `.conclusion` / `.startedAt`
+#   - StatusContext  (external CI via status API)  uses `.state` / `.createdAt`
+# so external-CI PRs aren't silently ignored.
 cmd_list_pr_repair() {
     local stuck_minutes="${POD_STUCK_CI_MINUTES:-120}"
     local stuck_seconds=$(( stuck_minutes * 60 ))
     local now
     now="$(date -u +%s)"
 
-    # One cheap list pass: mergeable + statusCheckRollup (without per-check
-    # ages). We'll fetch per-PR check ages only for PRs that already look
-    # suspect from this pass.
+    # One cheap list pass. `gh pr list` has no `--paginate`, so we bump
+    # `--limit` to a value high enough to cover any reasonable active repo.
+    # For repos with 500+ simultaneously-open PRs, the repair loop would
+    # probably need rethinking anyway.
     local prs_json
-    prs_json="$(gh pr list --repo "$REPO" --state open --limit 50 \
+    prs_json="$(gh pr list --repo "$REPO" --state open --limit 500 \
         --json number,title,mergeable,statusCheckRollup,labels)"
 
     # Conflicts (mergeable == CONFLICTING)
@@ -503,24 +509,32 @@ cmd_list_pr_repair() {
         | "#\(.number) [\($reason)] \(.title)"
     '
 
-    # Failed CI (any statusCheckRollup conclusion == FAILURE)
+    # Failed CI: either a CheckRun with conclusion FAILURE, or a
+    # StatusContext in state FAILURE / ERROR.
     echo "$prs_json" | jq -r --arg reason failed '
         [.[] | select(.mergeable != "CONFLICTING")
-             | select((.statusCheckRollup // []) | any(.conclusion == "FAILURE"))
+             | select(
+                 ((.statusCheckRollup // []) | any(.conclusion == "FAILURE"))
+                 or ((.statusCheckRollup // []) | any(.state == "FAILURE" or .state == "ERROR"))
+               )
              | select((.labels // []) | all(.name != "repair-claimed"))]
         | sort_by(.number)
         | .[]
         | "#\(.number) [\($reason)] \(.title)"
     '
 
-    # Stuck CI: any IN_PROGRESS check older than stuck_seconds.
-    # Only considered for PRs that are otherwise healthy (not conflicting,
-    # no failed checks already).
+    # Stuck CI: any IN_PROGRESS CheckRun or PENDING StatusContext older than
+    # stuck_seconds. Only considered for PRs that aren't already flagged as
+    # conflicting or failed by the cheap pass above.
     local suspect_prs
     suspect_prs="$(echo "$prs_json" | jq -r '
         [.[] | select(.mergeable != "CONFLICTING")
              | select((.statusCheckRollup // []) | all(.conclusion != "FAILURE"))
-             | select((.statusCheckRollup // []) | any(.status == "IN_PROGRESS"))
+             | select((.statusCheckRollup // []) | all(.state != "FAILURE" and .state != "ERROR"))
+             | select(
+                 ((.statusCheckRollup // []) | any(.status == "IN_PROGRESS"))
+                 or ((.statusCheckRollup // []) | any(.state == "PENDING" or .state == "EXPECTED"))
+               )
              | select((.labels // []) | all(.name != "repair-claimed"))
              | {number, title}]
         | .[] | "\(.number)\t\(.title)"
@@ -529,9 +543,11 @@ cmd_list_pr_repair() {
     if [[ -n "$suspect_prs" ]]; then
         while IFS=$'\t' read -r pr_num pr_title; do
             [[ -z "$pr_num" ]] && continue
-            # GraphQL for CheckRun.startedAt — it's the only rollup variant
-            # with a reliable start timestamp. StatusContext entries don't
-            # carry one; we treat them as not-stuck.
+            # GraphQL to get ages for BOTH rollup variants:
+            #  - CheckRun.startedAt (when the run began)
+            #  - StatusContext.createdAt (when the status was last reported)
+            # StatusContext has no "updated" field on the schema; createdAt is
+            # the closest proxy for "this has been pending since ...".
             local started_json
             started_json="$(gh api graphql \
                 -f query='query($owner:String!,$name:String!,$pr:Int!){
@@ -541,14 +557,22 @@ cmd_list_pr_repair() {
                                 checkSuites(first:20){nodes{
                                     checkRuns(first:50){nodes{status conclusion startedAt}}
                                 }}
+                                status{
+                                    contexts{ state createdAt }
+                                }
                             }}}
                         }
                     }
                 }' \
                 -F owner="${REPO%%/*}" -F name="${REPO##*/}" -F pr="$pr_num" \
-                --jq '[.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes[].checkRuns.nodes[]
-                       | select(.status == "IN_PROGRESS" and .startedAt != null)
-                       | .startedAt]' 2>/dev/null || echo "[]")"
+                --jq '[
+                    (.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes[].checkRuns.nodes[]
+                     | select(.status == "IN_PROGRESS" and .startedAt != null)
+                     | .startedAt),
+                    (.data.repository.pullRequest.commits.nodes[0].commit.status.contexts[]?
+                     | select((.state == "PENDING" or .state == "EXPECTED") and .createdAt != null)
+                     | .createdAt)
+                ]' 2>/dev/null || echo "[]")"
             local is_stuck
             is_stuck="$(echo "$started_json" | jq -r --argjson now "$now" --argjson threshold "$stuck_seconds" '
                 any(. as $s | ($now - ($s | fromdateiso8601)) > $threshold)


### PR DESCRIPTION
## Summary

Implements the `repair` agent type from #23. Salvages unhealthy PRs (merge conflicts, failed CI, stuck CI) so the planner stops idling on `target=0` while unhealthy PRs block the queue. Fix-or-abandon — no escalation to humans.

## Design decisions (from the issue, locked before coding)

1. Repair is **PR-native** with a separate claim namespace (`.pod/pr-claim-history.json`, `repair-claimed` label).
2. Stuck CI threshold is **configurable**, default **120 min** (`[repair].stuck_ci_minutes`).
3. Unsalvageable closure always **removes `has-pr`** from the linked issue and **adds `replan`** — no replacement issue.
4. **No escalation.** Two terminal states: salvaged or abandoned (→ `replan`). Complex conflicts become re-implementations via replan.
5. Repair dispatch is **orthogonal to `planner_target`**: short-circuit spawns up to `concurrency_cap` (default 2) repair agents even when the planner says target=0.

## What's in this PR

**Python / pod core** ([pod/cli.py](pod/cli.py)):
- New `[repair]` config section and `[worker_types.repair]` in `DEFAULT_CONFIG`.
- New `repair-claimed` and `unsalvageable` entries in `REQUIRED_LABELS`.
- `_list_pr_repair_count` / `_count_running_repair_agents` helpers.
- Short-circuit at the top of `dispatch_queue_balance` and explicit skip in `_choose_draining` / `_choose_critical_path_draining` so `repair` is never selected when no PR needs it.
- Auto-spawn `desired = max(target, running + repair_overflow)` — preserves existing crash-loop guard; doesn't bypass it.
- PR-claim namespace (`PR_CLAIM_HISTORY_PATH`, `load/record/clear_pr_claim`) and `check_dead_pr_claimed_prs` wired into the housekeeping loop.
- `coordination()` now exports `POD_STUCK_CI_MINUTES` to the script.

**Bash / coordination** ([pod/data/coordination](pod/data/coordination)):
- Four new subcommands: `list-pr-repair` (read-only), `claim-pr-repair`, `mark-pr-salvaged`, `close-pr-unsalvageable`.
- `list-pr-repair` is strictly read-only (no label writes) and uses `gh api graphql` on `CheckRun.startedAt` for stuck-CI detection because `statusCheckRollup` entries don't reliably carry that field.
- `_ensure_labels` extended with `repair-claimed` and `unsalvageable`.

**Agent config**:
- `/repair` slash commands for Claude and Codex.
- `pr-repair-flow/SKILL.md` for both backends (full claim → diagnose → fix → verify → push lifecycle, fix-or-abandon).
- `agent-worker-flow/SKILL.md` updated to note PR health is out of scope for workers.
- `CLAUDE.md` / `AGENTS.md` updated with the new agent type.

## Test plan

- [ ] `pod init` creates the new labels (`repair-claimed`, `unsalvageable`) on a fresh repo.
- [ ] `coordination list-pr-repair` returns zero output on a healthy repo (verified against this repo).
- [ ] Create a conflicting PR → it appears in `list-pr-repair [conflict]`, a repair agent claims and resolves it.
- [ ] Create a PR with a failing required check → repair agent makes targeted fix, pushes, `mark-pr-salvaged` clears the claim.
- [ ] Force a PR where verification keeps failing → repair agent calls `close-pr-unsalvageable`; linked issue loses `has-pr`, gains `replan`.
- [ ] Kill a repair agent mid-run → `check_dead_pr_claimed_prs` releases `repair-claimed` on the next housekeeping tick.
- [ ] `planner_target=0` + one conflicting PR → a repair agent spawns anyway; no other agents spawn.
- [ ] Crash-loop guard still trips if a repair agent dies 3× in a row.
- [ ] Existing `plan` / `work` dispatch unchanged when `list-pr-repair` is empty.

Closes #23.

🤖 Prepared with Claude Code