### PR TITLE
docs(prompts): align planner and worker on worker-led decomposition

### DIFF
--- a/pod/data/agent-config/claude/commands/plan.md
+++ b/pod/data/agent-config/claude/commands/plan.md
@@ -56,10 +56,18 @@ For each, exactly one of:
 - **Work already done** (a subsequent PR merged it): close with a note
 - **Plan stale / approach changed**: create a corrected replacement issue, close original linking forward
 - **Partial progress**: create issue for remaining deliverables, close original linking forward
-- **Worker-decomposed**: the worker already created sub-issues (look for a
-  `Decomposed into #X, #Y` comment). If the sub-issues fully cover the parent,
-  just close it linking forward — do NOT re-create them. If residual scope
-  remains, narrow the body to that residual and remove the `replan` label.
+- **Worker-decomposed**: the worker created sub-issues before releasing
+  the claim. Detect via a comment that starts with `Decomposed into #` and
+  lists the sub-issue numbers (workers must leave this breadcrumb before
+  `coordination skip` or `coordination create-pr --partial`). Read the
+  sub-issues and decide:
+  - sub-issues fully cover the parent → close the parent with a forward
+    link (do NOT re-create the sub-issues);
+  - residual scope remains → narrow the body to that residual and remove
+    the `replan` label so workers can claim it again.
+  In the partial-PR variant the parent will also have a merged or open PR
+  reference; treat it the same way and rely on the merged PR to record the
+  partial work.
 - **Still valid, body still accurate**: remove the `replan` label (`gh issue edit N --remove-label replan`) to re-open for workers
 - **Still valid, body stale**: update the issue body with current state, then remove the `replan` label
 

--- a/pod/data/agent-config/claude/commands/plan.md
+++ b/pod/data/agent-config/claude/commands/plan.md
@@ -56,6 +56,10 @@ For each, exactly one of:
 - **Work already done** (a subsequent PR merged it): close with a note
 - **Plan stale / approach changed**: create a corrected replacement issue, close original linking forward
 - **Partial progress**: create issue for remaining deliverables, close original linking forward
+- **Worker-decomposed**: the worker already created sub-issues (look for a
+  `Decomposed into #X, #Y` comment). If the sub-issues fully cover the parent,
+  just close it linking forward — do NOT re-create them. If residual scope
+  remains, narrow the body to that residual and remove the `replan` label.
 - **Still valid, body still accurate**: remove the `replan` label (`gh issue edit N --remove-label replan`) to re-open for workers
 - **Still valid, body stale**: update the issue body with current state, then remove the `replan` label
 
@@ -118,12 +122,18 @@ stage, follow them. The goal is many small, independent issues — not one large
 issue per stage.
 
 If you cannot yet determine the scope of a stage because it depends on earlier
