### PR TITLE
feat: refuse to dispatch on public repos without GitHub interaction limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,24 @@ gh api -X PUT repos/<owner>/<repo>/interaction-limits \
   -f limit=collaborators_only -f expiry=six_months
 ```
 
-GitHub interaction limits expire (max `six_months`), so the check runs
-on every `pod` startup and you'll need to renew periodically. The
-`[security]` section of `.pod/config.toml` exposes
-`enforce_interaction_limits`, `minimum_interaction_limit`, and
+The check runs at the top of `spawn_agent`, so every dispatch path is
+gated (`pod add`, TUI auto-spawn, dead-session restart). Results are
+cached for 5 minutes to bound API calls during burst spawning while
+still detecting limit removal/expiry inside long-running pod processes.
+
+GitHub interaction limits expire (max `six_months`), so you'll need to
+renew periodically. The `[security]` section of `.pod/config.toml`
+exposes `enforce_interaction_limits`, `minimum_interaction_limit`, and
 `minimum_expiry_days` if you need a different policy.
+
+**What this does *not* protect against:** interaction limits are
+forward-only. They block who can post *new* issues and comments, but
+they don't reach back through history. An issue body authored before
+the limit was enabled, or comments left on an issue *before* a
+collaborator applied the `agent-plan` / `human-oversight` label, are
+still ingested verbatim. Treat the check as defence against ongoing
+injection, not provenance for historical content. If your repo has
+existing untrusted issue history, audit it before enabling pod.
 
 ## Coordination
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,32 @@ Codex configuration such as custom providers, base URLs, MCP settings,
 and other global config; isolated Codex sessions use only pod-managed
 configuration plus the shared auth token.
 
+### Public-repo safety: GitHub interaction limits
+
+Pod feeds issue bodies and comments on labeled issues into agent
+prompts. On a public repo with no interaction limit, anyone with a
+GitHub account can post text into that prompt stream. Before
+dispatching agents, pod checks
+`gh api repos/<owner>/<repo>/interaction-limits` and refuses to run if:
+
+- the repo is public and has no interaction limit set;
+- the limit is weaker than the configured minimum (default
+  `collaborators_only`); or
+- the limit expires within `minimum_expiry_days` (default 7).
+
+Set or renew the limit with:
+
+```sh
+gh api -X PUT repos/<owner>/<repo>/interaction-limits \
+  -f limit=collaborators_only -f expiry=six_months
+```
+
+GitHub interaction limits expire (max `six_months`), so the check runs
+on every `pod` startup and you'll need to renew periodically. The
+`[security]` section of `.pod/config.toml` exposes
+`enforce_interaction_limits`, `minimum_interaction_limit`, and
+`minimum_expiry_days` if you need a different policy.
+
 ## Coordination
 
 `pod coordination <subcommand>` runs the bundled coordination script

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -184,6 +184,20 @@ min_queue = 3                      # queue_balance: below this → planner-type
 # longer than this many minutes. Used by `coordination list-pr-repair`.
 stuck_ci_minutes = 120
 
+[security]
+# Pod ingests issue/comment text into agent prompts. On a public repo,
+# anyone can post that text unless GitHub interaction limits are set.
+# Pod refuses to dispatch agents on a public repo whose interaction
+# limit is missing, weaker than `minimum_interaction_limit`, or expiring
+# in less than `minimum_expiry_days`.
+#
+# To set/renew the limit:
+#   gh api -X PUT repos/<owner>/<repo>/interaction-limits \
+#     -f limit=collaborators_only -f expiry=six_months
+enforce_interaction_limits = true
+minimum_interaction_limit = "collaborators_only"  # or "contributors_only", "existing_users"
+minimum_expiry_days = 7
+
 [monitor]
 poll_interval = 2                  # Seconds between status updates
 jsonl_stale_warning = 300          # Warn if JSONL unchanged for this many seconds
@@ -2302,6 +2316,125 @@ def _get_repo() -> str:
     except Exception:
         pass
     return "unknown/unknown"
+
+
+# Strictness ranking of GitHub interaction-limit values. Higher = more restrictive.
+_INTERACTION_LIMIT_RANK = {
+    "existing_users": 1,
+    "contributors_only": 2,
+    "collaborators_only": 3,
+}
+
+_security_checked: bool = False
+
+
+def _security_fail(slug: str, msg: str) -> None:
+    print(f"pod: security check failed for {slug}: {msg}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Refusing to dispatch agents. Either:", file=sys.stderr)
+    print("  • Set/renew the interaction limit:", file=sys.stderr)
+    print(f"      gh api -X PUT repos/{slug}/interaction-limits \\", file=sys.stderr)
+    print("        -f limit=collaborators_only -f expiry=six_months", file=sys.stderr)
+    print("  • Or disable the check (not recommended for public repos):", file=sys.stderr)
+    print("      under [security] in .pod/config.toml, set", file=sys.stderr)
+    print("      enforce_interaction_limits = false", file=sys.stderr)
+    sys.exit(1)
+
+
+def check_repo_security(config: dict) -> None:
+    """Refuse to dispatch agents if the repo's GitHub interaction limits are
+    missing, too lax, or expiring soon.
+
+    Pod feeds issue bodies and comments on labeled issues into agent prompts.
+    On a public repo with no interaction limit, an arbitrary GitHub user can
+    inject content there. GitHub's interaction-limits feature gates who can
+    post; this check enforces that gate before any agent runs.
+
+    Idempotent — only checks once per pod process.
+    """
+    global _security_checked
+    if _security_checked:
+        return
+
+    sec = config.get("security", {}) or {}
+    if not sec.get("enforce_interaction_limits", True):
+        _security_checked = True
+        return
+
+    minimum = sec.get("minimum_interaction_limit", "collaborators_only")
+    min_days = sec.get("minimum_expiry_days", 7)
+
+    try:
+        r = subprocess.run(
+            ["gh", "repo", "view", "--json", "visibility,nameWithOwner"],
+            capture_output=True, text=True, timeout=15, cwd=str(PROJECT_DIR),
+        )
+    except FileNotFoundError:
+        print("pod: security: `gh` CLI not found; cannot verify interaction limits.",
+              file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"pod: security: failed to query repo: {e}", file=sys.stderr)
+        sys.exit(1)
+    if r.returncode != 0 or not r.stdout.strip():
+        print(f"pod: security: cannot determine repo visibility: "
+              f"{r.stderr.strip() or 'empty response'}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        info = json.loads(r.stdout)
+        visibility = (info.get("visibility") or "").lower()
+        slug = info.get("nameWithOwner") or "unknown/unknown"
+    except json.JSONDecodeError as e:
+        print(f"pod: security: unparseable repo info: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if visibility != "public":
+        _security_checked = True
+        return
+
+    try:
+        r = subprocess.run(
+            ["gh", "api", f"repos/{slug}/interaction-limits"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except Exception as e:
+        _security_fail(slug, f"failed to query interaction-limits: {e}")
+    if r.returncode != 0:
+        _security_fail(slug, f"failed to query interaction-limits: "
+                             f"{r.stderr.strip() or 'gh api error'}")
+
+    body = r.stdout.strip() or "{}"
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as e:
+        _security_fail(slug, f"unparseable interaction-limits response: {e}")
+
+    if not data:
+        _security_fail(slug,
+            "no interaction limit set on this public repo. "
+            "Random GitHub users can post issues/comments whose contents "
+            "feed into pod agent prompts.")
+
+    have = data.get("limit", "")
+    if _INTERACTION_LIMIT_RANK.get(have, 0) < _INTERACTION_LIMIT_RANK.get(minimum, 0):
+        _security_fail(slug,
+            f"interaction limit is `{have or 'unknown'}`, "
+            f"but pod requires `{minimum}` or stricter.")
+
+    expires = data.get("expires_at")
+    if expires:
+        try:
+            t = datetime.datetime.fromisoformat(expires.replace("Z", "+00:00"))
+        except ValueError:
+            _security_fail(slug, f"unparseable expires_at: {expires!r}")
+        delta = t - datetime.datetime.now(datetime.timezone.utc)
+        days = delta.total_seconds() / 86400
+        if days < min_days:
+            _security_fail(slug,
+                f"interaction limit `{have}` expires in {days:.1f} days "
+                f"(< {min_days}-day threshold).")
+
+    _security_checked = True
 
 
 def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> bool:
@@ -4681,6 +4814,7 @@ def spawn_agent(config: dict, agent_id: str | None = None,
 
 def run_tui(config: dict):
     """Run the interactive curses TUI."""
+    check_repo_security(config)
     curses.wrapper(_tui_main, config)
 
 
@@ -5456,6 +5590,7 @@ def cmd_list(config: dict, args):
 
 def cmd_add(config: dict, args):
     """Launch new agents and update the target count."""
+    check_repo_security(config)
     n = args.count if args.count else 1
     for _ in range(n):
         pid = spawn_agent(config)

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -366,7 +366,9 @@ def ensure_config() -> dict:
     _agent_config_sync_check()
     with open(CONFIG_PATH, "rb") as f:
         cfg = tomllib.load(f)
-    return _migrate_legacy_config(cfg)
+    cfg = _migrate_legacy_config(cfg)
+    validate_security_config(cfg)
+    return cfg
 
 
 def get_isolated_config_dir(config: dict) -> Path | None:
@@ -2325,12 +2327,44 @@ _INTERACTION_LIMIT_RANK = {
     "collaborators_only": 3,
 }
 
-_security_checked: bool = False
+# Re-check the live interaction limit at most this often, to bound the cost
+# of `gh api` calls when many spawns happen in quick succession but still
+# detect limit removal/expiry inside long-running pod processes.
+_SECURITY_CHECK_TTL_SECONDS = 300
+
+_security_last_ok: float = 0.0
 
 
-def _security_fail(slug: str, msg: str) -> None:
+def validate_security_config(cfg: dict) -> None:
+    """Reject typo'd values in `[security]` so they fail loudly rather than
+    silently weakening the policy.
+    """
+    sec = cfg.get("security", {}) or {}
+    minimum = sec.get("minimum_interaction_limit", "collaborators_only")
+    if minimum not in _INTERACTION_LIMIT_RANK:
+        valid = ", ".join(sorted(_INTERACTION_LIMIT_RANK))
+        print(f"pod: invalid [security].minimum_interaction_limit = {minimum!r}; "
+              f"must be one of: {valid}", file=sys.stderr)
+        sys.exit(1)
+    enforce = sec.get("enforce_interaction_limits", True)
+    if not isinstance(enforce, bool):
+        print(f"pod: invalid [security].enforce_interaction_limits = {enforce!r}; "
+              f"must be true or false", file=sys.stderr)
+        sys.exit(1)
+    days = sec.get("minimum_expiry_days", 7)
+    if not isinstance(days, (int, float)) or isinstance(days, bool) or days < 0:
+        print(f"pod: invalid [security].minimum_expiry_days = {days!r}; "
+              f"must be a non-negative number", file=sys.stderr)
+        sys.exit(1)
+
+
+def _security_fail(slug: str, msg: str, *, auth_hint: bool = False) -> None:
     print(f"pod: security check failed for {slug}: {msg}", file=sys.stderr)
     print("", file=sys.stderr)
+    if auth_hint:
+        print("If `gh` is unauthenticated, run `gh auth status` / `gh auth login`.",
+              file=sys.stderr)
+        print("", file=sys.stderr)
     print("Refusing to dispatch agents. Either:", file=sys.stderr)
     print("  • Set/renew the interaction limit:", file=sys.stderr)
     print(f"      gh api -X PUT repos/{slug}/interaction-limits \\", file=sys.stderr)
@@ -2346,19 +2380,27 @@ def check_repo_security(config: dict) -> None:
     missing, too lax, or expiring soon.
 
     Pod feeds issue bodies and comments on labeled issues into agent prompts.
-    On a public repo with no interaction limit, an arbitrary GitHub user can
-    inject content there. GitHub's interaction-limits feature gates who can
-    post; this check enforces that gate before any agent runs.
+    On a public repo with no interaction limit, anyone with a GitHub account
+    can inject text into that prompt stream. GitHub's interaction-limits
+    feature gates who can post; this check enforces it before any spawn.
 
-    Idempotent — only checks once per pod process.
+    Note: interaction limits are forward-only — content posted *before* the
+    limit was enabled (issue bodies, comments on issues labeled later) is
+    not protected. This check guards against new injection, not provenance
+    of historical content.
+
+    Re-runs at most every `_SECURITY_CHECK_TTL_SECONDS`. Called from
+    `spawn_agent` so every dispatch path is gated, including TUI auto-spawn
+    and dead-session restart from `check_dead_claimed_issues`.
     """
-    global _security_checked
-    if _security_checked:
+    global _security_last_ok
+    now = time.time()
+    if _security_last_ok and (now - _security_last_ok) < _SECURITY_CHECK_TTL_SECONDS:
         return
 
     sec = config.get("security", {}) or {}
     if not sec.get("enforce_interaction_limits", True):
-        _security_checked = True
+        _security_last_ok = now
         return
 
     minimum = sec.get("minimum_interaction_limit", "collaborators_only")
@@ -2377,8 +2419,11 @@ def check_repo_security(config: dict) -> None:
         print(f"pod: security: failed to query repo: {e}", file=sys.stderr)
         sys.exit(1)
     if r.returncode != 0 or not r.stdout.strip():
-        print(f"pod: security: cannot determine repo visibility: "
-              f"{r.stderr.strip() or 'empty response'}", file=sys.stderr)
+        err = r.stderr.strip() or "empty response"
+        print(f"pod: security: cannot determine repo visibility: {err}", file=sys.stderr)
+        if "auth" in err.lower() or "login" in err.lower() or "401" in err:
+            print("    → run `gh auth status` / `gh auth login` and retry.",
+                  file=sys.stderr)
         sys.exit(1)
     try:
         info = json.loads(r.stdout)
@@ -2389,7 +2434,7 @@ def check_repo_security(config: dict) -> None:
         sys.exit(1)
 
     if visibility != "public":
-        _security_checked = True
+        _security_last_ok = now
         return
 
     try:
@@ -2400,8 +2445,11 @@ def check_repo_security(config: dict) -> None:
     except Exception as e:
         _security_fail(slug, f"failed to query interaction-limits: {e}")
     if r.returncode != 0:
-        _security_fail(slug, f"failed to query interaction-limits: "
-                             f"{r.stderr.strip() or 'gh api error'}")
+        err = r.stderr.strip() or "gh api error"
+        is_auth = ("auth" in err.lower() or "login" in err.lower()
+                   or "401" in err or "403" in err)
+        _security_fail(slug, f"failed to query interaction-limits: {err}",
+                       auth_hint=is_auth)
 
     body = r.stdout.strip() or "{}"
     try:
@@ -2434,7 +2482,7 @@ def check_repo_security(config: dict) -> None:
                 f"interaction limit `{have}` expires in {days:.1f} days "
                 f"(< {min_days}-day threshold).")
 
-    _security_checked = True
+    _security_last_ok = now
 
 
 def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> bool:
@@ -4770,6 +4818,9 @@ def spawn_agent(config: dict, agent_id: str | None = None,
     check_dead_claimed_issues) would break git's internal waitpid and cause
     silent failures in git worktree add.
     """
+    # Gate every dispatch path. TTL-cached, so back-to-back spawns from
+    # the TUI loop or auto-spawn don't each hit the GitHub API.
+    check_repo_security(config)
     pid = os.fork()
     if pid > 0:
         # Parent: wait for the short-lived intermediate child (exits immediately).
@@ -5590,7 +5641,6 @@ def cmd_list(config: dict, args):
 
 def cmd_add(config: dict, args):
     """Launch new agents and update the target count."""
-    check_repo_security(config)
     n = args.count if args.count else 1
     for _ in range(n):
         pid = spawn_agent(config)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -39,7 +39,7 @@ def _iso(days_from_now: float) -> str:
 
 class SecurityCheckTests(unittest.TestCase):
     def setUp(self):
-        cli._security_checked = False
+        cli._security_last_ok = 0.0
 
     def test_disabled_skips_all_checks(self):
         with mock.patch.object(cli.subprocess, "run") as run:
@@ -104,13 +104,107 @@ class SecurityCheckTests(unittest.TestCase):
                 {"security": {"minimum_interaction_limit": "contributors_only"}}
             )
 
-    def test_idempotent_within_process(self):
+    def test_ttl_skips_recheck(self):
         fake = _mock_run("private", "owner/repo", "{}")
         with mock.patch.object(cli.subprocess, "run", side_effect=fake) as run:
             cli.check_repo_security({})
             cli.check_repo_security({})
-        # Only the first call should have hit subprocess.
+        # Within TTL — only the first call should have hit subprocess.
         self.assertEqual(run.call_count, 1)
+
+    def test_ttl_expires(self):
+        fake = _mock_run("private", "owner/repo", "{}")
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake) as run:
+            cli.check_repo_security({})
+            # Simulate TTL elapsing.
+            cli._security_last_ok = (
+                cli._security_last_ok - cli._SECURITY_CHECK_TTL_SECONDS - 1
+            )
+            cli.check_repo_security({})
+        self.assertEqual(run.call_count, 2)
+
+    def test_gh_not_found_fails_closed(self):
+        with mock.patch.object(cli.subprocess, "run", side_effect=FileNotFoundError):
+            with self.assertRaises(SystemExit):
+                cli.check_repo_security({})
+
+    def test_gh_repo_view_error_fails_closed(self):
+        bad = mock.Mock()
+        bad.returncode = 1
+        bad.stdout = ""
+        bad.stderr = "auth required"
+        with mock.patch.object(cli.subprocess, "run", return_value=bad):
+            with self.assertRaises(SystemExit):
+                cli.check_repo_security({})
+
+    def test_gh_api_network_error_fails_closed(self):
+        repo_view = mock.Mock(returncode=0, stderr="",
+                              stdout='{"visibility":"public","nameWithOwner":"o/r"}')
+        api_err = mock.Mock(returncode=1, stdout="", stderr="HTTP 500: server error")
+
+        def fake_run(argv, **kwargs):
+            return repo_view if argv[:2] == ["gh", "repo"] else api_err
+
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+            with self.assertRaises(SystemExit):
+                cli.check_repo_security({})
+
+
+class ValidateSecurityConfigTests(unittest.TestCase):
+    def test_defaults_pass(self):
+        cli.validate_security_config({})
+
+    def test_explicit_valid_minimum_passes(self):
+        for v in ("existing_users", "contributors_only", "collaborators_only"):
+            cli.validate_security_config({"security": {"minimum_interaction_limit": v}})
+
+    def test_typo_minimum_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.validate_security_config(
+                {"security": {"minimum_interaction_limit": "colaborators_only"}}
+            )
+
+    def test_non_bool_enforce_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.validate_security_config(
+                {"security": {"enforce_interaction_limits": "yes"}}
+            )
+
+    def test_negative_expiry_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.validate_security_config({"security": {"minimum_expiry_days": -1}})
+
+    def test_non_numeric_expiry_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.validate_security_config({"security": {"minimum_expiry_days": "seven"}})
+
+
+class SpawnAgentSecurityGateTests(unittest.TestCase):
+    """Verify spawn_agent invokes the security check before forking, so
+    every dispatch path (cmd_add, TUI auto-spawn, dead-claim restart) is
+    gated regardless of where the call originates."""
+
+    def setUp(self):
+        cli._security_last_ok = 0.0
+
+    def test_spawn_agent_calls_check(self):
+        # Patch os.fork so we never actually fork during the test.
+        with mock.patch.object(cli, "check_repo_security") as chk, \
+             mock.patch.object(cli.os, "fork", return_value=12345), \
+             mock.patch.object(cli.os, "waitpid", return_value=(12345, 0)):
+            cli.spawn_agent({})
+        chk.assert_called_once_with({})
+
+    def test_spawn_agent_aborts_when_check_fails(self):
+        # check_repo_security exits → spawn_agent must propagate, never fork.
+        def boom(_cfg):
+            raise SystemExit(1)
+
+        with mock.patch.object(cli, "check_repo_security", side_effect=boom), \
+             mock.patch.object(cli.os, "fork") as fork:
+            with self.assertRaises(SystemExit):
+                cli.spawn_agent({})
+        fork.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,117 @@
+import datetime
+import unittest
+from unittest import mock
+
+from pod import cli
+
+
+def _mock_run(visibility: str, slug: str, limit_response: str | None,
+              limit_returncode: int = 0):
+    """Return a fake subprocess.run that responds to the two gh calls
+    check_repo_security makes (gh repo view, then gh api interaction-limits).
+    """
+    repo_view = mock.Mock()
+    repo_view.returncode = 0
+    repo_view.stdout = (
+        '{"visibility":"' + visibility + '","nameWithOwner":"' + slug + '"}\n'
+    )
+    repo_view.stderr = ""
+
+    api = mock.Mock()
+    api.returncode = limit_returncode
+    api.stdout = limit_response if limit_response is not None else ""
+    api.stderr = "" if limit_returncode == 0 else "API error"
+
+    def fake_run(argv, **kwargs):
+        if argv[:2] == ["gh", "repo"]:
+            return repo_view
+        if argv[:2] == ["gh", "api"]:
+            return api
+        raise AssertionError(f"unexpected subprocess call: {argv}")
+
+    return fake_run
+
+
+def _iso(days_from_now: float) -> str:
+    t = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=days_from_now)
+    return t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class SecurityCheckTests(unittest.TestCase):
+    def setUp(self):
+        cli._security_checked = False
+
+    def test_disabled_skips_all_checks(self):
+        with mock.patch.object(cli.subprocess, "run") as run:
+            cli.check_repo_security({"security": {"enforce_interaction_limits": False}})
+        run.assert_not_called()
+
+    def test_private_repo_passes(self):
+        fake = _mock_run("private", "owner/repo", "{}")
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            cli.check_repo_security({})  # no exit
+
+    def test_public_no_limit_refused(self):
+        fake = _mock_run("public", "owner/repo", "{}")
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            with self.assertRaises(SystemExit) as cm:
+                cli.check_repo_security({})
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_public_collaborators_only_long_expiry_passes(self):
+        body = (
+            '{"limit":"collaborators_only","origin":"repository",'
+            '"expires_at":"' + _iso(180) + '"}'
+        )
+        fake = _mock_run("public", "owner/repo", body)
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            cli.check_repo_security({})
+
+    def test_public_limit_too_lax_refused(self):
+        body = (
+            '{"limit":"existing_users","origin":"repository",'
+            '"expires_at":"' + _iso(180) + '"}'
+        )
+        fake = _mock_run("public", "owner/repo", body)
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            with self.assertRaises(SystemExit):
+                cli.check_repo_security({})
+
+    def test_public_expiring_soon_refused(self):
+        body = (
+            '{"limit":"collaborators_only","origin":"repository",'
+            '"expires_at":"' + _iso(3) + '"}'
+        )
+        fake = _mock_run("public", "owner/repo", body)
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            with self.assertRaises(SystemExit):
+                cli.check_repo_security({})
+
+    def test_public_no_expiry_passes(self):
+        body = '{"limit":"collaborators_only","origin":"repository"}'
+        fake = _mock_run("public", "owner/repo", body)
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            cli.check_repo_security({})
+
+    def test_lower_minimum_accepts_weaker_limit(self):
+        body = (
+            '{"limit":"contributors_only","origin":"repository",'
+            '"expires_at":"' + _iso(180) + '"}'
+        )
+        fake = _mock_run("public", "owner/repo", body)
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            cli.check_repo_security(
+                {"security": {"minimum_interaction_limit": "contributors_only"}}
+            )
+
+    def test_idempotent_within_process(self):
+        fake = _mock_run("private", "owner/repo", "{}")
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake) as run:
+            cli.check_repo_security({})
+            cli.check_repo_security({})
+        # Only the first call should have hit subprocess.
+        self.assertEqual(run.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a startup security check that refuses to dispatch agents on a public GitHub repository unless the repo has a GitHub interaction limit at least as strict as `collaborators_only` and not expiring within 7 days.

Why: pod feeds issue bodies and comments on labeled issues into agent prompts. On a public repo with no interaction limit, anyone with a GitHub account can post text into that prompt stream. Labels themselves are gated to collaborators, but the *content* an agent ingests on a labeled issue is not — anonymous users can comment on already-labeled issues, and an issue body authored by a stranger can become an agent prompt the moment a collaborator triages it.

The check runs once per pod process at the top of `cmd_add` and `run_tui`, querying `repos/{owner}/{repo}/interaction-limits` via `gh api`. It refuses with an actionable error (including the exact `gh` command to set the limit) if:

- the repo is public and no interaction limit is set;
- the limit is weaker than the configured minimum (default `collaborators_only`); or
- the limit expires in fewer than `minimum_expiry_days` days (default 7).

GitHub interaction limits cap at `six_months`, so renewal is required periodically — the per-startup check makes that unavoidable rather than something to remember.

Configurable under `[security]` in `.pod/config.toml`:

```toml
[security]
enforce_interaction_limits = true
minimum_interaction_limit = "collaborators_only"
minimum_expiry_days = 7
```

Existing config.toml files without a `[security]` section get the strict defaults, so this is a behaviour change for anyone running pod against a public repo without interaction limits set. The error message includes the one-liner to fix.

Tested manually against `kim-em/hex` (public, no limit → refused; one-day limit → refused for expiry; six-month limit → accepted) and via 9 new mocked unittests in `tests/test_security.py`. Full test suite (102 tests) passes.

🤖 Prepared with Claude Code