### PR TITLE
feat: per-message author provenance gate for issue ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,67 @@ forward-only. They block who can post *new* issues and comments, but
 they don't reach back through history. An issue body authored before
 the limit was enabled, or comments left on an issue *before* a
 collaborator applied the `agent-plan` / `human-oversight` label, are
-still ingested verbatim. Treat the check as defence against ongoing
-injection, not provenance for historical content. If your repo has
-existing untrusted issue history, audit it before enabling pod.
+still ingested verbatim by the interaction-limit check alone. The
+per-message provenance gate below covers that residual gap.
+
+### Per-message provenance gate
+
+A second layer that closes the historical-content gap. Pod refuses to
+surface issue bodies / comments authored by accounts without a
+trusted association with the repo. Decided per message using GitHub's
+`authorAssociation` field on every issue and comment, so it works
+without admin scope and covers content posted before any
+interaction-limit was set.
+
+Trusted by default: `OWNER`, `MEMBER`, `COLLABORATOR`. Configurable
+under `[security]`:
+
+```toml
+trust_only_collaborators = true
+trusted_author_associations = ["OWNER", "MEMBER", "COLLABORATOR"]
+trusted_users = []                # bot allowlist (e.g. "dependabot[bot]")
+provenance_cache_seconds = 60
+```
+
+Behaviour on rejection:
+
+- `coordination list-unclaimed` and `coordination orient` silently
+  omit untrusted issues. Set `POD_INCLUDE_UNTRUSTED=1` to surface
+  them annotated `[UNTRUSTED: <reason>]` for human triage.
+- `coordination claim N` refuses with `CLAIM FAILED: ...`; the agent
+  picks a different issue per the existing flow.
+- `coordination read-issue N` refuses; this is the gate that the
+  worker flow uses in place of `gh issue view N --json body`.
+- The planner's pre-claim body reads (in `plan.md` Steps 3 and 5) go
+  through `pod _filter-trusted-issues`, which drops untrusted issues
+  before any body text reaches the agent.
+
+Caching: list-time checks use a 60-second TTL; `claim` and
+`read-issue` always re-check fresh, so a comment added between
+discovery and read can't sneak past.
+
+**Org-membership caveat:** `MEMBER` is org membership, not write
+access on the specific repo. On an org repo it trusts every org
+member, including users who can't push to this repo. For stricter
+behaviour, drop `MEMBER` from `trusted_author_associations`.
+
+**Bot allowlist:** service accounts (`dependabot[bot]`,
+`github-actions[bot]`, custom CI/status bots that comment on issues)
+typically have `authorAssociation == NONE`. Add them to
+`trusted_users` so their comments don't trip the gate.
+
+**What this layer does *not* cover** (named honestly so we don't
+oversell):
+
+- PR diffs and PR review comments — the `/repair` flow operates on
+  PR metadata, but PR text is not run through this gate.
+- CI logs — relevant to `/repair`, which can ingest log text.
+- Repository file contents — if a malicious commit lands in a
+  file-path an agent reads, this gate doesn't help.
+- Linked issues/PRs that the agent fetches mid-session of its own
+  initiative.
+- Text a *trusted* collaborator copies into an issue from an
+  untrusted source. Provenance ≠ semantic sanitization.
 
 ## Coordination
 

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -198,6 +198,17 @@ enforce_interaction_limits = true
 minimum_interaction_limit = "collaborators_only"  # or "contributors_only", "existing_users"
 minimum_expiry_days = 7
 
+# Per-message author provenance gate. On top of the repo-wide
+# interaction-limit check, refuse to surface issue bodies / comments
+# whose authors don't have a trusted association with the repo.
+# See README for the threat model and limits, including the org-
+# membership caveat for `MEMBER`.
+trust_only_collaborators = true
+trusted_author_associations = ["OWNER", "MEMBER", "COLLABORATOR"]
+trusted_users = []                 # bot allowlist
+                                   # e.g. ["dependabot[bot]", "github-actions[bot]"]
+provenance_cache_seconds = 60      # applies to list/orient; claim/read are always fresh
+
 [monitor]
 poll_interval = 2                  # Seconds between status updates
 jsonl_stale_warning = 300          # Warn if JSONL unchanged for this many seconds
@@ -2327,6 +2338,13 @@ _INTERACTION_LIMIT_RANK = {
     "collaborators_only": 3,
 }
 
+# Possible values of GitHub's `authorAssociation` field on issues and comments.
+# See https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+_GH_AUTHOR_ASSOCIATIONS = {
+    "OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR",
+    "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MANNEQUIN", "NONE",
+}
+
 # Re-check the live interaction limit at most this often, to bound the cost
 # of `gh api` calls when many spawns happen in quick succession but still
 # detect limit removal/expiry inside long-running pod processes.