-output (e.g., item discovery), create the issue for the whole stage but include
-a note in the body: **"This issue needs decomposition: once the prerequisite is
-complete, the claiming worker should
-`coordination skip N 'needs decomposition into per-item sub-issues'` so the
-planner can create properly-scoped sub-issues."** This keeps issue creation under
-planner locking and overlap protection. Never ask workers to create issues directly.
+output (e.g., item discovery), it is fine to create the issue for the whole
+stage. **Workers are allowed and encouraged to decompose oversized issues
+themselves** — they have the freshest codebase context and can usually scope
+sub-tasks more accurately than you can in advance. See the `agent-worker-flow`
+skill's "Assess Scope" step for the worker-side mechanics.
+
+If you specifically want planner-led decomposition (e.g., the split needs
+cross-issue coordination you can see and the worker cannot), include a note in
+the body asking the claiming worker to
+`coordination skip N 'needs planner decomposition: <reason>'` instead of
+splitting it themselves. Default is worker-led decomposition; require
+planner-led only when there is a clear reason.
 
 **Critical-path issues**: When you create an issue that blocks all other planned
 work (e.g., the first issue in a sequential pipeline, or a bottleneck that many

--- a/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
@@ -38,12 +38,19 @@ The `gh` CLI defaults to the current repo, so `--repo` is not needed.
 **Issue lifecycle**: planner creates issue (label: `agent-plan`) →
 worker claims it (adds label: `claimed`) → worker creates PR closing it
 (label swaps to `has-pr`) → auto-merge squash-merges.
-Issues marked `replan` (by skip or partial completion) are handled by the next planner.
-Issues with `has-pr` are excluded from `list-unclaimed` and `queue-depth`.
+Issues marked `replan` (by skip, partial completion, or worker-led
+decomposition) are handled by the next planner. Issues with `has-pr` are
+excluded from `list-unclaimed` and `queue-depth`.
 
 **Partial completion**: worker uses `--partial` → label swaps to
 `replan`. A planner creates a new issue for remaining work, then closes
 the `replan` issue with a link to the new one.
+
+**Worker-led decomposition**: if the claimed issue is too large for one
+session, worker creates sub-issues and `coordination skip`s the parent
+with a `Decomposed into #X, #Y` breadcrumb comment. The next planner
+either closes the parent (sub-issues fully cover it) or narrows it to the
+residual scope. See "Assess Scope" (Step 4b) for the full procedure.
 
 **Dependencies**: Issues can declare `depends-on: #N` in their body.
 `coordination plan` auto-adds the `blocked` label if any dependency is
@@ -158,29 +165,40 @@ You may decompose when any of these is true:
 - you can write self-contained successor issues without further investigation.
 
 ```bash
-# Create self-contained sub-issues. Use `coordination plan` exactly as a
-# planner would — same body template (Current state / Deliverables /
-# Context / Verification), same label, same overlap-warning protection.
+# 1. Create self-contained sub-issues. Use `coordination plan` exactly as a
+#    planner would — same body template (Current state / Deliverables /
+#    Context / Verification), same label. Note: `coordination plan` does
+#    only best-effort title-keyword overlap warnings; it does not hold the
+#    planner lock and cannot atomically dedupe against concurrent creators.
+#    If you see open issues that look related, link or coordinate
+#    explicitly in the sub-issue body rather than relying on the warning.
 echo "body..." | coordination plan --label feature "Sub-task 1: ..."
 echo "body..." | coordination plan --label feature "Sub-task 2: ..."
 
-# Link ordering dependencies if any sub-task must precede another.
+# 2. Link ordering dependencies if any sub-task must precede another.
+#    Do NOT add `depends-on: #<parent>` — the parent is about to be
+#    superseded; depend on real predecessor sub-issues instead.
 coordination add-dep <sub2> <sub1>
+
+# 3. Leave a machine-readable breadcrumb on the parent. The planner's
+#    replan-triage step keys off this exact `Decomposed into #X, #Y`
+#    phrasing — keep it on a single line at the start of the comment.
+gh issue comment <parent> --body "Decomposed into #<sub1>, #<sub2>
+
+(reason: <one-line scope assessment>)"
+
+# 4. Release the claim by marking the parent for planner triage. This
+#    routes through pod's claim-state machinery and clears the in-process
+#    `state.claimed_issue` correctly. Do NOT use `gh issue close` directly:
+#    it leaves pod's session-end cleanup thinking the issue is still
+#    claimed and will attempt a stray `coordination skip` on a closed
+#    issue at exit.
+coordination skip <parent> "Decomposed into #<sub1>, #<sub2> — see comment"
 ```
 
-Then resolve the parent issue. Pick whichever fits:
-
-- **Sub-issues fully cover the parent** (no residual scope): close the
-  parent, linking forward so the planner doesn't re-triage it.
-  ```bash
-  gh issue close <parent> --comment "Decomposed into #X, #Y — superseded."
-  gh issue edit <parent> --remove-label claimed
-  ```
-- **Parent still has residual scope or needs re-scoping**: skip it so the
-  planner narrows the body to what's left.
-  ```bash
-  coordination skip <parent> "Decomposed into #X, #Y — narrow this to <residual>"
-  ```
+The planner's next replan-triage cycle picks the parent up and either
+closes it (if the sub-issues fully cover it) or narrows the body to the
+residual scope (if not).
 
 After decomposing, you have two options:
 
@@ -191,10 +209,18 @@ After decomposing, you have two options:
    brief progress entry and exit. The next worker will claim a sub-issue.
 
 If you've already done a coherent subset of the parent's work *before*
-deciding to decompose, prefer the partial-PR path instead: create sub-issues
-for the remaining work, then `coordination create-pr <parent> --partial`.
-That marks the parent `replan`; the next planner sees the sub-issues in the
-issue's comments and closes the parent with a forward link.
+deciding to decompose, prefer the partial-PR path:
+
+```bash
+# Steps 1-3 above (create sub-issues for the remaining work, leave the
+# `Decomposed into #X, #Y` breadcrumb on the parent).
+
+# Then land your coherent subset. `--partial` marks the parent `replan`.
+coordination create-pr <parent> --partial "feat: <what landed>"
+```
+
+The next planner sees the breadcrumb on the parent and closes it with a
+forward link to the sub-issues.
 
 ## Step 5: Execute
 

--- a/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
@@ -146,18 +146,55 @@ in a single session. Warning signs it doesn't:
 - The work naturally splits into independent sub-lemmas or sub-tasks
 - Difficulty feels higher than the issue says
 
-**If so, decompose immediately** — don't attempt the whole thing first.
+If the issue is too large, **decomposing it into smaller sub-issues is a
+normal success path**, not a failure mode. You have the freshest codebase
+context and can usually scope sub-tasks more accurately than a planner could
+in advance. A good decomposition is more valuable than a failed heroic
+attempt — and far better than overrunning the session trying to salvage it.
+
+You may decompose when any of these is true:
+- the claimed issue is too large for one session,
+- the work naturally splits into independent sub-tasks,
+- you can write self-contained successor issues without further investigation.
 
 ```bash
-# Create sub-issues, then skip the parent
+# Create self-contained sub-issues. Use `coordination plan` exactly as a
+# planner would — same body template (Current state / Deliverables /
+# Context / Verification), same label, same overlap-warning protection.
 echo "body..." | coordination plan --label feature "Sub-task 1: ..."
 echo "body..." | coordination plan --label feature "Sub-task 2: ..."
-coordination add-dep <sub2> <sub1>   # if ordering matters
-coordination skip <parent> "Decomposed into #X, #Y — too large for single session"
+
+# Link ordering dependencies if any sub-task must precede another.
+coordination add-dep <sub2> <sub1>
 ```
 
-Then claim one of the sub-issues and work on that instead.
-A good decomposition is more valuable than a failed heroic attempt.
+Then resolve the parent issue. Pick whichever fits:
+
+- **Sub-issues fully cover the parent** (no residual scope): close the
+  parent, linking forward so the planner doesn't re-triage it.
+  ```bash
+  gh issue close <parent> --comment "Decomposed into #X, #Y — superseded."
+  gh issue edit <parent> --remove-label claimed
+  ```
+- **Parent still has residual scope or needs re-scoping**: skip it so the
+  planner narrows the body to what's left.
+  ```bash
+  coordination skip <parent> "Decomposed into #X, #Y — narrow this to <residual>"
+  ```
+
+After decomposing, you have two options:
+
+1. **Continue on one of the sub-issues**: claim it via `coordination claim`,
+   then return to Step 2 with the sub-issue. Common case when the parent
+   was just two work items glued together.
+2. **Stop and exit**: if you've used most of your session orienting, write a
+   brief progress entry and exit. The next worker will claim a sub-issue.
+
+If you've already done a coherent subset of the parent's work *before*
+deciding to decompose, prefer the partial-PR path instead: create sub-issues
+for the remaining work, then `coordination create-pr <parent> --partial`.
+That marks the parent `replan`; the next planner sees the sub-issues in the
+issue's comments and closes the parent with a forward link.
 
 ## Step 5: Execute
 

--- a/pod/data/agent-config/codex/commands/plan.md
+++ b/pod/data/agent-config/codex/commands/plan.md
@@ -56,10 +56,18 @@ For each, exactly one of:
 - **Work already done** (a subsequent PR merged it): close with a note
 - **Plan stale / approach changed**: create a corrected replacement issue, close original linking forward
 - **Partial progress**: create issue for remaining deliverables, close original linking forward
-- **Worker-decomposed**: the worker already created sub-issues (look for a
-  `Decomposed into #X, #Y` comment). If the sub-issues fully cover the parent,
-  just close it linking forward — do NOT re-create them. If residual scope
-  remains, narrow the body to that residual and remove the `replan` label.
+- **Worker-decomposed**: the worker created sub-issues before releasing
+  the claim. Detect via a comment that starts with `Decomposed into #` and
+  lists the sub-issue numbers (workers must leave this breadcrumb before
+  `coordination skip` or `coordination create-pr --partial`). Read the
+  sub-issues and decide:
+  - sub-issues fully cover the parent → close the parent with a forward
+    link (do NOT re-create the sub-issues);
+  - residual scope remains → narrow the body to that residual and remove
+    the `replan` label so workers can claim it again.
+  In the partial-PR variant the parent will also have a merged or open PR
+  reference; treat it the same way and rely on the merged PR to record the
+  partial work.
 - **Still valid, body still accurate**: remove the `replan` label (`gh issue edit N --remove-label replan`) to re-open for workers
 - **Still valid, body stale**: update the issue body with current state, then remove the `replan` label
 

--- a/pod/data/agent-config/codex/commands/plan.md
+++ b/pod/data/agent-config/codex/commands/plan.md
@@ -56,6 +56,10 @@ For each, exactly one of:
 - **Work already done** (a subsequent PR merged it): close with a note
 - **Plan stale / approach changed**: create a corrected replacement issue, close original linking forward
 - **Partial progress**: create issue for remaining deliverables, close original linking forward
+- **Worker-decomposed**: the worker already created sub-issues (look for a
+  `Decomposed into #X, #Y` comment). If the sub-issues fully cover the parent,
+  just close it linking forward — do NOT re-create them. If residual scope
+  remains, narrow the body to that residual and remove the `replan` label.
 - **Still valid, body still accurate**: remove the `replan` label (`gh issue edit N --remove-label replan`) to re-open for workers
 - **Still valid, body stale**: update the issue body with current state, then remove the `replan` label
 
@@ -118,12 +122,18 @@ stage, follow them. The goal is many small, independent issues — not one large
 issue per stage.
 
 If you cannot yet determine the scope of a stage because it depends on earlier
-output (e.g., item discovery), create the issue for the whole stage but include
-a note in the body: **"This issue needs decomposition: once the prerequisite is
-complete, the claiming worker should
-`coordination skip N 'needs decomposition into per-item sub-issues'` so the
-planner can create properly-scoped sub-issues."** This keeps issue creation under
-planner locking and overlap protection. Never ask workers to create issues directly.
+output (e.g., item discovery), it is fine to create the issue for the whole
+stage. **Workers are allowed and encouraged to decompose oversized issues
+themselves** — they have the freshest codebase context and can usually scope
+sub-tasks more accurately than you can in advance. See the `agent-worker-flow`
+skill's "Assess Scope" step for the worker-side mechanics.
+
+If you specifically want planner-led decomposition (e.g., the split needs
+cross-issue coordination you can see and the worker cannot), include a note in
+the body asking the claiming worker to
+`coordination skip N 'needs planner decomposition: <reason>'` instead of
+splitting it themselves. Default is worker-led decomposition; require
+planner-led only when there is a clear reason.
 
 **Critical-path issues**: When you create an issue that blocks all other planned
 work (e.g., the first issue in a sequential pipeline, or a bottleneck that many

--- a/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
@@ -38,12 +38,19 @@ The `gh` CLI defaults to the current repo, so `--repo` is not needed.
 **Issue lifecycle**: planner creates issue (label: `agent-plan`) →
 worker claims it (adds label: `claimed`) → worker creates PR closing it
 (label swaps to `has-pr`) → auto-merge squash-merges.
-Issues marked `replan` (by skip or partial completion) are handled by the next planner.
-Issues with `has-pr` are excluded from `list-unclaimed` and `queue-depth`.
+Issues marked `replan` (by skip, partial completion, or worker-led
+decomposition) are handled by the next planner. Issues with `has-pr` are
+excluded from `list-unclaimed` and `queue-depth`.
 
 **Partial completion**: worker uses `--partial` → label swaps to
 `replan`. A planner creates a new issue for remaining work, then closes
 the `replan` issue with a link to the new one.
+
+**Worker-led decomposition**: if the claimed issue is too large for one
+session, worker creates sub-issues and `coordination skip`s the parent
+with a `Decomposed into #X, #Y` breadcrumb comment. The next planner
+either closes the parent (sub-issues fully cover it) or narrows it to the
+residual scope. See "Assess Scope" (Step 4b) for the full procedure.
 
 **Dependencies**: Issues can declare `depends-on: #N` in their body.
 `coordination plan` auto-adds the `blocked` label if any dependency is
@@ -158,29 +165,40 @@ You may decompose when any of these is true:
 - you can write self-contained successor issues without further investigation.
 
 ```bash
-# Create self-contained sub-issues. Use `coordination plan` exactly as a
-# planner would — same body template (Current state / Deliverables /
-# Context / Verification), same label, same overlap-warning protection.
+# 1. Create self-contained sub-issues. Use `coordination plan` exactly as a
+#    planner would — same body template (Current state / Deliverables /
+#    Context / Verification), same label. Note: `coordination plan` does
+#    only best-effort title-keyword overlap warnings; it does not hold the
+#    planner lock and cannot atomically dedupe against concurrent creators.
+#    If you see open issues that look related, link or coordinate
+#    explicitly in the sub-issue body rather than relying on the warning.
 echo "body..." | coordination plan --label feature "Sub-task 1: ..."
 echo "body..." | coordination plan --label feature "Sub-task 2: ..."
 
-# Link ordering dependencies if any sub-task must precede another.
+# 2. Link ordering dependencies if any sub-task must precede another.
+#    Do NOT add `depends-on: #<parent>` — the parent is about to be
+#    superseded; depend on real predecessor sub-issues instead.
 coordination add-dep <sub2> <sub1>
+
+# 3. Leave a machine-readable breadcrumb on the parent. The planner's
+#    replan-triage step keys off this exact `Decomposed into #X, #Y`
+#    phrasing — keep it on a single line at the start of the comment.
+gh issue comment <parent> --body "Decomposed into #<sub1>, #<sub2>
+
+(reason: <one-line scope assessment>)"
+
+# 4. Release the claim by marking the parent for planner triage. This
+#    routes through pod's claim-state machinery and clears the in-process
+#    `state.claimed_issue` correctly. Do NOT use `gh issue close` directly:
+#    it leaves pod's session-end cleanup thinking the issue is still
+#    claimed and will attempt a stray `coordination skip` on a closed
+#    issue at exit.
+coordination skip <parent> "Decomposed into #<sub1>, #<sub2> — see comment"
 ```
 
-Then resolve the parent issue. Pick whichever fits:
-
-- **Sub-issues fully cover the parent** (no residual scope): close the
-  parent, linking forward so the planner doesn't re-triage it.
-  ```bash
-  gh issue close <parent> --comment "Decomposed into #X, #Y — superseded."
-  gh issue edit <parent> --remove-label claimed
-  ```
-- **Parent still has residual scope or needs re-scoping**: skip it so the
-  planner narrows the body to what's left.
-  ```bash
-  coordination skip <parent> "Decomposed into #X, #Y — narrow this to <residual>"
-  ```
+The planner's next replan-triage cycle picks the parent up and either
+closes it (if the sub-issues fully cover it) or narrows the body to the
+residual scope (if not).
 
 After decomposing, you have two options:
 
@@ -191,10 +209,18 @@ After decomposing, you have two options:
    brief progress entry and exit. The next worker will claim a sub-issue.
 
 If you've already done a coherent subset of the parent's work *before*
-deciding to decompose, prefer the partial-PR path instead: create sub-issues
-for the remaining work, then `coordination create-pr <parent> --partial`.
-That marks the parent `replan`; the next planner sees the sub-issues in the
-issue's comments and closes the parent with a forward link.
+deciding to decompose, prefer the partial-PR path:
+
+```bash
+# Steps 1-3 above (create sub-issues for the remaining work, leave the
+# `Decomposed into #X, #Y` breadcrumb on the parent).
+
+# Then land your coherent subset. `--partial` marks the parent `replan`.
+coordination create-pr <parent> --partial "feat: <what landed>"
+```
+
+The next planner sees the breadcrumb on the parent and closes it with a
+forward link to the sub-issues.
 
 ## Step 5: Execute
 

--- a/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
@@ -146,18 +146,55 @@ in a single session. Warning signs it doesn't:
 - The work naturally splits into independent sub-lemmas or sub-tasks
 - Difficulty feels higher than the issue says
 
-**If so, decompose immediately** — don't attempt the whole thing first.
+If the issue is too large, **decomposing it into smaller sub-issues is a
+normal success path**, not a failure mode. You have the freshest codebase
+context and can usually scope sub-tasks more accurately than a planner could
+in advance. A good decomposition is more valuable than a failed heroic
+attempt — and far better than overrunning the session trying to salvage it.
+
+You may decompose when any of these is true:
+- the claimed issue is too large for one session,
+- the work naturally splits into independent sub-tasks,
+- you can write self-contained successor issues without further investigation.
 
 ```bash
-# Create sub-issues, then skip the parent
+# Create self-contained sub-issues. Use `coordination plan` exactly as a
+# planner would — same body template (Current state / Deliverables /
+# Context / Verification), same label, same overlap-warning protection.
 echo "body..." | coordination plan --label feature "Sub-task 1: ..."
 echo "body..." | coordination plan --label feature "Sub-task 2: ..."
-coordination add-dep <sub2> <sub1>   # if ordering matters
-coordination skip <parent> "Decomposed into #X, #Y — too large for single session"
+
+# Link ordering dependencies if any sub-task must precede another.
+coordination add-dep <sub2> <sub1>
 ```
 
-Then claim one of the sub-issues and work on that instead.
-A good decomposition is more valuable than a failed heroic attempt.
+Then resolve the parent issue. Pick whichever fits:
+
+- **Sub-issues fully cover the parent** (no residual scope): close the
+  parent, linking forward so the planner doesn't re-triage it.
+  ```bash
+  gh issue close <parent> --comment "Decomposed into #X, #Y — superseded."
+  gh issue edit <parent> --remove-label claimed
+  ```
+- **Parent still has residual scope or needs re-scoping**: skip it so the
+  planner narrows the body to what's left.
+  ```bash
+  coordination skip <parent> "Decomposed into #X, #Y — narrow this to <residual>"
+  ```
+
+After decomposing, you have two options:
+
+1. **Continue on one of the sub-issues**: claim it via `coordination claim`,
+   then return to Step 2 with the sub-issue. Common case when the parent
+   was just two work items glued together.
+2. **Stop and exit**: if you've used most of your session orienting, write a
+   brief progress entry and exit. The next worker will claim a sub-issue.
+
+If you've already done a coherent subset of the parent's work *before*
+deciding to decompose, prefer the partial-PR path instead: create sub-issues
+for the remaining work, then `coordination create-pr <parent> --partial`.
+That marks the parent `replan`; the next planner sees the sub-issues in the
+issue's comments and closes the parent with a forward link.
 
 ## Step 5: Execute
 


### PR DESCRIPTION
## Summary

Resolves the contradiction between the worker skill (which encouraged
sub-issue creation when a claimed issue was too large) and the planner
prompt (which forbade it: "Never ask workers to create issues directly").

Worker-led decomposition is now the default success path for oversized
issues. The planner still owns replan triage; the worker just produces a
better starting point for it.

## Changes

- **Worker skill `Step 4b: Assess Scope`** — explicit four-step procedure:
  1. Create self-contained sub-issues via `coordination plan`.
  2. Add ordering deps with `coordination add-dep` (never `depends-on: #<parent>`).
  3. Leave a machine-readable `Decomposed into #X, #Y` breadcrumb on the parent.
  4. Release via `coordination skip` (never raw `gh issue close`, which
     bypasses pod's claim-state machinery and would cause session-end
     cleanup to put `replan` on an already-closed issue).
- **Worker skill lifecycle summary** — adds the worker-led decomposition path.
- **Planner Step 6 (Stage granularity)** — removes "Never ask workers to
  create issues directly"; default is worker-led decomposition, opt in to
  planner-led only with a clear reason.
- **Planner Step 3 (replan triage)** — new "Worker-decomposed" bullet that
  keys off the breadcrumb format and tells the planner to either close
  the parent (if sub-issues fully cover it) or narrow the body.
- Both Claude and Codex copies updated identically.

## Design notes

- No coordination subcommand changes. Worker decomposition uses existing
  primitives (`coordination plan`, `gh issue comment`, `coordination skip`
  or `coordination create-pr --partial`) so the diff is doc-only.
- Overlap-warning language softened: `coordination plan`'s warning is
  best-effort title-keyword matching, not an atomic dedupe — workers are
  told to coordinate explicitly when they see related open issues.
- A future enhancement could add a `coordination decompose` command that
  wraps the four steps atomically; that's out of scope here.

## Second opinion

Reviewed by Codex; first revision had three issues (raw `gh issue close`
bypassing claim state, missing breadcrumb on the partial-PR path,
overstated overlap protection). Second commit addresses all three.

Closes #22

🤖 Prepared with Claude Code