### PR TITLE
fix: release GitHub claim and clean up state when agent process crashes

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -40,6 +40,7 @@ import sys
 import threading
 import time
 import tomllib
+import traceback
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -4509,18 +4510,46 @@ _agent_proc: subprocess.Popen | None = None
 _agent_config: dict = {}
 
 
-def _sigterm_handler(signum, frame):
-    """Handle SIGTERM: kill claude, unclaim, cleanup, exit."""
+def _release_agent_resources(reason: str, skip_msg: str) -> None:
+    """Tear down this agent's resources before exit.
+
+    Kills any child claude/codex subprocess, unclaims the agent's GitHub
+    issue (if any), releases its dispatch lock, cleans up its worktree,
+    and removes its state file.
+
+    Used both by the SIGTERM path and the unhandled-exception path in
+    `spawn_agent`. Without this on the crash path, an unhandled exception
+    in `agent_process_main` (e.g. a stale `_data_dir()` path after an
+    editable-install switcheroo, a transient GitHub failure, an OOM in a
+    helper) would leave the GitHub `claimed` label and the
+    `claim-history.json` entry orphaned: the issue would sit unclaimable
+    until the next housekeeping cycle's dead-claim sweep, and the
+    operator would just see "agent disappeared from the TUI" with no
+    indication of why.
+
+    `reason` becomes the agent's `status` ("killed", "crashed", …) and
+    is excluded from the "another live agent has this claim" check so
+    the unclaim path is taken correctly.
+
+    `skip_msg` is the operator-visible reason recorded by
+    `coordination skip`. Callers should embed enough detail (session
+    UUID, exception text) to identify the failure post-hoc.
+
+    Idempotent. Safe to call from a signal handler or from a
+    `try/except` in the grandchild process.
+    """
     global _agent_state, _agent_proc, _agent_config
     state = _agent_state
     config = _agent_config
 
     if state:
-        log(f"Agent {state.short_id} received SIGTERM")
-        state.status = "killed"
-        state.write()
+        state.status = reason
+        try:
+            state.write()
+        except OSError:
+            pass
 
-    # Kill claude subprocess
+    # Kill the child agent subprocess (claude/codex), if still running.
     if _agent_proc and _agent_proc.poll() is None:
         try:
             os.killpg(os.getpgid(_agent_proc.pid), signal.SIGTERM)
@@ -4539,28 +4568,35 @@ def _sigterm_handler(signum, frame):
         # live agent is also working on this issue (prevents unclaiming
         # when killing duplicate claimants).
         if state.claimed_issue > 0 and state.pr_number == 0:
+            try:
+                other_agents = read_all_agents()
+            except Exception:
+                other_agents = []
             other_live = any(
                 a.claimed_issue == state.claimed_issue
                 and a.uuid != state.uuid
-                and a.status not in ("dead", "stopped", "killed")
-                for a in read_all_agents()
+                and a.status not in ("dead", "stopped", "killed", "crashed")
+                for a in other_agents
             )
             if other_live:
                 log(f"Agent {state.short_id}: not unclaiming #{state.claimed_issue} — another agent has it")
-                clear_claim(state.claimed_issue, session_uuid=state.uuid)
+                try:
+                    clear_claim(state.claimed_issue, session_uuid=state.uuid)
+                except Exception:
+                    pass
             else:
                 try:
                     coordination(
                         config, "skip", str(state.claimed_issue),
-                        f"Agent killed by operator (session {state.uuid})",
+                        skip_msg,
                         env_extra={"POD_SESSION_ID": state.uuid},
                     )
                     clear_claim(state.claimed_issue, session_uuid=state.uuid)
                     log(f"Unclaimed issue #{state.claimed_issue}")
-                except Exception:
+                except Exception as e:
                     # Don't clear_claim — leave in history so housekeeping
                     # can retry the GitHub label removal later.
-                    log(f"Failed to skip #{state.claimed_issue} on kill, keeping in history")
+                    log(f"Failed to skip #{state.claimed_issue} on {reason} ({e}), keeping in history")
 
         # Release lock if held
         if state.lock_held:
@@ -4572,10 +4608,26 @@ def _sigterm_handler(signum, frame):
 
         # Cleanup worktree
         if state.worktree and state.branch:
-            cleanup_worktree(state.worktree, state.branch)
+            try:
+                cleanup_worktree(state.worktree, state.branch)
+            except Exception as e:
+                log(f"Worktree cleanup failed on {reason}: {e}")
 
-        state.remove_file()
+        try:
+            state.remove_file()
+        except OSError:
+            pass
 
+
+def _sigterm_handler(signum, frame):
+    """Handle SIGTERM: kill claude, unclaim, cleanup, exit."""
+    state = _agent_state
+    if state:
+        log(f"Agent {state.short_id} received SIGTERM")
+        skip_msg = f"Agent killed by operator (session {state.uuid})"
+    else:
+        skip_msg = "Agent killed by operator"
+    _release_agent_resources("killed", skip_msg)
     os._exit(0)
 
 