@@ -2354,6 +2372,35 @@ def validate_security_config(cfg: dict) -> None:
     days = sec.get("minimum_expiry_days", 7)
     if not isinstance(days, (int, float)) or isinstance(days, bool) or days < 0:
         print(f"pod: invalid [security].minimum_expiry_days = {days!r}; "
+              f"must be a non-negative number", file=sys.stderr)
+        sys.exit(1)
+
+    trust = sec.get("trust_only_collaborators", True)
+    if not isinstance(trust, bool):
+        print(f"pod: invalid [security].trust_only_collaborators = {trust!r}; "
+              f"must be true or false", file=sys.stderr)
+        sys.exit(1)
+    assocs = sec.get("trusted_author_associations",
+                     ["OWNER", "MEMBER", "COLLABORATOR"])
+    if not isinstance(assocs, list) or not all(isinstance(a, str) for a in assocs):
+        print(f"pod: invalid [security].trusted_author_associations = {assocs!r}; "
+              f"must be a list of strings", file=sys.stderr)
+        sys.exit(1)
+    bad = [a for a in assocs if a not in _GH_AUTHOR_ASSOCIATIONS]
+    if bad:
+        valid = ", ".join(sorted(_GH_AUTHOR_ASSOCIATIONS))
+        print(f"pod: invalid value(s) in [security].trusted_author_associations: "
+              f"{bad!r}; must each be one of: {valid}", file=sys.stderr)
+        sys.exit(1)
+    users = sec.get("trusted_users", [])
+    if not isinstance(users, list) or not all(isinstance(u, str) for u in users):
+        print(f"pod: invalid [security].trusted_users = {users!r}; "
+              f"must be a list of strings", file=sys.stderr)
+        sys.exit(1)
+    cache_s = sec.get("provenance_cache_seconds", 60)
+    if (not isinstance(cache_s, (int, float)) or isinstance(cache_s, bool)
+            or cache_s < 0):
+        print(f"pod: invalid [security].provenance_cache_seconds = {cache_s!r}; "
               f"must be a non-negative number", file=sys.stderr)
         sys.exit(1)
 
@@ -2483,6 +2530,260 @@ def check_repo_security(config: dict) -> None:
                 f"(< {min_days}-day threshold).")
 
     _security_last_ok = now
