### PR TITLE
fix: [r] handler invalidates return-to-human bg cache (closes #30)

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -4047,7 +4047,13 @@ def _tui_main(stdscr, config: dict):
         try:
             result = fn(*args)
             with _bg_mutex:
-                _bg_data[key] = result
+                # Only commit if we weren't cancelled while the call was in
+                # flight.  A synchronous handler (e.g. 'r' clearing
+                # return-to-human, see #30) cancels a pending fetch by
+                # discarding the key from _bg_active so its sampled-before-
+                # clear result can't race back in and re-set stale state.
+                if key in _bg_active:
+                    _bg_data[key] = result
         except Exception:
             pass
         finally:
@@ -4615,6 +4621,15 @@ def _tui_main(stdscr, config: dict):
                     cached_return_to_human = False
                     _acted_on_return_to_human = False
                     _grandfathered_agents = set()
+                    # Invalidate the background cache so the next main-loop
+                    # iteration doesn't re-apply a stale True and re-fire the
+                    # one-shot side effects before the next poll (see #30).
+                    # Also cancel any in-flight fetch whose result (sampled
+                    # before the label was cleared) would otherwise race back
+                    # in and re-latch True.
+                    with _bg_mutex:
+                        _bg_data["return_to_human"] = False
+                        _bg_active.discard("return_to_human")
                     message = "Return-to-human signal cleared. Press [a] to add an agent."
                 except Exception as e:
                     message = f"Failed to clear signal: {e}"


### PR DESCRIPTION
## Summary

- Pressing \`r\` to clear the return-to-human banner was ineffective: the handler cleared the GitHub label and local state but left \`_bg_data[\"return_to_human\"]\` stale. The next main-loop iteration re-applied the stale \`True\` and re-fired the one-shot side effects (\`write_target(0)\` + SIGUSR1 to agents), clobbering the handler's \"signal cleared\" message and re-latching the banner for up to \`CACHE_SECS\` seconds.
- Fix (a) from #30: seed \`_bg_data[\"return_to_human\"] = False\` under \`_bg_mutex\` in the \`r\` handler. We're authoritative about the cleared state immediately after \`clear_return_to_human(config)\` succeeds, so this is deterministic and doesn't depend on fetch latency.
- Also close the narrower in-flight race flagged by second-opinion review: an already-running \`_bg_fetch(\"return_to_human\", ...)\` whose API call sampled \`True\` before the clear could write \`True\` back after the handler returned. The handler now also discards the key from \`_bg_active\`, and \`_bg_run\` checks membership under the mutex before committing its result — a cancelled fetch's stale value is dropped.

## Test plan

- [x] Existing unit tests pass (\`python -m unittest discover -s tests\`)
- [ ] Manual TUI test: trigger return-to-human, press \`r\`, confirm banner disappears immediately and one-shot side effects don't re-fire
- [ ] Manual TUI test: press \`r\` during an in-flight fetch, confirm no race re-latch

🤖 Prepared with Claude Code