### PR TITLE
fix: self-heal worktree setup and pause dispatch on low disk

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -34,6 +34,7 @@ import random
 import re
 import signal
 import shutil
+import stat
 import subprocess
 import sys
 import threading
@@ -2851,12 +2852,57 @@ def check_dead_pr_claimed_prs(config: dict):
 # Agent Lifecycle
 # ---------------------------------------------------------------------------
 
+def _remove_path_any(path: Path) -> None:
+    """Remove `path` whatever its type — directory, regular file, symlink
+    (including broken symlink).  Best-effort; logs but doesn't raise.
+
+    ``shutil.rmtree`` is a no-op on non-directories, and ``Path.exists()``
+    returns False for broken symlinks — both pitfalls have bitten this
+    codebase before.  Use ``lexists`` semantics so broken links are seen.
+    """
+    try:
+        # lstat will succeed for broken symlinks where stat won't
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return
+    except OSError as e:
+        log(f"Warning: lstat({path}) failed during scrub: {e}")
+        return
+    try:
+        if stat.S_ISDIR(st.st_mode):
+            shutil.rmtree(str(path), ignore_errors=True)
+        else:
+            # Regular file, symlink (including broken), socket, etc.
+            path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        log(f"Warning: failed to remove {path} during scrub: {e}")
+
+
+def _live_branches(exclude_short_id: str | None = None) -> set[str]:
+    """Branches owned by any non-dead live agent state file.
+
+    ``exclude_short_id`` lets a caller filter out a specific agent
+    (typically itself) so its own pre-registered branch doesn't show up
+    as a "collision" against its own setup.
+    """
+    owned: set[str] = set()
+    for agent in read_all_agents():
+        if agent.short_id == exclude_short_id:
+            continue
+        if agent.branch and agent.status != "dead":
+            owned.add(agent.branch)
+    return owned
+
+
 def _scrub_worktree_remnants(short_id: str, wt_dir: Path) -> None:
     """Best-effort removal of any partial worktree/branch state for short_id.
 
     Handles four kinds of leftovers from a crashed or partially-failed
     ``git worktree add``:
-      - the worktree directory itself (``worktrees/<short_id>``)
+      - the worktree path itself (``worktrees/<short_id>``) — directory,
+        regular file, or symlink (including broken symlink)
       - the worktree admin entry (``.git/worktrees/<short_id>``)
       - a stale branch lock (``.git/refs/heads/agent/<short_id>.lock``)
       - the branch ref (``agent/<short_id>``)
@@ -2865,20 +2911,34 @@ def _scrub_worktree_remnants(short_id: str, wt_dir: Path) -> None:
     ``git worktree add -b`` is non-atomic — it writes the branch ref before
     the worktree dir is fully checked out, so a partial failure (disk full,
     SIGTERM, lock contention) can leave any subset of these behind.
+
+    Catches ``OSError`` and ``TimeoutExpired`` from individual steps so
+    one transient failure (e.g. ``git worktree prune`` timing out) does
+    not abort the whole scrub or escape past callers that only handle
+    ``CalledProcessError``.
     """
     branch = f"agent/{short_id}"
-    if wt_dir.exists():
+    # 1. Unlock first so prune below can sweep the admin entry
+    try:
         subprocess.run(
             ["git", "-C", str(PROJECT_DIR), "worktree", "unlock", str(wt_dir)],
             capture_output=True, timeout=10,
         )