+
+
+# ----------------------------------------------------------------------
+# Per-message author provenance gate.
+#
+# A defense-in-depth layer on top of the repo-wide interaction-limit
+# check. We refuse to surface issue bodies / comments authored by
+# accounts that lack a trusted association with the repo. Trust is
+# decided by GitHub's `authorAssociation` field on issues and comments
+# (no admin scope needed). See README "Public-repo safety" for the
+# threat model and limits — including the `MEMBER` ≠ repo-write caveat
+# for org repos.
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class _ProvenanceComment:
+    comment_id: int
+    login: str
+    association: str
+
+
+@dataclass
+class _IssueProvenance:
+    repo: str
+    issue_num: int
+    author_login: str
+    author_association: str
+    comments: list[_ProvenanceComment]
+    fetched_at: float
+
+
+# Cache: {(repo, issue_num): _IssueProvenance}.
+_provenance_cache: dict[tuple[str, int], _IssueProvenance] = {}
+
+
+def _provenance_ttl(config: dict) -> float:
+    sec = config.get("security", {}) or {}
+    return float(sec.get("provenance_cache_seconds", 60))
+
+
+def _is_repo_public(config: dict) -> bool:
+    """Return True iff the current repo is public. Cached via the same
+    `gh repo view` call used by `check_repo_security`. Safe to call from
+    contexts where we want to short-circuit the gate on private repos.
+    """
+    try:
+        r = subprocess.run(
+            ["gh", "repo", "view", "--json", "visibility"],
+            capture_output=True, text=True, timeout=15, cwd=str(PROJECT_DIR),
+        )
+    except Exception:
+        return True  # fail-closed: treat as public so we still check
+    if r.returncode != 0 or not r.stdout.strip():
+        return True
+    try:
+        return (json.loads(r.stdout).get("visibility") or "").lower() == "public"
+    except json.JSONDecodeError:
+        return True
+
+
+def fetch_issue_provenance(repo: str, issue_num: int) -> _IssueProvenance:
+    """Fetch the issue + its comments and bundle author/association data.
+
+    Two `gh api` calls per issue: one for the issue, one paginated for
+    comments. Raises subprocess.CalledProcessError on `gh` failure so
+    callers can surface a clear error.
+    """
+    issue_r = subprocess.run(
+        ["gh", "api", f"repos/{repo}/issues/{issue_num}"],
+        capture_output=True, text=True, timeout=30, check=True,
+    )
+    issue = json.loads(issue_r.stdout)
+    comments_r = subprocess.run(
+        ["gh", "api", "--paginate", f"repos/{repo}/issues/{issue_num}/comments"],
+        capture_output=True, text=True, timeout=60, check=True,
+    )
+    # `gh api --paginate` concatenates JSON arrays; parse each line that's
+    # an array, falling back to a single document on no pagination.
+    comments_raw: list = []
+    body = comments_r.stdout.strip()
+    if body:
+        # `gh` emits one or more arrays back-to-back (no separator).
+        # JSONDecoder.raw_decode handles that.
+        decoder = json.JSONDecoder()
+        idx = 0
+        while idx < len(body):
+            while idx < len(body) and body[idx].isspace():
+                idx += 1
+            if idx >= len(body):
+                break
+            obj, end = decoder.raw_decode(body, idx)
+            if isinstance(obj, list):
+                comments_raw.extend(obj)
+            idx = end
+    comments = [
+        _ProvenanceComment(
+            comment_id=int(c.get("id", 0)),
+            login=(c.get("user") or {}).get("login", "") or "",
+            association=c.get("author_association", "NONE") or "NONE",
+        )
+        for c in comments_raw
+    ]
+    return _IssueProvenance(
+        repo=repo,
+        issue_num=issue_num,
+        author_login=(issue.get("user") or {}).get("login", "") or "",
+        author_association=issue.get("author_association", "NONE") or "NONE",
+        comments=comments,
+        fetched_at=time.time(),
+    )
+
+
+def is_trusted(provenance: _IssueProvenance, config: dict) -> tuple[bool, str]:
+    """Pure policy: decide whether `provenance` passes the trust rule.
+
+    Returns `(True, "")` if trusted, else `(False, reason)`. Reason is a
+    grep-friendly single line naming the offending login and (for
+    comments) the comment id.
+    """
+    sec = config.get("security", {}) or {}
+    if not sec.get("trust_only_collaborators", True):
+        return True, ""
+    trusted_assocs = set(sec.get("trusted_author_associations",
+                                  ["OWNER", "MEMBER", "COLLABORATOR"]))
+    trusted_users = set(sec.get("trusted_users", []) or [])
+
+    def author_ok(login: str, assoc: str) -> bool:
+        return assoc in trusted_assocs or login in trusted_users
+
+    if not author_ok(provenance.author_login, provenance.author_association):
+        return False, (f"untrusted issue author @{provenance.author_login} "
+                       f"({provenance.author_association})")
+    for c in provenance.comments:
+        if not author_ok(c.login, c.association):
+            return False, (f"untrusted comment c#{c.comment_id} "
+                           f"@{c.login} ({c.association})")
+    return True, ""
+
+
+def _cached_provenance(repo: str, issue_num: int, config: dict,
+                        *, fresh: bool) -> _IssueProvenance:
+    """Shared cache entry point. `fresh=True` invalidates and re-fetches."""
+    key = (repo, issue_num)
+    if fresh:
+        _provenance_cache.pop(key, None)
+    else:
+        cached = _provenance_cache.get(key)
+        if cached and (time.time() - cached.fetched_at) < _provenance_ttl(config):
+            return cached
+    prov = fetch_issue_provenance(repo, issue_num)
+    _provenance_cache[key] = prov
+    return prov
+
+
+def check_issue_provenance(repo: str, issue_num: int, config: dict,
+                            *, fresh: bool = False) -> tuple[bool, str]:
+    """High-level gate: short-circuits on private/disabled, fetches (cached
+    or fresh per `fresh`), runs `is_trusted`, returns `(ok, reason)`."""
+    sec = config.get("security", {}) or {}
+    if not sec.get("trust_only_collaborators", True):
+        return True, ""
+    if not _is_repo_public(config):
+        return True, ""
+    try:
+        prov = _cached_provenance(repo, issue_num, config, fresh=fresh)
+    except subprocess.CalledProcessError as e:
+        err = (e.stderr or "").strip() or "gh api error"
+        return False, f"failed to fetch provenance for #{issue_num}: {err}"
+    except (json.JSONDecodeError, ValueError) as e:
+        return False, f"unparseable provenance response for #{issue_num}: {e}"
+    return is_trusted(prov, config)
+
+
+def cmd_check_provenance(config: dict, args) -> None:
+    """`pod _check-provenance N [--fresh]` — single-issue gate.
+
+    Exit 0 if trusted, exit 1 with reason on stderr if not.
+    Used by `coordination claim` and `coordination read-issue`
+    (always with --fresh).
+    """
+    repo = _get_repo()
+    ok, reason = check_issue_provenance(repo, args.issue_num, config,
+                                          fresh=args.fresh)
+    if ok:
+        return
+    print(f"pod: provenance check failed for {repo}#{args.issue_num}: {reason}",
+          file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_filter_trusted_issues(config: dict, args) -> None:
+    """`pod _filter-trusted-issues [...gh-issue-list-args...]` — runs
+    `gh issue list` once, drops untrusted issues in one Python pass, then
+    applies `--jq` (if any) to the surviving JSON array. One Python
+    startup, regardless of issue count.
+
+    Used by `coordination list-unclaimed`, `coordination orient` blocked
+    section, and directly by `plan.md` to replace inline `gh issue list`.
+    """
+    repo = _get_repo()
+    cmd = ["gh", "issue", "list", "--repo", repo]
+    for label in (args.label or []):
+        cmd += ["--label", label]
+    if args.state:
+        cmd += ["--state", args.state]
+    if args.limit:
+        cmd += ["--limit", str(args.limit)]
+    # Always include the fields needed to filter, plus whatever the
+    # caller asked for.
+    requested = set((args.json or "number,title").split(","))
+    requested |= {"number"}
+    cmd += ["--json", ",".join(sorted(requested))]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if r.returncode != 0:
+        print(f"pod: gh issue list failed: {r.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        items = json.loads(r.stdout or "[]")
+    except json.JSONDecodeError as e:
+        print(f"pod: unparseable gh issue list output: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    sec_enabled = (config.get("security", {}) or {}).get(
+        "trust_only_collaborators", True)
+    repo_public = _is_repo_public(config) if sec_enabled else False
+    filtered: list[dict] = []
+    if not (sec_enabled and repo_public):
+        filtered = items
+    else:
+        for it in items:
+            num = int(it.get("number", 0))
+            if num <= 0:
+                continue
+            ok, reason = check_issue_provenance(repo, num, config, fresh=False)
+            if ok:
+                filtered.append(it)
+            elif args.include_untrusted:
+                marked = dict(it)
+                if "title" in marked:
+                    marked["title"] = f"[UNTRUSTED: {reason}] {marked['title']}"
+                filtered.append(marked)
+
+    out_json = json.dumps(filtered)
+    if args.jq:
+        jq = subprocess.run(["jq", "-r", args.jq], input=out_json,
+                             capture_output=True, text=True, timeout=30)
+        if jq.returncode != 0:
+            print(f"pod: jq failed: {jq.stderr.strip()}", file=sys.stderr)
+            sys.exit(1)
+        sys.stdout.write(jq.stdout)
+    else:
+        sys.stdout.write(out_json)
+        sys.stdout.write("\n")
 
 
 def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> bool:
@@ -6172,6 +6473,27 @@ def main():
     p_config.add_argument("--edit", action="store_true",
                            help="Open config in $EDITOR")
 
+    # Internal helpers shelled out to from the bundled `coordination` script.
+    # Underscore-prefixed names keep them out of casual `--help` browsing.
+    p_check = sub.add_parser("_check-provenance",
+                              help=argparse.SUPPRESS)
+    p_check.add_argument("issue_num", type=int)
+    p_check.add_argument("--fresh", action="store_true",
+                          help="Bypass cache and re-fetch")
+
+    p_filter = sub.add_parser("_filter-trusted-issues",
+                               help=argparse.SUPPRESS)
+    p_filter.add_argument("--label", action="append",
+                           help="Forwarded to gh issue list (repeatable)")
+    p_filter.add_argument("--state", default="open")
+    p_filter.add_argument("--limit", type=int, default=50)
+    p_filter.add_argument("--json", default="number,title",
+                           help="Forwarded to gh issue list")
+    p_filter.add_argument("--jq", default=None,
+                           help="Applied to filtered JSON array")
+    p_filter.add_argument("--include-untrusted", action="store_true",
+                           help="Surface untrusted issues with [UNTRUSTED: ...] prefix")
+
     args = parser.parse_args()
 
     # Handle subcommands that don't require ensure_config()
@@ -6212,6 +6534,10 @@ def main():
         cmd_log(config, args)
     elif args.command == "config":
         cmd_config(config, args)
+    elif args.command == "_check-provenance":
+        cmd_check_provenance(config, args)
+    elif args.command == "_filter-trusted-issues":
+        cmd_filter_trusted_issues(config, args)
 
 
 if __name__ == "__main__":

--- a/pod/data/agent-config/claude/commands/plan.md
+++ b/pod/data/agent-config/claude/commands/plan.md
@@ -47,7 +47,7 @@ Never skip this step. Downstream agents are blocked on `main` until merged PRs l
 
 Fetch the list:
 ```
-gh issue list --label replan --state open --json number,title,body \
+pod _filter-trusted-issues --label replan --state open --json number,title,body \
     --jq '.[] | "### #\(.number) \(.title)\n\(.body)\n"'
 ```
 
@@ -97,7 +97,7 @@ These fix issues take priority over all new feature work.
 
 Read the **full body** of every open `agent-plan` issue:
 ```
-gh issue list --label agent-plan --state open --limit 20 \
+pod _filter-trusted-issues --label agent-plan --state open --limit 20 \
     --json number,title,body --jq '.[] | "### #\(.number) \(.title)\n\(.body)\n"'
 ```
 

--- a/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
@@ -100,7 +100,7 @@ coordination claim <issue-number>
 on that issue — pick a different one. Only proceed if the output says
 `Claimed issue #N`. Read the full issue body:
 ```
-gh issue view <N> --json body --jq .body
+coordination read-issue <N> --json body --jq .body
 ```
 
 ## Step 2: Set Up

--- a/pod/data/agent-config/codex/commands/plan.md
+++ b/pod/data/agent-config/codex/commands/plan.md
@@ -47,7 +47,7 @@ Never skip this step. Downstream agents are blocked on `main` until merged PRs l
 
 Fetch the list:
 ```
-gh issue list --label replan --state open --json number,title,body \
+pod _filter-trusted-issues --label replan --state open --json number,title,body \
     --jq '.[] | "### #\(.number) \(.title)\n\(.body)\n"'
 ```
 
@@ -97,7 +97,7 @@ These fix issues take priority over all new feature work.
 
 Read the **full body** of every open `agent-plan` issue:
 ```
-gh issue list --label agent-plan --state open --limit 20 \
+pod _filter-trusted-issues --label agent-plan --state open --limit 20 \
     --json number,title,body --jq '.[] | "### #\(.number) \(.title)\n\(.body)\n"'
 ```
 

--- a/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
@@ -100,7 +100,7 @@ coordination claim <issue-number>
 on that issue — pick a different one. Only proceed if the output says
 `Claimed issue #N`. Read the full issue body:
 ```
-gh issue view <N> --json body --jq .body
+coordination read-issue <N> --json body --jq .body
 ```
 
 ## Step 2: Set Up

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -31,6 +31,15 @@
 #   coordination set-target N                 — planner sets recommended target agent count (pod uses min of this and user target)
 #   coordination set-min-queue N              — planner sets recommended min_queue (pod uses min of this and config value; 0 disables backfill)
 #   coordination nothing-to-plan              — planner signals queue saturated; decrements target by 1 (deprecated: use set-target/set-min-queue instead)
+#   coordination read-issue N [--json F] [--jq E]
+#                                              — read issue #N's body (or specified fields), gated by provenance check;
+#                                                fails if any author is untrusted. Defaults to: --json body --jq .body
+#
+# Provenance gate: list-unclaimed and orient silently omit issues whose body or
+# any comment was authored by an account without a trusted association with the
+# repo (default: OWNER/MEMBER/COLLABORATOR). Configure under [security] in
+# .pod/config.toml. Set POD_INCLUDE_UNTRUSTED=1 to surface untrusted issues
+# annotated `[UNTRUSTED: …]`. claim and read-issue refuse outright.
 
 set -euo pipefail
 
@@ -153,20 +162,26 @@ _ensure_labels
 # Helper: get unclaimed issues as JSON array
 # Optional arg: extra label to filter by (e.g. "feature", "review")
 # Always includes human-oversight issues (even without agent-plan) when no extra label is given.
+#
+# Untrusted-author issues (failing the provenance gate) are silently
+# omitted via `pod _filter-trusted-issues`. To surface them anyway, set
+# POD_INCLUDE_UNTRUSTED=1 in the environment.
 _unclaimed_issues() {
     local extra_label="${1:-}"
     local filter='[.[] | select(.labels | all(.name != "claimed") and all(.name != "blocked") and all(.name != "has-pr") and all(.name != "replan"))] | sort_by(if (.labels | any(.name == "critical-path")) then 0 else 1 end, .createdAt)'
+    local include_untrusted=()
+    [[ "${POD_INCLUDE_UNTRUSTED:-0}" == "1" ]] && include_untrusted=(--include-untrusted)
     if [[ -n "$extra_label" ]]; then
-        gh issue list --repo "$REPO" --label agent-plan --label "$extra_label" --state open --limit 50 \
-            --json number,title,labels,createdAt \
+        pod _filter-trusted-issues --label agent-plan --label "$extra_label" --state open --limit 50 \
+            --json number,title,labels,createdAt "${include_untrusted[@]}" \
             --jq "$filter"
     else
         # Merge agent-plan issues with human-oversight issues, deduplicate by number
         {
-            gh issue list --repo "$REPO" --label agent-plan --state open --limit 50 \
-                --json number,title,labels,createdAt
-            gh issue list --repo "$REPO" --label human-oversight --state open --limit 50 \
-                --json number,title,labels,createdAt
+            pod _filter-trusted-issues --label agent-plan --state open --limit 50 \
+                --json number,title,labels,createdAt "${include_untrusted[@]}"
+            pod _filter-trusted-issues --label human-oversight --state open --limit 50 \
+                --json number,title,labels,createdAt "${include_untrusted[@]}"
         } | jq -s "add | unique_by(.number) | $filter"
     fi
 }
@@ -184,9 +199,12 @@ cmd_orient() {
 
     echo ""
     echo "=== Blocked issues ==="
+    # Provenance gate: untrusted-author blocked issues are silently
+    # omitted (their bodies must not feed into agent prompts via the
+    # depends-on extraction below).
     local open_nums
     open_nums="$(gh issue list --repo "$REPO" --state open --limit 100 --json number --jq '[.[].number]')"
-    gh issue list --repo "$REPO" --label agent-plan --label blocked --state open --limit 50 \
+    pod _filter-trusted-issues --label agent-plan --label blocked --state open --limit 50 \
         --json number,title,body \
     | jq -r --argjson open "$open_nums" \
         '.[] | "#\(.number) [Blocked on \([.body | match("depends-on: #([0-9]+)"; "g") | .captures[0].string | tonumber | . as $d | if ($open | index($d) != null) then "#\($d)" else empty end] | join(", "))] \(.title)"'
@@ -233,10 +251,12 @@ cmd_plan() {
     done
     local title="${1:?usage: coordination plan [--label L] [--critical-path] \"title\"}"
 
-    # Fetch all open agent-plan issues with full bodies for overlap detection
+    # Fetch open agent-plan issue titles for overlap detection.
+    # Bodies aren't used here — keep the request narrow so untrusted
+    # body text never enters this script's stdout.
     local existing_json
     existing_json="$(gh issue list --repo "$REPO" --label agent-plan --state open --limit 50 \
-        --json number,title,body)"
+        --json number,title)"
 
     # Warn if any existing issue title shares significant keywords with the new title
     local existing_titles
@@ -759,6 +779,18 @@ cmd_critical_path_depth() {
 cmd_claim() {
     local issue_num="${1:?usage: coordination claim N}"
 
+    # Provenance gate (defense-in-depth on top of repo-level interaction
+    # limits). Refuse to claim issues whose body or any comment was
+    # written by an account without a trusted association with the repo.
+    # Always uses --fresh so a comment added between list-time caching
+    # and now can't sneak past.
+    local prov_err
+    if ! prov_err="$(pod _check-provenance "$issue_num" --fresh 2>&1)"; then
+        echo "CLAIM FAILED: $prov_err"
+        echo "You MUST NOT work on this issue. Pick a different issue immediately."
+        return 1
+    fi
+
     # Check if already claimed
     local labels
     labels="$(gh issue view "$issue_num" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')"
@@ -1124,6 +1156,35 @@ EOF
     echo "Planner min_queue set to $n"
 }
 
+# --- read-issue ---
+# Read a single issue's body (or other JSON fields), gated by the
+# provenance check so untrusted text never reaches the agent's prompt.
+# Used by the agent-worker-flow skill in place of `gh issue view`.
+#
+# Usage: coordination read-issue N [--json FIELDS] [--jq EXPR]
+# Defaults: --json body --jq .body  (matches the bare `gh issue view --jq .body` pattern)
+cmd_read_issue() {
+    local issue_num="${1:?usage: coordination read-issue N [--json FIELDS] [--jq EXPR]}"
+    shift
+    local json_fields="body"
+    local jq_expr=".body"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json) json_fields="${2:?--json requires a value}"; shift 2 ;;
+            --jq)   jq_expr="${2:?--jq requires a value}"; shift 2 ;;
+            *) die "unknown arg to read-issue: $1" ;;
+        esac
+    done
+
+    local prov_err
+    if ! prov_err="$(pod _check-provenance "$issue_num" --fresh 2>&1)"; then
+        echo "READ FAILED: $prov_err" >&2
+        return 1
+    fi
+
+    gh issue view "$issue_num" --repo "$REPO" --json "$json_fields" --jq "$jq_expr"
+}
+
 # --- nothing-to-plan ---
 # Deprecated: this is now a no-op. Planners should use set-target/set-min-queue instead.
 cmd_nothing_to_plan() {
@@ -1160,6 +1221,7 @@ case "${1:-}" in
     nothing-to-plan)        cmd_nothing_to_plan ;;
     set-target)          shift; cmd_set_target "$@" ;;
     set-min-queue)       shift; cmd_set_min_queue "$@" ;;
