### PR TITLE
fix: planner can cleanly shut down (closes #27)

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1914,7 +1914,9 @@ def dispatch_queue_balance(config: dict, queue_depth: int,
     This keeps repair orthogonal to `planner_target` and to queue depth.
     """
     # Repair short-circuit. Runs first so that unhealthy PRs are always
-    # addressed before new feature work is planned or drained.
+    # addressed before new feature work is planned or drained.  Repair is
+    # intentionally orthogonal to `effective_target`: an unhealthy PR may
+    # need attention even after the planner has called return-to-human.
     if "repair" in worker_types:
         candidates = _list_pr_repair_count(config)
         running_repair = _count_running_repair_agents()
@@ -1927,12 +1929,23 @@ def dispatch_queue_balance(config: dict, queue_depth: int,
             log(f"dispatch: repair candidates={candidates} but running_repair={running_repair} "
                 f"already at/near cap={cap}, falling through")
 
+    # Honour an effective target of 0.  `get_effective_target()` returns 0
+    # whenever the user or the planner has set their respective target to 0
+    # (e.g. via `coordination return-to-human`).  Without this check the
+    # per-session dispatch loop would keep handing prompts to an existing
+    # agent forever, because target=0 is only consulted by the auto-spawn
+    # and restart paths.
+    effective_target = get_effective_target()
+    if effective_target == 0:
+        log("dispatch: effective_target=0, no dispatch (return-to-human or user target=0)")
+        return None
+
     config_min_queue = cfg_get(config, "dispatch", "min_queue", default=3)
     planner_min_queue = read_planner_min_queue()
     if planner_min_queue is not None:
-        min_queue = max(1, min(config_min_queue, planner_min_queue))
+        min_queue = max(0, min(config_min_queue, planner_min_queue))
     else:
-        min_queue = max(1, config_min_queue)
+        min_queue = max(0, config_min_queue)
 
     # Separate types into queue-filling (have locks) and queue-draining (no locks).
     # `repair` is draining in principle but is handled exclusively by the
@@ -1954,7 +1967,7 @@ def dispatch_queue_balance(config: dict, queue_depth: int,
             log(f"dispatch: critical-path override → {chosen}")
             return chosen
 
-    if queue_depth < min_queue and filling:
+    if min_queue > 0 and queue_depth < min_queue and filling:
         log(f"dispatch: queue low ({queue_depth} < {min_queue}), trying filling types")
         # Try to acquire lock for a filling type
         for name, wt in filling.items():
@@ -2022,6 +2035,11 @@ def dispatch_round_robin(config: dict, queue_depth: int,
                           state: AgentState | None = None) -> str | None:
     """Cycle through worker types, skipping locked ones."""
     global _round_robin_idx
+    # Honour effective_target=0 (issue #27) so the per-session dispatch loop
+    # doesn't keep handing prompts to a running agent after return-to-human.
+    if get_effective_target() == 0:
+        log("dispatch: effective_target=0, no dispatch (round_robin)")
+        return None
     names = list(worker_types.keys())
     if not names:
         return None
@@ -2045,6 +2063,13 @@ def dispatch_custom(config: dict, queue_depth: int,
                      worker_types: dict,
                      state: AgentState | None = None) -> str | None:
     """Run a custom dispatch script."""
+    # Honour effective_target=0 (issue #27).  We could pass it to the script
+    # via env, but the safer default is to never invoke the script at all
+    # when shutdown has been requested — there's nothing the script could
+    # legitimately return that we'd want to act on.
+    if get_effective_target() == 0:
+        log("dispatch: effective_target=0, no dispatch (custom)")
+        return None
     strategy = cfg_get(config, "dispatch", "strategy", default="")
     script = os.path.expanduser(strategy)
     env = dict(os.environ)
@@ -3987,11 +4012,27 @@ def _tui_main(stdscr, config: dict):
     except Exception:
         cached_return_to_human = False
     return_to_human_fetch_time = 0.0
-    # _acted_on_return_to_human: True once this session has already sent SIGUSR1.
-    # Set True at startup when signal was pre-existing so we skip the SIGUSR1 burst.
+    # _acted_on_return_to_human: True once this session has already taken the
+    # one-shot side effects (write_target=0, banner) for the current label
+    # presence.  Reset to False when the label disappears so a re-application
+    # re-fires those side effects.
     _acted_on_return_to_human = cached_return_to_human
+    # Agents alive when this TUI started up while the label was already set
+    # are "grandfathered": we won't send them SIGUSR1, on the assumption that
+    # the operator restarted pod intentionally and wants to keep observing
+    # them.  Any agent that appears after startup (including a stale orphan
+    # TUI's looping agent that was missed by the original one-shot fire) is
+    # signalled normally.  Identified by (short_id, pid_start_time) so a
+    # recycled short_id with a different process can't accidentally inherit
+    # grandfather status.
+    _grandfathered_agents: set[tuple[str, float]] = set()
     if cached_return_to_human:
         write_target(0)
+        _grandfathered_agents = {
+            (a.short_id, a.pid_start_time)
+            for a in read_all_agents()
+            if a.status not in ("stopped", "dead") and a.pid > 0
+        }
     CACHE_SECS = 60           # Refresh interval for primary GitHub API data (queue, items)
     CACHE_SECS_SLOW = 120     # Refresh interval for less-critical data (blocked deps, lock, return-to-human)
 
@@ -4083,7 +4124,9 @@ def _tui_main(stdscr, config: dict):
             _bg_fetch("blocked_deps", fetch_blocked_deps)
             blocked_deps_fetch_time = now
         # Return-to-human signal: planner labels sentinel issue when no work remains.
-        if not _acted_on_return_to_human and now - return_to_human_fetch_time > CACHE_SECS:
+        # Poll continuously so we observe both label re-applications (planner re-fires
+        # after each empty-queue tick) and external clears (`gh issue edit --remove-label`).
+        if now - return_to_human_fetch_time > CACHE_SECS:
             _bg_fetch("return_to_human", get_return_to_human, config)
             return_to_human_fetch_time = now
         # Repair candidates: count of PRs needing repair. Used by the
@@ -4117,19 +4160,37 @@ def _tui_main(stdscr, config: dict):
             if _bg_data["repair_candidates"] is not None:
                 cached_repair_candidates = _bg_data["repair_candidates"]
 
-        # React to return-to-human signal: set target=0 and gracefully finish all agents.
-        # Only act once per TUI session (idempotent).
-        if cached_return_to_human and not _acted_on_return_to_human:
-            _acted_on_return_to_human = True
-            write_target(0)
+        # React to return-to-human signal: set target=0 and gracefully finish agents.
+        # The latched flag (`_acted_on_return_to_human`) gates one-shot side effects —
+        # writing target=0 and showing the status banner — so they don't repeat each tick.
+        # The per-agent re-signal loop runs on every tick whenever the label is present,
+        # so any running agent that hasn't already received SIGUSR1 (including a stale
+        # orphan TUI's looping agent that the original one-shot fire missed) gets stopped.
+        # `_grandfathered_agents` exempts agents present at startup-with-label-present so
+        # an intentional restart doesn't kill agents the operator is observing.
+        if cached_return_to_human:
+            if not _acted_on_return_to_human:
+                _acted_on_return_to_human = True
+                write_target(0)
+                message = "Return-to-human: planner found no remaining work. Target set to 0; agents finishing."
+                message_time = now
             for a in agents:
-                if a.pid > 0 and a.status not in ("stopped", "dead") and _pid_is_valid(a.pid, a.pid_start_time):
+                if (a.short_id, a.pid_start_time) in _grandfathered_agents:
+                    continue
+                if (a.pid > 0
+                        and not a.finishing
+                        and a.status not in ("stopped", "dead", "finishing")
+                        and _pid_is_valid(a.pid, a.pid_start_time)):
                     try:
                         os.kill(a.pid, signal.SIGUSR1)
                     except (ProcessLookupError, OSError):
                         pass
-            message = "Return-to-human: planner found no remaining work. Target set to 0; agents finishing."
-            message_time = now
+        elif _acted_on_return_to_human:
+            # Label cleared (externally or via 'r' keypress path below).  Reset the
+            # latch and the grandfather set so a future re-application starts fresh:
+            # any agents still alive at re-application time will be signalled.
+            _acted_on_return_to_human = False
+            _grandfathered_agents = set()
 
         # Auto-spawn agents to maintain target (only if no agents are finishing).
         # Repair overflow: if there are PR repair candidates with spare
@@ -4553,6 +4614,7 @@ def _tui_main(stdscr, config: dict):
                     clear_return_to_human(config)
                     cached_return_to_human = False
                     _acted_on_return_to_human = False
+                    _grandfathered_agents = set()
                     message = "Return-to-human signal cleared. Press [a] to add an agent."
                 except Exception as e:
                     message = f"Failed to clear signal: {e}"

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -29,7 +29,7 @@
 #   coordination check-return-to-human        — check if return-to-human signal is set on sentinel (exits 0 if set)
 #   coordination clear-return-to-human        — remove return-to-human signal (e.g. to resume work after completion)
 #   coordination set-target N                 — planner sets recommended target agent count (pod uses min of this and user target)
-#   coordination set-min-queue N              — planner sets recommended min_queue (pod uses min of this and config value, floored at 1)
+#   coordination set-min-queue N              — planner sets recommended min_queue (pod uses min of this and config value; 0 disables backfill)
 #   coordination nothing-to-plan              — planner signals queue saturated; decrements target by 1 (deprecated: use set-target/set-min-queue instead)
 
 set -euo pipefail
@@ -1104,7 +1104,8 @@ EOF
 
 # --- set-min-queue ---
 # Planner sets recommended min_queue for dispatch.
-# Pod uses max(1, min(config_min_queue, planner_min_queue)) as the effective value.
+# Pod uses min(config_min_queue, planner_min_queue) as the effective value
+# (no floor at 1 — set 0 to explicitly disable queue-low backfill).
 cmd_set_min_queue() {
     local n="${1:?usage: coordination set-min-queue N}"
     local main_root
@@ -1116,7 +1117,8 @@ cmd_set_min_queue() {
     fi
     cat > "$pod_dir/planner-min-queue" <<EOF
 # Planner advisory: lower queue_balance min_queue threshold.
-# Effective min_queue is max(1, min(config min_queue, planner-min-queue)).
+# Effective min_queue is min(config min_queue, planner-min-queue).
+# Set to 0 to explicitly disable queue-low backfill (no planner re-fire).
 $n
 EOF
     echo "Planner min_queue set to $n"

--- a/tests/test_dispatch_shutdown.py
+++ b/tests/test_dispatch_shutdown.py
@@ -1,0 +1,139 @@
+"""Regression tests for issue #27.
+
+When the planner calls `coordination return-to-human`, three state files are
+written: `target=0`, `planner-target=0`, `planner-min-queue=1` (or 0).  The
+dispatcher must then refuse to hand new prompts to the running agent.
+Previously, `dispatch_queue_balance` clamped `min_queue` to 1 and never
+consulted `get_effective_target()`, so an agent kept being dispatched as
+`plan` indefinitely.
+"""
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pod import cli
+
+
+class DispatchHonoursReturnToHumanTests(unittest.TestCase):
+    """`dispatch_queue_balance` must return None when shutdown is requested."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self._patches = [
+            mock.patch.object(cli, "TARGET_FILE", root / "target"),
+            mock.patch.object(cli, "PLANNER_TARGET_FILE", root / "planner-target"),
+            mock.patch.object(cli, "PLANNER_MIN_QUEUE_FILE", root / "planner-min-queue"),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _worker_types(self):
+        # Mirrors the default `plan` (filling) + `work` (draining) shape that
+        # the planner-driven shutdown loop exercises.
+        return {
+            "plan": {"lock": "planner"},
+            "work": {},
+        }
+
+    def test_effective_target_zero_returns_none_even_with_empty_queue(self):
+        cli.write_target(0)
+        cli._write_commented_int(cli.PLANNER_TARGET_FILE, 0,
+                                  ["Planner-recommended target."])
+        cli._write_commented_int(cli.PLANNER_MIN_QUEUE_FILE, 1,
+                                  ["Planner-recommended min queue."])
+
+        chosen = cli.dispatch_queue_balance(
+            config={}, queue_depth=0, worker_types=self._worker_types(),
+        )
+        self.assertIsNone(chosen,
+            "dispatch must not return 'plan' when planner asked for shutdown")
+
+    def test_planner_min_queue_zero_skips_filling_branch_when_draining_has_work(self):
+        # Belt-and-braces: even without target=0, planner-min-queue=0 must
+        # disable the queue-low filling branch.  Previously `max(1, …)`
+        # clamped the planner's value back to 1, so queue_depth=0 < 1 always
+        # entered the filling branch and dispatched `plan`, even when the
+        # draining branch had work to do.
+        cli.write_target(3)
+        cli._write_commented_int(cli.PLANNER_MIN_QUEUE_FILE, 0,
+                                  ["Planner-recommended min queue."])
+
+        # `_choose_draining` returns a worker name → that's what dispatch
+        # should pick.  Pre-fix it would have picked `plan` first.  Post-fix
+        # the filling branch is gated, so we fall through to draining.
+        with mock.patch.object(cli, "_choose_draining", return_value="work"):
+            chosen = cli.dispatch_queue_balance(
+                config={}, queue_depth=0, worker_types=self._worker_types(),
+            )
+        self.assertEqual(chosen, "work",
+            "planner-min-queue=0 must skip the queue-low filling branch")
+
+    def test_target_zero_short_circuits_before_min_queue_logic(self):
+        # When target=0 is set without planner files, the dispatch should still
+        # return None — the planner's request is the user's target=0 alone.
+        cli.write_target(0)
+        # Force the (would-be-broken) min_queue path to throw if ever reached.
+        with mock.patch.object(cli, "read_planner_min_queue",
+                                side_effect=AssertionError("min_queue must not be consulted")):
+            chosen = cli.dispatch_queue_balance(
+                config={}, queue_depth=0, worker_types=self._worker_types(),
+            )
+        self.assertIsNone(chosen)
+
+    def test_round_robin_honours_effective_target_zero(self):
+        # round_robin doesn't have a min_queue concept, so the bug presents
+        # differently: it just keeps cycling worker types forever.  Same fix
+        # required.  Pre-fix: returns "plan" (or "work").  Post-fix: None.
+        cli.write_target(0)
+        with mock.patch.object(cli, "coordination",
+                                side_effect=AssertionError("must not attempt lock when target=0")):
+            chosen = cli.dispatch_round_robin(
+                config={}, queue_depth=0, worker_types=self._worker_types(),
+            )
+        self.assertIsNone(chosen)
+
+    def test_custom_dispatch_honours_effective_target_zero(self):
+        # Custom dispatch must not even invoke the script when target=0 —
+        # there's nothing it could legitimately return that we'd want to act on.
+        cli.write_target(0)
+        with mock.patch("subprocess.run",
+                         side_effect=AssertionError("must not invoke script when target=0")):
+            chosen = cli.dispatch_custom(
+                config={"dispatch": {"strategy": "/nonexistent/script"}},
+                queue_depth=0, worker_types=self._worker_types(),
+            )
+        self.assertIsNone(chosen)
+
+
+class GetEffectiveTargetTests(unittest.TestCase):
+    """Sanity check on the helper used by the new dispatch guard."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self._patches = [
+            mock.patch.object(cli, "TARGET_FILE", root / "target"),
+            mock.patch.object(cli, "PLANNER_TARGET_FILE", root / "planner-target"),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_returns_zero_when_both_targets_zero(self):
+        cli.write_target(0)
+        cli._write_commented_int(cli.PLANNER_TARGET_FILE, 0, ["x"])
+        self.assertEqual(cli.get_effective_target(), 0)
+
+    def test_returns_zero_when_user_target_zero(self):
+        cli.write_target(0)
+        # No planner file.
+        self.assertEqual(cli.get_effective_target(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #27.  When the planner called `coordination return-to-human`, the dispatcher and the per-session agent loop ignored every state file the planner wrote (`target=0`, `planner-target=0`, `planner-min-queue=…`, plus the sentinel issue label).  An existing agent kept being dispatched as `plan` indefinitely, burning Codex sessions until killed by hand.

Three changes — one root-cause fix and two defence-in-depth tightenings — make the shutdown path semantically clean.

### 1. Per-session dispatch honours `effective_target == 0`
`dispatch_queue_balance`, `dispatch_round_robin`, and `dispatch_custom` now short-circuit to `None` when `get_effective_target() == 0`.  Previously only the auto-spawn and restart paths consulted it, so a running agent kept getting fed prompts after the planner asked for shutdown.  The `repair` short-circuit in `queue_balance` is preserved intentionally (repair stays orthogonal to `planner_target`, matching the existing TUI auto-spawn carveout).

### 2. `min_queue` floor of 1 dropped
The hardcoded `max(1, …)` clamp meant the planner could never write a value that disabled the queue-low filling branch.  Floor relaxed to 0, and the dispatch condition is now `min_queue > 0 and queue_depth < min_queue and filling`, so `coordination set-min-queue 0` is an explicit "do not backfill".  The `coordination` script's documentation comment is updated to match.

### 3. Return-to-human handler is non-latching
`_acted_on_return_to_human` no longer latches forever after the first observation.  The TUI re-polls the label each tick and re-fires SIGUSR1 to any running agent that hasn't already received it.  This covers the orphan-TUI scenario in the bug report, where a stale TUI latched and stopped reaching its own looping agent.

To preserve the "operator restarted pod intentionally" semantics, agents that were alive at TUI startup *while the label was already set* are grandfathered (identified by `(short_id, pid_start_time)`) and are not signalled.  Any agent that appears later — including agents owned by another (orphan) TUI process — is signalled normally.  The grandfather set is cleared when the label disappears, so a future re-application starts fresh.

## Test plan
- [x] `python -m unittest discover -s tests` — 38 tests pass (5 new in `tests/test_dispatch_shutdown.py` cover all three dispatch strategies with `target=0`, the `planner-min-queue=0` path, and the `get_effective_target` helper).
- [ ] Manual reproduction: starve a planner-driven project, verify pod settles into "agents finishing" rather than re-dispatching `plan`.

🤖 Prepared with Claude Code