@@ -5155,7 +5207,28 @@ def spawn_agent(config: dict, agent_id: str | None = None,
         os.close(devnull_w)
         agent_process_main(config, agent_id, resume_uuid)
     except Exception as e:
-        log(f"Agent process crashed: {e}")
+        # Log the full traceback so the operator can diagnose post-hoc.
+        # The agent's stdout went to /dev/null after the dup2 above, so
+        # this `log` call (which writes to .pod/pod.log) is the only
+        # surviving record.
+        log(f"Agent process crashed: {e}\n{traceback.format_exc()}")
+        # Best-effort cleanup so the GitHub claim is released and the
+        # state file is removed; otherwise the issue sits in
+        # claim-history.json with `released: false` and the GitHub
+        # `claimed` label, blocking other agents from picking it up
+        # until the next housekeeping dead-claim sweep notices the
+        # session UUID is dead. Wrap in its own try/except because the
+        # crash itself may have come from a broken environment in which
+        # the cleanup helpers will also raise (e.g. a stale `_data_dir()`
+        # path after an editable-install switcheroo).
+        sid = _agent_state.short_id if _agent_state else "?"
+        uid = _agent_state.uuid if _agent_state else "?"
+        skip_msg = f"Agent crashed: {e!s} (session {uid})"
+        try:
+            _release_agent_resources("crashed", skip_msg)
+        except Exception as cleanup_e:
+            log(f"Agent {sid}: crash cleanup also failed: {cleanup_e}\n"
+                f"{traceback.format_exc()}")
     finally:
         os._exit(0)
 


### PR DESCRIPTION
This PR fixes a class of bugs where an unhandled exception in `agent_process_main` (the body of a forked agent) caused the process to die silently, the TUI to drop the agent from its list, and the agent's GitHub issue claim to sit orphaned in `claim-history.json` until the next housekeeping dead-claim sweep noticed.

## Symptom

Operator presses a TUI key (`!` to skip the local quota wait, in the case I hit), the agent disappears from the TUI list, and a previously-claimed GitHub issue remains in the `claimed` label and `claim-history.json` with `released: false`. There's no clear error in `pod.log` because only `str(e)` is recorded, no traceback.

## Concrete trigger I encountered

A long-running pod TUI started before an editable-install switcheroo had `pod.cli.__file__` cached to the old install path. After the install was converted to editable (`uv tool install -e ...`), the bundled `data/coordination` script lived under the editable source tree, but the cached `__file__` still pointed at the now-deleted install path. When I pressed `!` to release a paused agent, the agent woke from its quota wait, broke out, and called `coordination(...)` from the dispatch path, which tried to exec the stale path and raised `FileNotFoundError`. The exception killed the process and left the issue stuck on `claimed`.

The pre-fix log showed only:

```
[2026-05-07 16:31:48] Agent 39c3c101: force_quota enabled, skipping wait
[2026-05-07 16:31:58] Agent process crashed: [Errno 2] No such file or directory: '/Users/kim/.local/share/uv/tools/dev-pod/lib/python3.11/site-packages/pod/data/coordination'
```

…then nothing about the agent. The TUI list dropped by one. The GitHub issue stayed labelled `claimed`.

The stale-`__file__` is a one-off, but the same shape — uncaught exception in the agent loop → claim leak → silent disappearance — applies to any future bug in `coordination()`, transient GitHub failures, OOM in a helper, etc. So the fix is to make the crash path actually clean up.

## Changes

- Extracts the SIGTERM cleanup body in `_sigterm_handler` into a shared helper `_release_agent_resources(reason, skip_msg)`. The helper is more defensive than the original — each `coordination` / subprocess / filesystem call now has its own `try/except` so a partial failure doesn't skip downstream cleanup. SIGTERM behavior is unchanged.
- Wraps the crash path in `spawn_agent`'s grandchild with that cleanup, so an unhandled exception in `agent_process_main` now releases the GitHub claim, kills any child claude/codex subprocess, releases the dispatch lock, cleans up the worktree, and removes the state file — same as a SIGTERM.
- Logs the full traceback via `traceback.format_exc()` (writing to `pod.log`, since stdout is `/dev/null`-ed in the grandchild) instead of just `str(e)`, so post-hoc diagnosis is actually possible.
- Adds `"crashed"` to the set of statuses excluded from the "another live agent has this claim" check, so the unclaim path is taken correctly when the only claimant of an issue is the one that just crashed.

## Verification

- `python3 -m pytest tests/ -q` → 135 passed.
- I'll redeploy this in the wild repo where I hit the original bug; if the next crash-by-stale-path leaves the claim cleanly released, that's the expected behavior.

🤖 Prepared with Claude Code