+    read-issue)          shift; cmd_read_issue "$@" ;;
     *)               die "unknown command: ${1:-}
-Usage: coordination {orient|plan [--label L] [--critical-path]|create-pr|claim-fix|close-pr|list-pr-repair|claim-pr-repair|mark-pr-salvaged|close-pr-unsalvageable|list-unclaimed [--label L]|queue-depth [L]|critical-path-depth|claim|skip|add-dep|check-blocked|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner|return-to-human|check-return-to-human|clear-return-to-human|nothing-to-plan|set-target|set-min-queue}" ;;
+Usage: coordination {orient|plan [--label L] [--critical-path]|create-pr|claim-fix|close-pr|list-pr-repair|claim-pr-repair|mark-pr-salvaged|close-pr-unsalvageable|list-unclaimed [--label L]|queue-depth [L]|critical-path-depth|claim|skip|add-dep|check-blocked|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner|return-to-human|check-return-to-human|clear-return-to-human|nothing-to-plan|set-target|set-min-queue|read-issue}" ;;
 esac

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -207,5 +207,163 @@ class SpawnAgentSecurityGateTests(unittest.TestCase):
         fork.assert_not_called()
 
 
+def _prov(*, author_login="alice", author_assoc="OWNER", comments=()):
+    return cli._IssueProvenance(
+        repo="o/r", issue_num=1,
+        author_login=author_login, author_association=author_assoc,
+        comments=[
+            cli._ProvenanceComment(comment_id=cid, login=login, association=assoc)
+            for cid, login, assoc in comments
+        ],
+        fetched_at=datetime.datetime.now(datetime.timezone.utc).timestamp(),
+    )
+
+
+class IsTrustedTests(unittest.TestCase):
+    def test_owner_no_comments_trusted(self):
+        ok, reason = cli.is_trusted(_prov(), {})
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
+    def test_member_collaborator_trusted(self):
+        for assoc in ("OWNER", "MEMBER", "COLLABORATOR"):
+            ok, _ = cli.is_trusted(_prov(author_assoc=assoc), {})
+            self.assertTrue(ok, assoc)
+
+    def test_none_author_rejected_with_login_in_reason(self):
+        ok, reason = cli.is_trusted(
+            _prov(author_login="attacker", author_assoc="NONE"), {})
+        self.assertFalse(ok)
+        self.assertIn("@attacker", reason)
+        self.assertIn("NONE", reason)
+
+    def test_contributor_rejected_by_default(self):
+        # CONTRIBUTOR = "previously merged a PR" — not a trust signal.
+        ok, reason = cli.is_trusted(
+            _prov(author_login="bob", author_assoc="CONTRIBUTOR"), {})
+        self.assertFalse(ok)
+        self.assertIn("@bob", reason)
+
+    def test_untrusted_comment_rejected_with_comment_id(self):
+        ok, reason = cli.is_trusted(
+            _prov(comments=[(12345, "attacker", "NONE")]), {})
+        self.assertFalse(ok)
+        self.assertIn("c#12345", reason)
+        self.assertIn("@attacker", reason)
+
+    def test_trusted_users_promotes_none_author(self):
+        ok, _ = cli.is_trusted(
+            _prov(author_login="dependabot[bot]", author_assoc="NONE"),
+            {"security": {"trusted_users": ["dependabot[bot]"]}})
+        self.assertTrue(ok)
+
+    def test_trusted_users_promotes_none_commenter(self):
+        ok, _ = cli.is_trusted(
+            _prov(comments=[(1, "ci-bot", "NONE")]),
+            {"security": {"trusted_users": ["ci-bot"]}})
+        self.assertTrue(ok)
+
+    def test_disabled_short_circuits(self):
+        ok, _ = cli.is_trusted(
+            _prov(author_assoc="NONE"),
+            {"security": {"trust_only_collaborators": False}})
+        self.assertTrue(ok)
+
+    def test_custom_trusted_assocs(self):
+        # Operator drops MEMBER from trust set — MEMBER author now rejected.
+        ok, _ = cli.is_trusted(
+            _prov(author_assoc="MEMBER"),
+            {"security": {"trusted_author_associations":
+                          ["OWNER", "COLLABORATOR"]}})
+        self.assertFalse(ok)
+
+
+class ProvenanceCacheTests(unittest.TestCase):
+    def setUp(self):
+        cli._provenance_cache.clear()
+
+    def _patch_fetch(self, prov):
+        # Patch the fetcher and visibility check; return mock for assertions.
+        return mock.patch.multiple(
+            cli,
+            fetch_issue_provenance=mock.MagicMock(return_value=prov),
+            _is_repo_public=mock.MagicMock(return_value=True),
+        )
+
+    def test_cached_call_reuses(self):
+        prov = _prov()
+        with self._patch_fetch(prov):
+            cli.check_issue_provenance("o/r", 1, {})
+            cli.check_issue_provenance("o/r", 1, {})
+            self.assertEqual(cli.fetch_issue_provenance.call_count, 1)
+
+    def test_fresh_bypasses_cache(self):
+        prov = _prov()
+        with self._patch_fetch(prov):
+            cli.check_issue_provenance("o/r", 1, {})
+            cli.check_issue_provenance("o/r", 1, {}, fresh=True)
+            self.assertEqual(cli.fetch_issue_provenance.call_count, 2)
+
+    def test_ttl_expiry_refetches(self):
+        prov = _prov()
+        with self._patch_fetch(prov):
+            cli.check_issue_provenance("o/r", 1, {})
+            # Age the cached entry past TTL.
+            cached = cli._provenance_cache[("o/r", 1)]
+            cached.fetched_at -= cli._provenance_ttl({}) + 1
+            cli.check_issue_provenance("o/r", 1, {})
+            self.assertEqual(cli.fetch_issue_provenance.call_count, 2)
+
+    def test_private_repo_short_circuits(self):
+        with mock.patch.object(cli, "_is_repo_public", return_value=False), \
+             mock.patch.object(cli, "fetch_issue_provenance") as fetch:
+            ok, _ = cli.check_issue_provenance("o/r", 1, {})
+        self.assertTrue(ok)
+        fetch.assert_not_called()
+
+    def test_disabled_short_circuits(self):
+        with mock.patch.object(cli, "fetch_issue_provenance") as fetch, \
+             mock.patch.object(cli, "_is_repo_public", return_value=True):
+            ok, _ = cli.check_issue_provenance(
+                "o/r", 1, {"security": {"trust_only_collaborators": False}})
+        self.assertTrue(ok)
+        fetch.assert_not_called()
+
+
+class ValidateProvenanceConfigTests(unittest.TestCase):
+    def test_defaults_pass(self):
+        cli.validate_security_config({})
+
+    def test_explicit_associations_pass(self):
+        cli.validate_security_config(
+            {"security": {"trusted_author_associations":
+                          ["OWNER", "COLLABORATOR"]}})
+
+    def test_typo_association_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.validate_security_config(
+                {"security": {"trusted_author_associations": ["OWNERR"]}})
+
+    def test_non_list_associations_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.validate_security_config(
+                {"security": {"trusted_author_associations": "OWNER"}})
+
+    def test_non_list_trusted_users_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.validate_security_config(
+                {"security": {"trusted_users": "dependabot"}})
+
+    def test_negative_cache_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.validate_security_config(
+                {"security": {"provenance_cache_seconds": -1}})
+
+    def test_non_bool_trust_rejected(self):
+        with self.assertRaises(SystemExit):
+            cli.validate_security_config(
+                {"security": {"trust_only_collaborators": "yes"}})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds a per-message author provenance gate that refuses to surface issue bodies / comments authored by accounts without a trusted association with the repo. Decided per message via GitHub's `authorAssociation` field, so it works without admin scope and covers content posted *before* any interaction-limit was set.

