### PR TITLE
docs(planner): stop creating meditate issues by default

### DIFF
--- a/pod/data/agent-config/claude/commands/plan.md
+++ b/pod/data/agent-config/claude/commands/plan.md
@@ -106,11 +106,10 @@ Your work item MUST NOT overlap with any existing issue's deliverables.
 
 ## Step 6: Write new issues
 
-Work types: **`feature`**, **`review`**, **`summarize`**, **`meditate`**.
+Work types: **`feature`**, **`review`**, **`summarize`**.
 Target roughly 2:1 feature:review during implementation; 1:1 during cleanup.
 
 **Summarize trigger**: when 10+ PRs merged since last summarize issue closed.
-**Meditate trigger**: when 15+ PRs merged since last meditate issue closed.
 
 Each issue body MUST be **self-contained**:
 - **Current state**, **Deliverables**, **Context**, **Verification**
@@ -166,7 +165,7 @@ gh issue list --label agent-plan --state open --limit 20 \
 
 For each issue, write the plan body to `plans/<UUID-prefix>-N.md`, then post:
 ```
-coordination plan --label <feature|review|summarize|meditate> "title" < plans/<UUID-prefix>-N.md
+coordination plan --label <feature|review|summarize> "title" < plans/<UUID-prefix>-N.md
 ```
 
 **Adjusting agent pool size**: After assessing the project state, use these

--- a/pod/data/agent-config/codex/commands/plan.md
+++ b/pod/data/agent-config/codex/commands/plan.md
@@ -106,11 +106,10 @@ Your work item MUST NOT overlap with any existing issue's deliverables.
 
 ## Step 6: Write new issues
 
-Work types: **`feature`**, **`review`**, **`summarize`**, **`meditate`**.
+Work types: **`feature`**, **`review`**, **`summarize`**.
 Target roughly 2:1 feature:review during implementation; 1:1 during cleanup.
 
 **Summarize trigger**: when 10+ PRs merged since last summarize issue closed.
-**Meditate trigger**: when 15+ PRs merged since last meditate issue closed.
 
 Each issue body MUST be **self-contained**:
 - **Current state**, **Deliverables**, **Context**, **Verification**
@@ -166,7 +165,7 @@ gh issue list --label agent-plan --state open --limit 20 \
 
 For each issue, write the plan body to `plans/<UUID-prefix>-N.md`, then post:
 ```
-coordination plan --label <feature|review|summarize|meditate> "title" < plans/<UUID-prefix>-N.md
+coordination plan --label <feature|review|summarize> "title" < plans/<UUID-prefix>-N.md
 ```
 
 **Adjusting agent pool size**: After assessing the project state, use these


### PR DESCRIPTION
Drops `meditate` from the planner's default work-types list and removes the 15-PR auto-trigger line in both the Claude and Codex planner prompts.

The `/meditate` command file, `coordination` script, and `/work`'s label dispatch are untouched, so hand-created meditate issues still route correctly — the planner just won't spontaneously produce them. Projects that want meditate back can either hand-create issues with the `meditate` label or re-add the trigger in their own `.claude/commands/plan.md`.

## Summary
- Remove `meditate` from the work-types enumeration in `plan.md`
- Remove the "Meditate trigger: when 15+ PRs merged..." line
- Update the `coordination plan --label <...>` usage hint

## Test plan
- [ ] Planner reads the new prompt and no longer emits meditate issues on its own
- [ ] Hand-creating an issue with the `meditate` label still gets picked up by `/work` → `/meditate`

🤖 Prepared with Claude Code