-        shutil.rmtree(str(wt_dir), ignore_errors=True)
-    # Always prune — clears admin entries even when wt_dir is already gone
-    subprocess.run(
-        ["git", "-C", str(PROJECT_DIR), "worktree", "prune"],
-        capture_output=True, timeout=30,
-    )
-    # Clear stale branch lock that can outlive a crashed git process
+    except subprocess.TimeoutExpired:
+        log(f"Warning: 'git worktree unlock {wt_dir}' timed out during scrub")
+    # 2. Remove the worktree path — handles dir, file, and (broken) symlink.
+    #    Use lexists so broken symlinks are seen.
+    if os.path.lexists(str(wt_dir)):
+        _remove_path_any(wt_dir)
+    # 3. Always prune — clears admin entries even when wt_dir is already gone
+    try:
+        subprocess.run(
+            ["git", "-C", str(PROJECT_DIR), "worktree", "prune"],
+            capture_output=True, timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        log("Warning: 'git worktree prune' timed out during scrub")
+    # 4. Clear stale branch lock that can outlive a crashed git process
     lock_path = PROJECT_DIR / ".git" / "refs" / "heads" / f"{branch}.lock"
     try:
         lock_path.unlink()
@@ -2886,54 +2946,101 @@ def _scrub_worktree_remnants(short_id: str, wt_dir: Path) -> None:
         pass
     except OSError as e:
         log(f"Warning: could not remove stale branch lock {lock_path}: {e}")
-    subprocess.run(
-        ["git", "branch", "-D", branch],
-        capture_output=True, timeout=10, cwd=str(PROJECT_DIR),
-    )
+    # 5. Force-delete the branch ref
+    try:
+        subprocess.run(
+            ["git", "branch", "-D", branch],
+            capture_output=True, timeout=10, cwd=str(PROJECT_DIR),
+        )
+    except subprocess.TimeoutExpired:
+        log(f"Warning: 'git branch -D {branch}' timed out during scrub")
 
 
-def setup_worktree(config: dict, short_id: str) -> tuple[str, str]:
+def setup_worktree(config: dict, short_id: str,
+                   *, own_agent_id: str | None = None) -> tuple[str, str]:
     """Create a fresh git worktree. Returns (worktree_path, branch_name).
 
     Self-healing: scrubs any leftover state from a previous crash or
     partial failure before attempting creation, and on failure scrubs
-    again so the next retry starts from a clean slate.  Re-raises
-    ``CalledProcessError`` with the underlying git stderr in the message
-    so callers' logs show *why* git failed, not just the command line.
+    again so the next retry starts from a clean slate.
+
+    Refuses to scrub a worktree/branch already claimed by a *different*
+    live agent (defence against ``session_uuid[:8]`` collisions or
+    operator-supplied short_id reuse) — raises ``CalledProcessError``
+    instead of destroying another agent's working state.  Pass
+    ``own_agent_id`` so the caller's own pre-registered state is not
+    treated as a collision against itself.
+
+    Always raises ``subprocess.CalledProcessError`` on any failure
+    (timeout, OSError, git error), with the underlying stderr embedded
+    in the message so callers can log *why* it failed.  Callers
+    therefore only need to catch one exception type.
     """
     base = PROJECT_DIR / cfg_get(config, "project", "worktree_base", default="worktrees")
     base.mkdir(parents=True, exist_ok=True)
     wt_dir = base / short_id
     branch = f"agent/{short_id}"
 
-    # Fetch latest default branch
+    # Refuse to clobber a worktree/branch claimed by a *different* live
+    # agent.  Defence against the (astronomically rare but possible)
+    # session_uuid[:8] collision: two live sessions with the same
+    # short_id would otherwise have one's setup_worktree wipe the
+    # other's working tree.
+    if branch in _live_branches(exclude_short_id=own_agent_id):
+        raise subprocess.CalledProcessError(
+            1, ("setup_worktree", short_id),
+            output=b"",
+            stderr=(f"refusing to scrub: branch {branch} is owned by another live agent "
+                    f"(short_id collision?)").encode(),
+        )
+
+    # Fetch latest default branch (network failure is non-fatal — git uses
+    # cached refs.  Timeout is swallowed since worktree add will fail
+    # cleanly below if the ref really is missing.)
     base_branch = _get_base_branch()
-    subprocess.run(
-        ["git", "-C", str(PROJECT_DIR), "fetch", "origin", base_branch, "--quiet"],
-        capture_output=True, timeout=60,
-    )
+    try:
+        subprocess.run(
+            ["git", "-C", str(PROJECT_DIR), "fetch", "origin", base_branch, "--quiet"],
+            capture_output=True, timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        log(f"Warning: 'git fetch origin {base_branch}' timed out; using cached refs")
 
     # Scrub any leftover worktree/branch/admin state from a previous crash
     _scrub_worktree_remnants(short_id, wt_dir)
 
-    # Create worktree
+    # Create worktree.  Normalize all failure modes to CalledProcessError
+    # (git non-zero, subprocess timeout, OSError from filesystem) so the
+    # caller in agent_process_main only needs one except clause and the
+    # partial state always gets scrubbed.
+    cmd = ["git", "-C", str(PROJECT_DIR), "worktree", "add", "-b", branch,
+           str(wt_dir), f"origin/{base_branch}", "--quiet"]
     try:
-        r = subprocess.run(
-            ["git", "-C", str(PROJECT_DIR), "worktree", "add", "-b", branch,
-             str(wt_dir), f"origin/{base_branch}", "--quiet"],
-            capture_output=True, timeout=60, check=True,
-        )
+        r = subprocess.run(cmd, capture_output=True, timeout=60, check=True)
     except subprocess.CalledProcessError as e:
-        # git may have created the branch ref before failing on the worktree
-        # checkout (disk full, lock contention, etc.). Scrub the partial
-        # state so the next dispatch attempt isn't blocked by leftovers.
         _scrub_worktree_remnants(short_id, wt_dir)
         stderr = (e.stderr or b"").decode(errors="replace").strip()
-        # Re-raise with stderr embedded so the caller's log shows it
         raise subprocess.CalledProcessError(
             e.returncode, e.cmd,
             output=e.output,
             stderr=(stderr + " [setup_worktree scrubbed partial state]").encode(),
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        _scrub_worktree_remnants(short_id, wt_dir)
+        stderr = (e.stderr or b"").decode(errors="replace").strip() if e.stderr else ""
+        raise subprocess.CalledProcessError(
+            124, cmd,  # 124 = GNU timeout convention
+            output=e.stdout,
+            stderr=(stderr + f" [git worktree add timed out after {e.timeout}s; "
+                    "partial state scrubbed]").encode(),
+        ) from e
+    except OSError as e:
+        _scrub_worktree_remnants(short_id, wt_dir)
+        raise subprocess.CalledProcessError(
+            1, cmd,
+            output=b"",
+            stderr=(f"OSError invoking git worktree add: {e} "
+                    "[partial state scrubbed]").encode(),
         ) from e
 
     if not wt_dir.exists():
@@ -3338,10 +3445,7 @@ def cleanup_stale_branches(config: dict, *, verbose: bool = False,
         return 0
 
     # Branches referenced by live (non-dead) agents — never delete these
-    live_branches: set[str] = set()
-    for agent in read_all_agents():
-        if agent.branch and agent.status != "dead":
-            live_branches.add(agent.branch)
+    live_branches = _live_branches()
 
     now = time.time()
     deleted = 0
@@ -3382,13 +3486,47 @@ def cleanup_stale_branches(config: dict, *, verbose: bool = False,
     return deleted
 
 
+def _distinct_mounts(*paths: Path) -> list[Path]:
+    """Return one representative path per distinct filesystem device.
+
+    Walks each input path upward until it finds an existing ancestor
+    (``shutil.disk_usage`` rejects non-existent paths), then dedupes by
+    ``st_dev``.  Used by ``_disk_low`` so we check every volume the
+    project writes to, not just ``PROJECT_DIR``.
+    """
+    seen_devs: set[int] = set()
+    out: list[Path] = []
+    for p in paths:
+        # Walk upward until something exists — covers configured paths
+        # whose leaf hasn't been created yet.
+        probe: Path = p
+        while not probe.exists() and probe != probe.parent:
+            probe = probe.parent
+        if not probe.exists():
+            continue
+        try:
+            dev = probe.stat().st_dev
+        except OSError:
+            continue
+        if dev in seen_devs:
+            continue
+        seen_devs.add(dev)
+        out.append(probe)
+    return out
+
+
 def _disk_low(config: dict) -> str | None:
     """Return a human-readable reason if free disk is below the configured
-    threshold, else None.
+    threshold on any volume the project writes to, else None.
 
-    Used to pause dispatch before a disk-full event corrupts worktree state
-    (the canonical failure mode: ``git worktree add`` half-completes,
-    leaving an orphan branch that blocks future dispatches).
+    Checks every distinct filesystem hosting ``PROJECT_DIR``,
+    ``project.worktree_base``, or ``project.session_dir`` — so an
+    absolute ``session_dir`` on a separate volume is covered, not just
+    the project filesystem.
+
+    Used to pause dispatch before a disk-full event corrupts worktree
+    state (the canonical failure mode: ``git worktree add`` half-
+    completes, leaving an orphan branch that blocks future dispatches).
     """
     try:
         min_gb = float(cfg_get(config, "project", "min_free_disk_gb", default=2))
@@ -3396,13 +3534,21 @@ def _disk_low(config: dict) -> str | None:
         min_gb = 2.0
     if min_gb <= 0:
         return None
-    try:
-        usage = shutil.disk_usage(str(PROJECT_DIR))
-    except OSError as e:
-        return f"disk_usage check failed: {e}"
-    free_gb = usage.free / (1024 ** 3)
-    if free_gb < min_gb:
-        return f"{free_gb:.2f} GiB free < {min_gb:.2f} GiB threshold"
+
+    worktree_base = PROJECT_DIR / cfg_get(config, "project", "worktree_base", default="worktrees")
+    session_dir = PROJECT_DIR / cfg_get(config, "project", "session_dir", default="sessions")
+    targets = _distinct_mounts(PROJECT_DIR, worktree_base, session_dir)
+    if not targets:
+        targets = [PROJECT_DIR]
+
+    for probe in targets:
+        try:
+            usage = shutil.disk_usage(str(probe))
+        except OSError as e:
+            return f"disk_usage({probe}) failed: {e}"
+        free_gb = usage.free / (1024 ** 3)
+        if free_gb < min_gb:
+            return f"{free_gb:.2f} GiB free at {probe} < {min_gb:.2f} GiB threshold"
     return None
 
 
@@ -4159,7 +4305,7 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         state.write()
 
         try:
-            wt_dir, branch = setup_worktree(config, session_short)
+            wt_dir, branch = setup_worktree(config, session_short, own_agent_id=short_id)
         except subprocess.CalledProcessError as e:
             stderr_text = (e.stderr or b"").decode(errors="replace").strip()
             log(f"Agent {short_id}: worktree setup failed: {e}"

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -99,6 +99,7 @@ worktree_base = "worktrees"        # Where git worktrees are created
 session_dir = "sessions"           # Session stdout capture directory
 build_cache_dir = ".lake"          # Build cache to rsync into worktrees
 protected_files = ["PLAN.md"]      # Files agents may not modify in PRs
+min_free_disk_gb = 2               # Pause dispatch when free disk drops below this
 
 [merge]
 # Status check contexts that must pass before a PR can auto-merge.
@@ -2850,8 +2851,56 @@ def check_dead_pr_claimed_prs(config: dict):
 # Agent Lifecycle
 # ---------------------------------------------------------------------------
 
+def _scrub_worktree_remnants(short_id: str, wt_dir: Path) -> None:
+    """Best-effort removal of any partial worktree/branch state for short_id.
+
+    Handles four kinds of leftovers from a crashed or partially-failed
+    ``git worktree add``:
+      - the worktree directory itself (``worktrees/<short_id>``)
+      - the worktree admin entry (``.git/worktrees/<short_id>``)
+      - a stale branch lock (``.git/refs/heads/agent/<short_id>.lock``)
+      - the branch ref (``agent/<short_id>``)
+
+    Idempotent: safe to call when nothing exists.  We need this because
+    ``git worktree add -b`` is non-atomic — it writes the branch ref before
+    the worktree dir is fully checked out, so a partial failure (disk full,
+    SIGTERM, lock contention) can leave any subset of these behind.
+    """
+    branch = f"agent/{short_id}"
+    if wt_dir.exists():
+        subprocess.run(
+            ["git", "-C", str(PROJECT_DIR), "worktree", "unlock", str(wt_dir)],
+            capture_output=True, timeout=10,
+        )
+        shutil.rmtree(str(wt_dir), ignore_errors=True)
+    # Always prune — clears admin entries even when wt_dir is already gone
+    subprocess.run(
+        ["git", "-C", str(PROJECT_DIR), "worktree", "prune"],
+        capture_output=True, timeout=30,
+    )
+    # Clear stale branch lock that can outlive a crashed git process
+    lock_path = PROJECT_DIR / ".git" / "refs" / "heads" / f"{branch}.lock"
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        log(f"Warning: could not remove stale branch lock {lock_path}: {e}")
+    subprocess.run(
+        ["git", "branch", "-D", branch],
+        capture_output=True, timeout=10, cwd=str(PROJECT_DIR),
+    )
+
+
 def setup_worktree(config: dict, short_id: str) -> tuple[str, str]:
-    """Create a fresh git worktree. Returns (worktree_path, branch_name)."""
+    """Create a fresh git worktree. Returns (worktree_path, branch_name).
+
+    Self-healing: scrubs any leftover state from a previous crash or
+    partial failure before attempting creation, and on failure scrubs
+    again so the next retry starts from a clean slate.  Re-raises
+    ``CalledProcessError`` with the underlying git stderr in the message
+    so callers' logs show *why* git failed, not just the command line.
+    """
     base = PROJECT_DIR / cfg_get(config, "project", "worktree_base", default="worktrees")
     base.mkdir(parents=True, exist_ok=True)
     wt_dir = base / short_id
@@ -2864,33 +2913,35 @@ def setup_worktree(config: dict, short_id: str) -> tuple[str, str]:
         capture_output=True, timeout=60,
     )
 
-    # Clean up any leftover worktree/branch from a crash
-    if wt_dir.exists():
-        # Unlock first — locked worktrees survive prune even when the dir is gone
-        subprocess.run(
-            ["git", "-C", str(PROJECT_DIR), "worktree", "unlock", str(wt_dir)],
-            capture_output=True, timeout=10,
-        )
-        shutil.rmtree(str(wt_dir), ignore_errors=True)
-        subprocess.run(
-            ["git", "-C", str(PROJECT_DIR), "worktree", "prune"],
-            capture_output=True, timeout=30,
-        )
-    subprocess.run(
-        ["git", "branch", "-D", branch],
-        capture_output=True, timeout=10, cwd=str(PROJECT_DIR),
-    )
+    # Scrub any leftover worktree/branch/admin state from a previous crash
+    _scrub_worktree_remnants(short_id, wt_dir)
 
     # Create worktree
-    r = subprocess.run(
-        ["git", "-C", str(PROJECT_DIR), "worktree", "add", "-b", branch,
-         str(wt_dir), f"origin/{base_branch}", "--quiet"],
-        capture_output=True, timeout=60, check=True,
-    )
-    if not wt_dir.exists():
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(PROJECT_DIR), "worktree", "add", "-b", branch,
+             str(wt_dir), f"origin/{base_branch}", "--quiet"],
+            capture_output=True, timeout=60, check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        # git may have created the branch ref before failing on the worktree
+        # checkout (disk full, lock contention, etc.). Scrub the partial
+        # state so the next dispatch attempt isn't blocked by leftovers.
+        _scrub_worktree_remnants(short_id, wt_dir)
+        stderr = (e.stderr or b"").decode(errors="replace").strip()
+        # Re-raise with stderr embedded so the caller's log shows it
         raise subprocess.CalledProcessError(
-            0, "git worktree add",
-            output=r.stdout, stderr=(r.stderr + b" [dir not created]"),
+            e.returncode, e.cmd,
+            output=e.output,
+            stderr=(stderr + " [setup_worktree scrubbed partial state]").encode(),
+        ) from e
+
+    if not wt_dir.exists():
+        _scrub_worktree_remnants(short_id, wt_dir)
+        raise subprocess.CalledProcessError(
+            1, "git worktree add",
+            output=r.stdout,
+            stderr=(r.stderr + b" [dir not created; partial state scrubbed]"),
         )
 
     return str(wt_dir), branch
@@ -3208,9 +3259,12 @@ def _cleanup_stale_worktrees_locked(
              str(entry)],
             capture_output=True, timeout=10,
         )
+        # Worktrees may contain large build outputs (e.g. Lake .lake dirs
+        # with 100k+ files) that take well over 2 minutes to remove on
+        # spinning disks or busy SSDs.  600s gives realistic headroom.
         r = subprocess.run(
             ["rm", "-rf", str(entry)],
-            capture_output=True, timeout=120,
+            capture_output=True, timeout=600,
         )
         return r.returncode == 0 and not entry.exists()
 
@@ -3253,6 +3307,103 @@ def _cleanup_stale_worktrees_locked(
         log(msg)
 
     return removed
+
+
+# Minimum age before an orphan agent/* branch is eligible for cleanup.
+# Protects against racing with a setup_worktree() call that has just
+# created the branch but hasn't finished checking out the worktree.
+STALE_BRANCH_MIN_AGE_SECONDS = 300
+
+
+def cleanup_stale_branches(config: dict, *, verbose: bool = False,
+                           min_age: float = STALE_BRANCH_MIN_AGE_SECONDS) -> int:
+    """Delete ``agent/*`` branches with no worktree and no live owner.
+
+    Why: ``git worktree add -b`` is non-atomic — it creates the branch
+    ref before the worktree dir is fully checked out.  When that second
+    step fails (disk full, lock contention, signal), the branch persists
+    and becomes a permanent leftover.  Over time this accumulates
+    hundreds of dead refs that bloat ``.git/refs/heads/agent/`` and can
+    collide with future session UUIDs.
+
+    Safety:
+      - Only deletes branches whose worktree dir does **not** exist.
+      - Skips branches referenced by any live agent state file.
+      - Skips branches younger than ``min_age`` seconds (default 5 min)
+        to avoid racing with an in-flight ``setup_worktree`` call.
+    """
+    base = PROJECT_DIR / cfg_get(config, "project", "worktree_base", default="worktrees")
+    refs_dir = PROJECT_DIR / ".git" / "refs" / "heads" / "agent"
+    if not refs_dir.is_dir():
+        return 0
+
+    # Branches referenced by live (non-dead) agents — never delete these
+    live_branches: set[str] = set()
+    for agent in read_all_agents():
+        if agent.branch and agent.status != "dead":
+            live_branches.add(agent.branch)
+
+    now = time.time()
+    deleted = 0
+    skipped_young = 0
+    skipped_live = 0
+    skipped_has_worktree = 0
+    for ref in sorted(refs_dir.iterdir()):
+        if not ref.is_file():
+            continue
+        short_id = ref.name
+        branch = f"agent/{short_id}"
+        if branch in live_branches:
+            skipped_live += 1
+            continue
+        if (base / short_id).exists():
+            skipped_has_worktree += 1
+            continue
+        try:
+            age = now - ref.stat().st_mtime
+        except OSError:
+            continue
+        if age < min_age:
+            skipped_young += 1
+            continue
+        r = subprocess.run(
+            ["git", "branch", "-D", branch],
+            capture_output=True, text=True, timeout=10, cwd=str(PROJECT_DIR),
+        )
+        if r.returncode == 0:
+            deleted += 1
+        elif verbose:
+            log(f"cleanup_stale_branches: failed to delete {branch}: {r.stderr.strip()}")
+
+    if verbose and (deleted or skipped_young or skipped_live or skipped_has_worktree):
+        log(f"cleanup_stale_branches: deleted={deleted} "
+            f"skipped(young={skipped_young}, live={skipped_live}, "
+            f"has_worktree={skipped_has_worktree})")
+    return deleted
+
+
+def _disk_low(config: dict) -> str | None:
+    """Return a human-readable reason if free disk is below the configured
+    threshold, else None.
+
+    Used to pause dispatch before a disk-full event corrupts worktree state
+    (the canonical failure mode: ``git worktree add`` half-completes,
+    leaving an orphan branch that blocks future dispatches).
+    """
+    try:
+        min_gb = float(cfg_get(config, "project", "min_free_disk_gb", default=2))
+    except (TypeError, ValueError):
+        min_gb = 2.0
+    if min_gb <= 0:
+        return None
+    try:
+        usage = shutil.disk_usage(str(PROJECT_DIR))
+    except OSError as e:
+        return f"disk_usage check failed: {e}"
+    free_gb = usage.free / (1024 ** 3)
+    if free_gb < min_gb:
+        return f"{free_gb:.2f} GiB free < {min_gb:.2f} GiB threshold"
+    return None
 
 
 def _log_credential_state(session_uuid: str, claude_config_dir: Path | None = None):
@@ -3913,6 +4064,23 @@ def agent_process_main(config: dict, agent_id: str | None = None,
                 cleanup_stale_worktrees(config, verbose=True)
             except Exception:
                 pass
+            try:
+                cleanup_stale_branches(config, verbose=True)
+            except Exception:
+                pass
+
+        # --- Disk-space guard ---
+        # Pause dispatch when free disk drops below the configured threshold.
+        # A disk-full event during ``git worktree add`` corrupts state in ways
+        # that take manual cleanup to recover from (orphan branch refs that
+        # block all future dispatches), so it's much cheaper to back off here.
+        disk_reason = _disk_low(config)
+        if disk_reason:
+            log(f"Agent {short_id}: pausing dispatch — disk low ({disk_reason})")
+            state.status = "waiting_disk"
+            state.write()
+            time.sleep(60)
+            continue
 
         # --- Dispatch (sets state.lock_held atomically if lock acquired) ---
         # If this agent was spawned to resume a specific session, skip dispatch.
@@ -3993,7 +4161,9 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         try:
             wt_dir, branch = setup_worktree(config, session_short)
         except subprocess.CalledProcessError as e:
-            log(f"Agent {short_id}: worktree setup failed: {e}")
+            stderr_text = (e.stderr or b"").decode(errors="replace").strip()
+            log(f"Agent {short_id}: worktree setup failed: {e}"
+                + (f" — stderr: {stderr_text}" if stderr_text else ""))
             state.worktree = ""
             state.branch = ""
             if lock_name:

--- a/tests/test_worktree_self_heal.py
+++ b/tests/test_worktree_self_heal.py
@@ -1,0 +1,256 @@
+"""Tests for the worktree self-healing path and disk-space guard.
+
+These cover the changes that prevent the dispatch -> error -> dispatch
+loop seen after a disk-full event:
+
+  - ``_scrub_worktree_remnants`` is idempotent and clears all four kinds
+    of leftover state (branch ref, branch lock, admin dir, worktree dir).
+  - ``setup_worktree`` re-raises with stderr embedded on failure, and
+    scrubs partial state so retries get a clean slate.
+  - ``cleanup_stale_branches`` deletes orphan ``agent/*`` refs but
+    respects live agents, existing worktrees, and the min-age window.
+  - ``_disk_low`` correctly classifies free-disk values against the
+    configured threshold.
+"""
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pod import cli
+
+
+def _git(args, cwd):
+    """Run a git command, raising if it fails."""
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True, check=True, text=True,
+    )
+
+
+def _init_repo(root: Path) -> Path:
+    """Create a bare-bones repo with one commit so worktrees can branch off.
+
+    Adds a self-pointing ``origin`` remote and fetches it so that
+    ``setup_worktree`` (which always uses ``origin/<base>``) works.
+    """
+    _git(["init", "-q", "-b", "main"], cwd=root)
+    _git(["config", "user.email", "test@example.com"], cwd=root)
+    _git(["config", "user.name", "test"], cwd=root)
+    (root / "README").write_text("hi\n")
+    _git(["add", "."], cwd=root)
+    _git(["commit", "-q", "-m", "init"], cwd=root)
+    _git(["remote", "add", "origin", str(root)], cwd=root)
+    _git(["fetch", "-q", "origin", "main"], cwd=root)
+    return root
+
+
+class ScrubRemnantsTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = _init_repo(Path(self._tmp.name))
+        self._patches = [
+            mock.patch.object(cli, "PROJECT_DIR", self.root),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_idempotent_when_nothing_exists(self):
+        # Should not raise even though branch/dir/admin all absent
+        cli._scrub_worktree_remnants("deadbeef", self.root / "worktrees" / "deadbeef")
+
+    def test_removes_orphan_branch_ref(self):
+        # Create a branch that points at HEAD but has no worktree
+        _git(["branch", "agent/abc12345"], cwd=self.root)
+        ref = self.root / ".git" / "refs" / "heads" / "agent" / "abc12345"
+        self.assertTrue(ref.exists())
+
+        cli._scrub_worktree_remnants("abc12345", self.root / "worktrees" / "abc12345")
+
+        self.assertFalse(ref.exists(), "orphan branch ref should be deleted")
+
+    def test_removes_stale_branch_lock(self):
+        # Simulate a crashed git process that left a .lock file
+        ref_dir = self.root / ".git" / "refs" / "heads" / "agent"
+        ref_dir.mkdir(parents=True)
+        lock = ref_dir / "abc12345.lock"
+        lock.write_text("garbage\n")
+
+        cli._scrub_worktree_remnants("abc12345", self.root / "worktrees" / "abc12345")
+
+        self.assertFalse(lock.exists(), "stale branch lock should be cleaned up")
+
+    def test_removes_existing_worktree_dir_and_admin_entry(self):
+        # Make a real worktree, then verify scrub cleans both the dir and the
+        # admin entry under .git/worktrees/.
+        wt_dir = self.root / "worktrees" / "abc12345"
+        _git(["worktree", "add", "-b", "agent/abc12345", str(wt_dir), "main", "--quiet"],
+             cwd=self.root)
+        admin = self.root / ".git" / "worktrees" / "abc12345"
+        self.assertTrue(wt_dir.exists())
+        self.assertTrue(admin.exists())
+
+        cli._scrub_worktree_remnants("abc12345", wt_dir)
+
+        self.assertFalse(wt_dir.exists())
+        self.assertFalse(admin.exists(), "git worktree prune should drop the admin entry")
+        # And the branch
+        ref = self.root / ".git" / "refs" / "heads" / "agent" / "abc12345"
+        self.assertFalse(ref.exists())
+
+
+class SetupWorktreeFailureTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = _init_repo(Path(self._tmp.name))
+        self._patches = [
+            mock.patch.object(cli, "PROJECT_DIR", self.root),
+            mock.patch.object(cli, "_get_base_branch", return_value="main"),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_success_creates_worktree_and_branch(self):
+        wt_dir, branch = cli.setup_worktree({}, "11111111")
+        self.assertTrue(Path(wt_dir).exists())
+        self.assertEqual(branch, "agent/11111111")
+        # Cleanup so worktree handles don't leak between tests
+        cli._scrub_worktree_remnants("11111111", Path(wt_dir))
+
+    def test_failure_scrubs_partial_state_and_surfaces_stderr(self):
+        # Pre-create the destination as a *file* so `git worktree add` fails
+        # with a clear error after creating the branch ref. This mimics the
+        # disk-full / lock-contention failure mode where git creates the
+        # branch then trips on the worktree directory.
+        wt_dir = self.root / "worktrees" / "22222222"
+        wt_dir.parent.mkdir(parents=True, exist_ok=True)
+        wt_dir.write_text("not a directory\n")  # blocks worktree creation
+
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            cli.setup_worktree({}, "22222222")
+
+        # stderr from git is surfaced (decoded) in the re-raised exception
+        stderr = (cm.exception.stderr or b"").decode(errors="replace")
+        self.assertTrue(stderr, "stderr should be non-empty so the caller can log why git failed")
+        self.assertIn("scrubbed partial state", stderr)
+
+        # Partial state was scrubbed: no orphan branch ref left over
+        ref = self.root / ".git" / "refs" / "heads" / "agent" / "22222222"
+        self.assertFalse(ref.exists(),
+                         "branch ref must be scrubbed so the next dispatch attempt can reuse the slot")
+
+        # Clean up the blocker file
+        wt_dir.unlink()
+
+
+class CleanupStaleBranchesTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = _init_repo(Path(self._tmp.name))
+        agents_dir = self.root / ".pod" / "agents"
+        agents_dir.mkdir(parents=True)
+        self._patches = [
+            mock.patch.object(cli, "PROJECT_DIR", self.root),
+            mock.patch.object(cli, "AGENTS_DIR", agents_dir),
+            mock.patch.object(cli, "read_all_agents", return_value=[]),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _make_branch(self, short_id: str, *, age_seconds: float = 1000.0) -> Path:
+        _git(["branch", f"agent/{short_id}"], cwd=self.root)
+        ref = self.root / ".git" / "refs" / "heads" / "agent" / short_id
+        if age_seconds:
+            past = ref.stat().st_mtime - age_seconds
+            os.utime(ref, (past, past))
+        return ref
+
+    def test_deletes_orphan_branch_with_no_worktree(self):
+        ref = self._make_branch("aaaaaaaa")
+
+        deleted = cli.cleanup_stale_branches({}, min_age=0)
+
+        self.assertEqual(deleted, 1)
+        self.assertFalse(ref.exists())
+
+    def test_skips_branch_with_existing_worktree_dir(self):
+        ref = self._make_branch("bbbbbbbb")
+        # Worktree dir exists (e.g. an in-flight setup_worktree just created it)
+        (self.root / "worktrees" / "bbbbbbbb").mkdir(parents=True)
+
+        deleted = cli.cleanup_stale_branches({}, min_age=0)
+
+        self.assertEqual(deleted, 0)
+        self.assertTrue(ref.exists())
+
+    def test_skips_branch_referenced_by_live_agent(self):
+        ref = self._make_branch("cccccccc")
+
+        live = cli.AgentState(
+            uuid="some-session", short_id="agent01",
+            branch="agent/cccccccc", status="working",
+        )
+        with mock.patch.object(cli, "read_all_agents", return_value=[live]):
+            deleted = cli.cleanup_stale_branches({}, min_age=0)
+
+        self.assertEqual(deleted, 0)
+        self.assertTrue(ref.exists())
+
+    def test_skips_young_branch(self):
+        # Just-created (mtime = now)
+        ref = self._make_branch("dddddddd", age_seconds=0)
+
+        deleted = cli.cleanup_stale_branches({}, min_age=300)
+
+        self.assertEqual(deleted, 0,
+                         "must not delete a branch that may belong to an in-flight setup_worktree")
+        self.assertTrue(ref.exists())
+
+
+class DiskLowTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        patcher = mock.patch.object(cli, "PROJECT_DIR", self.root)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _patch_free(self, free_gib: float):
+        # disk_usage returns a namedtuple-like with .free in bytes
+        usage = mock.MagicMock()
+        usage.free = int(free_gib * (1024 ** 3))
+        return mock.patch("pod.cli.shutil.disk_usage", return_value=usage)
+
+    def test_returns_none_when_disk_above_threshold(self):
+        with self._patch_free(50.0):
+            self.assertIsNone(cli._disk_low({"project": {"min_free_disk_gb": 2}}))
+
+    def test_returns_reason_when_below_threshold(self):
+        with self._patch_free(0.5):
+            reason = cli._disk_low({"project": {"min_free_disk_gb": 2}})
+            self.assertIsNotNone(reason)
+            self.assertIn("0.50", reason)
+            self.assertIn("2.00", reason)
+
+    def test_threshold_zero_disables_check(self):
+        with self._patch_free(0.001):
+            self.assertIsNone(cli._disk_low({"project": {"min_free_disk_gb": 0}}))
+
+    def test_default_threshold_is_two_gb(self):
+        with self._patch_free(1.5):
+            self.assertIsNotNone(cli._disk_low({}))
+        with self._patch_free(5.0):
+            self.assertIsNone(cli._disk_low({}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_worktree_self_heal.py
+++ b/tests/test_worktree_self_heal.py
@@ -102,6 +102,34 @@ class ScrubRemnantsTests(unittest.TestCase):
         ref = self.root / ".git" / "refs" / "heads" / "agent" / "abc12345"
         self.assertFalse(ref.exists())
 
+    def test_removes_regular_file_at_worktree_path(self):
+        # shutil.rmtree(..., ignore_errors=True) is a no-op on regular files.
+        # The scrub must dispatch on file type so a file blocker actually goes
+        # away — otherwise the next setup_worktree retry still fails.
+        wt_dir = self.root / "worktrees" / "ffffffff"
+        wt_dir.parent.mkdir(parents=True, exist_ok=True)
+        wt_dir.write_text("not a directory\n")
+        self.assertTrue(wt_dir.is_file())
+
+        cli._scrub_worktree_remnants("ffffffff", wt_dir)
+
+        self.assertFalse(wt_dir.exists(), "regular file blocker must be removed")
+
+    def test_removes_broken_symlink_at_worktree_path(self):
+        # Path.exists() returns False for broken symlinks — so the old
+        # if-exists guard would skip them and leave them in place to block
+        # the retry.  Verify lexists semantics actually clean up.
+        wt_dir = self.root / "worktrees" / "55555555"
+        wt_dir.parent.mkdir(parents=True, exist_ok=True)
+        wt_dir.symlink_to(self.root / "definitely_does_not_exist")
+        self.assertFalse(wt_dir.exists(), "broken symlink: exists() == False")
+        self.assertTrue(wt_dir.is_symlink())
+
+        cli._scrub_worktree_remnants("55555555", wt_dir)
+
+        self.assertFalse(wt_dir.is_symlink(), "broken-symlink blocker must be removed")
+        self.assertFalse(os.path.lexists(str(wt_dir)))
+
 
 class SetupWorktreeFailureTests(unittest.TestCase):
     def setUp(self):
@@ -123,30 +151,90 @@ class SetupWorktreeFailureTests(unittest.TestCase):
         # Cleanup so worktree handles don't leak between tests
         cli._scrub_worktree_remnants("11111111", Path(wt_dir))
 
-    def test_failure_scrubs_partial_state_and_surfaces_stderr(self):
-        # Pre-create the destination as a *file* so `git worktree add` fails
-        # with a clear error after creating the branch ref. This mimics the
-        # disk-full / lock-contention failure mode where git creates the
-        # branch then trips on the worktree directory.
+    def test_file_blocker_is_self_healed_and_setup_succeeds(self):
+        # A regular file at wt_dir is the exact failure mode left behind
+        # by some partial git failures.  After the fix, setup_worktree
+        # should clean it up and succeed without manual intervention.
         wt_dir = self.root / "worktrees" / "22222222"
         wt_dir.parent.mkdir(parents=True, exist_ok=True)
-        wt_dir.write_text("not a directory\n")  # blocks worktree creation
+        wt_dir.write_text("not a directory\n")
 
-        with self.assertRaises(subprocess.CalledProcessError) as cm:
-            cli.setup_worktree({}, "22222222")
+        out_dir, branch = cli.setup_worktree({}, "22222222")
 
-        # stderr from git is surfaced (decoded) in the re-raised exception
+        self.assertTrue(Path(out_dir).is_dir(),
+                        "scrub must remove the file blocker so setup succeeds")
+        self.assertEqual(branch, "agent/22222222")
+        cli._scrub_worktree_remnants("22222222", Path(out_dir))
+
+    def test_failure_scrubs_partial_state_and_surfaces_stderr(self):
+        # Force the underlying `git worktree add` to fail by pointing at a
+        # nonexistent base ref.  Verifies the failure path: stderr is
+        # surfaced and any partial state is scrubbed.
+        with mock.patch.object(cli, "_get_base_branch", return_value="nonexistent_ref"):
+            with self.assertRaises(subprocess.CalledProcessError) as cm:
+                cli.setup_worktree({}, "33333333")
+
         stderr = (cm.exception.stderr or b"").decode(errors="replace")
-        self.assertTrue(stderr, "stderr should be non-empty so the caller can log why git failed")
+        self.assertTrue(stderr,
+                        "stderr should be non-empty so the caller can log why git failed")
         self.assertIn("scrubbed partial state", stderr)
 
-        # Partial state was scrubbed: no orphan branch ref left over
-        ref = self.root / ".git" / "refs" / "heads" / "agent" / "22222222"
-        self.assertFalse(ref.exists(),
-                         "branch ref must be scrubbed so the next dispatch attempt can reuse the slot")
+        # No leftover branch ref to block the next attempt
+        ref = self.root / ".git" / "refs" / "heads" / "agent" / "33333333"
+        self.assertFalse(ref.exists())
 
-        # Clean up the blocker file
-        wt_dir.unlink()
+    def test_timeout_normalised_to_called_process_error(self):
+        # subprocess.TimeoutExpired must not escape — it bypasses the
+        # caller's CalledProcessError except clause and leaves the agent
+        # half-set-up.  Verify the conversion.
+        cmd_calls = []
+        real_run = subprocess.run
+
+        def faulty_run(args, *a, **kw):
+            cmd_calls.append(args)
+            # Time out only on the actual `worktree add` invocation
+            if isinstance(args, list) and "add" in args and "worktree" in args:
+                raise subprocess.TimeoutExpired(cmd=args, timeout=kw.get("timeout", 60))
+            return real_run(args, *a, **kw)
+
+        with mock.patch.object(cli.subprocess, "run", side_effect=faulty_run):
+            with self.assertRaises(subprocess.CalledProcessError) as cm:
+                cli.setup_worktree({}, "44444444")
+
+        stderr = (cm.exception.stderr or b"").decode(errors="replace")
+        self.assertIn("timed out", stderr)
+        self.assertIn("scrubbed", stderr)
+        # Branch must not remain
+        ref = self.root / ".git" / "refs" / "heads" / "agent" / "44444444"
+        self.assertFalse(ref.exists())
+
+    def test_refuses_to_clobber_live_agent_branch(self):
+        # If another live agent already owns this branch (short_id
+        # collision), setup_worktree must refuse rather than scrubbing
+        # the other agent's working state.
+        live = cli.AgentState(
+            uuid="other-session", short_id="otheragent",
+            branch="agent/77777777", status="working",
+        )
+        with mock.patch.object(cli, "read_all_agents", return_value=[live]):
+            with self.assertRaises(subprocess.CalledProcessError) as cm:
+                cli.setup_worktree({}, "77777777")
+
+        stderr = (cm.exception.stderr or b"").decode(errors="replace")
+        self.assertIn("owned by another live agent", stderr)
+
+    def test_excludes_self_via_own_agent_id(self):
+        # The collision check must NOT trigger for the agent's own
+        # pre-registered state — that would self-deadlock every dispatch.
+        own = cli.AgentState(
+            uuid="my-session", short_id="myagent",
+            branch="agent/88888888", status="dispatching",
+        )
+        with mock.patch.object(cli, "read_all_agents", return_value=[own]):
+            out_dir, branch = cli.setup_worktree({}, "88888888", own_agent_id="myagent")
+
+        self.assertTrue(Path(out_dir).is_dir())
+        cli._scrub_worktree_remnants("88888888", Path(out_dir))
 
 
 class CleanupStaleBranchesTests(unittest.TestCase):
@@ -250,6 +338,49 @@ class DiskLowTests(unittest.TestCase):
             self.assertIsNotNone(cli._disk_low({}))
         with self._patch_free(5.0):
             self.assertIsNone(cli._disk_low({}))
+
+    def test_checks_distinct_mountpoints(self):
+        # When session_dir lives on a different volume, _disk_low must
+        # check that volume too — not just PROJECT_DIR.
+        config = {"project": {"min_free_disk_gb": 2}}
+
+        # First volume (PROJECT_DIR) has plenty; second (session_dir) is full.
+        # Stub disk_usage to vary by path.
+        def fake_usage(path):
+            usage = mock.MagicMock()
+            usage.free = int(0.5 * (1024 ** 3)) if "session" in str(path) else int(50 * (1024 ** 3))
+            return usage
+
+        # Stub _distinct_mounts to return both PROJECT_DIR and a sessions dir,
+        # so we exercise the per-mount loop.
+        sess = self.root / "sessions_on_other_volume"
+        sess.mkdir()
+        with mock.patch("pod.cli.shutil.disk_usage", side_effect=fake_usage), \
+             mock.patch.object(cli, "_distinct_mounts", return_value=[self.root, sess]):
+            reason = cli._disk_low(config)
+
+        self.assertIsNotNone(reason)
+        self.assertIn("sessions_on_other_volume", reason)
+
+
+class DistinctMountsTests(unittest.TestCase):
+    def test_dedupes_by_st_dev(self):
+        # All paths under the same tmp dir share st_dev — should collapse to one.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            a = root / "a"; a.mkdir()
+            b = root / "b"; b.mkdir()
+            mounts = cli._distinct_mounts(root, a, b)
+            self.assertEqual(len(mounts), 1, f"all under same fs but got {mounts}")
+
+    def test_walks_up_to_existing_ancestor(self):
+        # If a configured leaf doesn't exist yet, walk up so disk_usage works.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            phantom = root / "does" / "not" / "exist" / "yet"
+            mounts = cli._distinct_mounts(phantom)
+            self.assertEqual(len(mounts), 1)
+            self.assertTrue(mounts[0].exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes pod recover from disk-full events (and other partial-failure modes of `git worktree add`) without manual intervention, and prevents the dispatch -> error -> dispatch loop that we hit after one such event.

**Background.** A disk-full incident left an `Etingof` checkout with hundreds of orphan `agent/*` branch refs and a hung dispatcher. Root cause: `git worktree add -b agent/<id> path origin/main` is non-atomic. It creates the branch ref first and then checks out the worktree directory. When the second step fails (disk full, lock contention, SIGTERM), the branch persists with no worktree. The next dispatch attempt at the same `short_id` then fails on `branch already exists`, and the existing cleanup code only handles the `wt_dir.exists()` case. The original stderr was discarded, so the failure looked like a mystery `exit 255` in the log.

Five changes, one PR:

A. `setup_worktree` now re-raises `CalledProcessError` with git's stderr embedded, so the caller's log shows *why* git failed, not just the command line.

B. New `_scrub_worktree_remnants` helper clears all four kinds of leftover state (worktree dir, `.git/worktrees/<id>` admin entry, `agent/<id>.lock`, branch ref) both before *and* after the `git worktree add`. Partial failure no longer permanently jams the same `short_id`.

C. The stale-worktree cleanup `rm -rf` timeout goes from 120s to 600s. Lake build dirs routinely have 100k+ files and were timing out on real worktrees, leaving them stuck as `prunable`.

D. New `cleanup_stale_branches` helper deletes orphan `agent/*` refs in the housekeeping loop. Safety: only deletes branches with no worktree dir, no live agent owner, and at least 5 minutes old (so it can't race with an in-flight `setup_worktree`).

E. New `_disk_low` guard pauses dispatch when free disk drops below `project.min_free_disk_gb` (default 2 GiB). Prevents the original incident from recurring at all.

14 new tests cover scrubbing idempotency, the four leftover-state classes, `setup_worktree` failure paths (success + stderr-surfaced failure), the stale-branch GC safety predicates (worktree-exists / live-owner / young-branch), and the disk-low classifier (above/below threshold, zero-disables, default value).

Full suite: 84 passed.

🤖 Prepared with Claude Code