Stacked on top of #40 (the repo-wide interaction-limit check). The interaction-limit gate is forward-only — it restricts new posts but doesn't reach back through history. This gate closes that residual gap, and also defends against issues labeled long after creation, against comments added between issue discovery and read, and against the planner's pre-claim body reads (which are an exposure the interaction-limit check does nothing for).

Mechanism:

- New internal pod CLI helpers (underscore-prefixed):
  - `pod _check-provenance N [--fresh]` — single-issue gate (exit 0 / 1 + grep-friendly reason on stderr).
  - `pod _filter-trusted-issues [...gh-issue-list-args...]` — runs `gh issue list` once, filters out untrusted issues in one Python pass, applies `--jq`. Replaces inline `gh issue list` calls without a fork-per-issue.
- Coordination changes:
  - `claim N` calls `_check-provenance --fresh` before claiming.
  - `_unclaimed_issues` (used by `list-unclaimed` and `queue-depth`) routes through `_filter-trusted-issues`. `POD_INCLUDE_UNTRUSTED=1` surfaces rejected issues annotated `[UNTRUSTED: ...]`.
  - `orient`'s blocked-issues section likewise filtered (it parses body for depends-on refs).
  - New `read-issue N` subcommand wraps `gh issue view` with a fresh provenance check; replaces direct `gh issue view` in the agent-worker-flow skill.
  - `plan` overlap detection drops `body` from its query (only titles were used).
- Agent instructions (claude + codex variants):
  - `agent-worker-flow` SKILL.md uses `coordination read-issue` instead of `gh issue view`.
  - `plan.md` Steps 3 (replan triage) and 5 (understand existing plans) use `pod _filter-trusted-issues` in place of inline `gh issue list ... --json ...,body`. Other `gh issue list` calls in plan.md are title-only and don't need gating.
- `[security]` config additions, validated at load time so typos fail loudly:
  - `trust_only_collaborators` (default true)
  - `trusted_author_associations` (default `["OWNER","MEMBER","COLLABORATOR"]`; typos rejected against GitHub's enum)
  - `trusted_users` (bot allowlist for accounts with NONE association — dependabot[bot], CI status bots commenting on issues, etc.)
  - `provenance_cache_seconds` (default 60; applies to list/orient only — claim and read always re-check fresh, closing the comment-between-discovery-and-read race)

Caveats documented honestly in the README:

- `MEMBER` is org membership, not write access on this specific repo. On an org repo it trusts every org member, including users who can't push here. Drop `MEMBER` from `trusted_author_associations` for stricter behaviour.
- Out of scope (named so we don't oversell): PR diffs and review comments, CI logs (relevant to `/repair`!), repository file contents, linked-issue follow-ups the agent fetches mid-session, and text a *trusted* collaborator pastes into an issue from an untrusted source. Provenance ≠ semantic sanitization.

Tested manually against `kim-em/hex` (OWNER → all paths trusted) including end-to-end coordination calls (`read-issue 2544`, `list-unclaimed`), and via 21 new mocked unittests covering the policy function, cache behaviour, fresh-bypass, private-repo short-circuit, and config validation. Full suite is 135 tests, all green.

🤖 Prepared with Claude Code

- [ ] depends on: https://github.com/FormalFrontier/pod/pull/40