### PR TITLE
fix: prevent has-pr / blocked label drift and surface PR# in TUI

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1832,13 +1832,18 @@ def fetch_issues_and_prs() -> list[GHItem]:
 
 
 def fetch_blocked_deps() -> dict[int, list[int]]:
-    """Fetch open depends-on dependencies for blocked issues (closed deps filtered out)."""
+    """Fetch open depends-on dependencies for blocked issues (closed deps filtered out).
+
+    Queries every open `blocked` issue regardless of family label
+    (`agent-plan`, `human-oversight`, etc.) so the TUI can render
+    `[Blocked on #N]` annotations consistently.
+    """
     import re as _re
     cwd = str(PROJECT_DIR)
     try:
         r = subprocess.run(
-            ["gh", "issue", "list", "--label", "agent-plan", "--label", "blocked",
-             "--state", "open", "--limit", "20", "--json", "number,body"],
+            ["gh", "issue", "list", "--label", "blocked",
+             "--state", "open", "--limit", "40", "--json", "number,body"],
             capture_output=True, text=True, timeout=30, cwd=cwd,
         )
         if r.returncode != 0:
@@ -1862,6 +1867,52 @@ def fetch_blocked_deps() -> dict[int, list[int]]:
 
         return {num: filtered for num, deps in raw.items()
                 if (filtered := [d for d in deps if d in open_nums])}
+    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+        return {}
+
+
+def fetch_has_pr_links() -> dict[int, list[int]]:
+    """Fetch open linked PRs for each open `has-pr` issue.
+
+    Returned dict maps issue number → list of OPEN PR numbers that
+    reference the issue via `Closes #N` (GitHub's `closedByPullRequestsReferences`).
+    An empty list means the `has-pr` label is orphan: every PR that
+    once linked the issue has merged or been closed without
+    auto-closing it. The caller should still emit the entry so the
+    TUI can flag the orphan; auto-cleanup happens in housekeeping
+    via `coordination check-has-pr`.
+    """
+    cwd = str(PROJECT_DIR)
+    try:
+        r = subprocess.run(
+            ["gh", "issue", "list", "--label", "has-pr",
+             "--state", "open", "--limit", "40", "--json", "number"],
+            capture_output=True, text=True, timeout=30, cwd=cwd,
+        )
+        if r.returncode != 0:
+            return {}
+
+        issue_nums = [iss["number"] for iss in json.loads(r.stdout)]
+        if not issue_nums:
+            return {}
+
+        result: dict[int, list[int]] = {}
+        for num in issue_nums:
+            r2 = subprocess.run(
+                ["gh", "issue", "view", str(num),
+                 "--json", "closedByPullRequestsReferences",
+                 "--jq", "[.closedByPullRequestsReferences[] "
+                        "| select(.state == \"OPEN\") | .number]"],
+                capture_output=True, text=True, timeout=15, cwd=cwd,
+            )
+            if r2.returncode == 0:
+                try:
+                    result[num] = json.loads(r2.stdout) or []
+                except json.JSONDecodeError:
+                    result[num] = []
+            else:
+                result[num] = []
+        return result
     except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
         return {}
 
@@ -5075,7 +5126,7 @@ def agent_process_main(config: dict, agent_id: str | None = None,
 
     iteration = 0
     consecutive_wait = 0  # Consecutive dispatch-returned-None iterations (for backoff)
-    HOUSEKEEPING_INTERVAL = 600  # seconds between housekeeping runs (check-blocked, dead claims)
+    HOUSEKEEPING_INTERVAL = 600  # seconds between housekeeping runs (check-blocked, check-has-pr, dead claims)
     while not state.finishing:
         iteration += 1
         state.loop_iteration = iteration
@@ -5148,6 +5199,10 @@ def agent_process_main(config: dict, agent_id: str | None = None,
                 if _gh_quota_ok():
                     try:
                         coordination(config, "check-blocked")
+                    except Exception:
+                        pass
+                    try:
+                        coordination(config, "check-has-pr")
                     except Exception:
                         pass
                     try:
@@ -5675,6 +5730,8 @@ def _tui_main(stdscr, config: dict):
     items_fetch_time = 0.0
     cached_blocked_deps: dict[int, list[int]] = {}
     blocked_deps_fetch_time = 0.0
+    cached_has_pr_links: dict[int, list[int]] = {}
+    has_pr_links_fetch_time = 0.0
     cached_lock_status: str | None = None  # "locked" or "unlocked"
     lock_fetch_time = 0.0
     # (The repair worker type, if configured, is dispatched directly by
@@ -5713,7 +5770,8 @@ def _tui_main(stdscr, config: dict):
 
     # Background fetch infrastructure: all GH/coordination calls run in daemon
     # threads so the TUI never blocks on network I/O.
-    _bg_data: dict = {"queue": None, "items": None, "blocked_deps": None, "lock_status": None,
+    _bg_data: dict = {"queue": None, "items": None, "blocked_deps": None,
+                      "has_pr_links": None, "lock_status": None,
                       "return_to_human": None}
     _bg_active: set = set()
     _bg_mutex = threading.Lock()
@@ -5804,6 +5862,9 @@ def _tui_main(stdscr, config: dict):
         if now - blocked_deps_fetch_time > CACHE_SECS_SLOW:
             _bg_fetch("blocked_deps", fetch_blocked_deps)
             blocked_deps_fetch_time = now
+        if now - has_pr_links_fetch_time > CACHE_SECS_SLOW:
+            _bg_fetch("has_pr_links", fetch_has_pr_links)
+            has_pr_links_fetch_time = now
         # Return-to-human signal: planner labels sentinel issue when no work remains.
         # Poll continuously so we observe both label re-applications (planner re-fires
         # after each empty-queue tick) and external clears (`gh issue edit --remove-label`).
@@ -5828,6 +5889,8 @@ def _tui_main(stdscr, config: dict):
                 cached_items = _bg_data["items"]
             if _bg_data["blocked_deps"] is not None:
                 cached_blocked_deps = _bg_data["blocked_deps"]
+            if _bg_data["has_pr_links"] is not None:
+                cached_has_pr_links = _bg_data["has_pr_links"]
             if _bg_data["lock_status"] is not None:
                 cached_lock_status = _bg_data["lock_status"]
             if _bg_data["return_to_human"] is not None:
@@ -6062,6 +6125,14 @@ def _tui_main(stdscr, config: dict):
                 if "blocked" in item.labels and item.number in cached_blocked_deps:
                     deps = cached_blocked_deps[item.number]
                     title = f"[Blocked on {', '.join(f'#{d}' for d in deps)}] {title}"
+                elif "has-pr" in item.labels and item.kind == "issue":
+                    if item.number in cached_has_pr_links:
+                        prs = cached_has_pr_links[item.number]
+                        if prs:
+                            tag = "PR " + ", ".join(f"#{p}" for p in prs)
+                        else:
+                            tag = "PR ?"
+                        title = f"[{tag}] {title}"
                 # Truncate title to fit
                 prefix_len = 31
                 max_title = width - prefix_len - 1

--- a/pod/data/agent-config/claude/commands/plan.md
+++ b/pod/data/agent-config/claude/commands/plan.md
@@ -23,6 +23,17 @@ These are direct instructions from the project owner. Treat them as highest prio
 - **Do not create issues that overlap with or supersede a `human-oversight` issue**
 - **Do not close `human-oversight` issues** — only the owner closes them
 - **Do not add `replan` to `human-oversight` issues** — they stay open until done
+- **Do not hand-apply `has-pr` to a `human-oversight` issue** to "park" it
+  while sub-issues do the work. `has-pr` is owned by `coordination create-pr`
+  alone — applied automatically when a PR with `Closes #N` is opened, removed
+  automatically when GitHub auto-closes the issue on merge. Manual
+  application desynchronises the label from any real PR; when the partial
+  PR merges (without `Closes #N`) the issue stays `has-pr` forever and is
+  silently excluded from the work queue. To park a decomposed directive
+  cleanly, run `coordination add-dep <directive> <sub-issue>` for each open
+  sub-issue: the directive becomes `blocked` and auto-unblocks when all
+  subs close. The housekeeping cycle (`check-has-pr`, `check-blocked`) will
+  remove orphan labels and post an audit comment.
 - If a `human-oversight` issue is already claimed, continue to Step 2 (workers are on it)
 - If unclaimed, prioritise creating any supporting infrastructure issues first, then exit
   — the next worker will claim the directive itself

--- a/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
@@ -27,7 +27,8 @@ The `gh` CLI defaults to the current repo, so `--repo` is not needed.
 | `coordination claim N` | Claim issue #N — adds `claimed` label + comment, detects races |
 | `coordination skip N "reason"` | Mark claimed issue as needing replan — removes `claimed`, adds `replan` label |
 | `coordination add-dep N M` | Add `depends-on: #M` to issue #N's body; adds `blocked` label if #M is open |
-| `coordination check-blocked` | Unblock issues whose `depends-on` dependencies are all closed |
+| `coordination check-blocked` | Unblock issues whose `depends-on` dependencies are all closed; remove orphan `blocked` from issues whose body has no `depends-on:` lines |
+| `coordination check-has-pr` | Remove orphan `has-pr` from open issues that have no currently-open PR closing them (post audit comment) |
 | `coordination release-stale-claims [SECS]` | Release claimed issues with no PR after SECS seconds (default 4h); **manual use only** |
 | `coordination lock-planner` | Acquire advisory planner lock (20min TTL) |
 | `coordination unlock-planner` | Release planner lock early |
@@ -40,6 +41,18 @@ worker claims it (adds label: `claimed`) → worker creates PR closing it
 Issues marked `replan` (by skip, partial completion, or worker-led
 decomposition) are handled by the next planner. Issues with `has-pr` are
 excluded from `list-unclaimed` and `queue-depth`.
+
+**Never apply `has-pr` manually.** The label is set automatically by
+`coordination create-pr` (full path) and cleared by GitHub's auto-close
+on merge of a `Closes #N` PR. Hand-applying it desynchronises the label
+from any actual PR — when the supposed PR closes or merges without
+`Closes #N`, the issue stays `has-pr` forever and is silently excluded
+from the work queue. If you want to "park" an issue while sub-issues
+do the work, use `coordination add-dep <parent> <sub>` for each
+sub-issue: the parent becomes `blocked`, and `check-blocked` auto-clears
+the label when all subs close. The orphan-label housekeeping cycle
+(`check-has-pr`, `check-blocked`) auto-removes mis-applied labels and
+posts an audit comment on the issue.
 
 **Partial completion**: worker uses `--partial` → label swaps to
 `replan`. A planner creates a new issue for remaining work, then closes

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -21,7 +21,8 @@
 #   coordination claim N                      — claim an issue for this session (label + comment)
 #   coordination skip N "reason"              — mark a claimed issue as replan (stale/wrong assumptions)
 #   coordination add-dep N M                  — add depends-on: #M to issue #N's body; add blocked label if #M is open
-#   coordination check-blocked                — unblock issues whose dependencies are all closed
+#   coordination check-blocked                — unblock issues whose dependencies are all closed; remove orphan blocked from issues with no depends-on lines
+#   coordination check-has-pr                 — remove orphan has-pr from issues with no open linked PR
 #   coordination release-stale-claims [SECS]  — release claimed issues with no activity for SECS seconds (default 14400 = 4h)
 #   coordination lock-planner                 — acquire advisory planner lock (20min TTL)
 #   coordination unlock-planner               — release planner lock early
@@ -397,6 +398,20 @@ cmd_create_pr() {
     existing_pr="$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq '.[0].number // empty')"
     if [[ -n "$existing_pr" ]]; then
         echo "PR #$existing_pr already exists for branch $BRANCH. Enabling auto-merge."
+        # Defensive guard for the full-PR path: refuse to set `has-pr` on
+        # the issue unless the existing PR's body contains a closing keyword
+        # for it. Otherwise GitHub will not auto-close the issue when the PR
+        # merges, leaving an orphan `has-pr` label that silently excludes
+        # the issue from `list-unclaimed` and `queue-depth` forever.
+        if [[ "$partial" == false ]]; then
+            local existing_body
+            existing_body="$(gh pr view "$existing_pr" --repo "$REPO" --json body --jq .body 2>/dev/null || true)"
+            if ! grep -qiE "(closes|fixes|resolves) #${issue_num}\b" <<<"$existing_body"; then
+                die "PR #$existing_pr body does not reference 'Closes #${issue_num}'.
+Refusing to set 'has-pr' on issue #${issue_num} — the label would become orphan after merge.
+Either edit the PR body to add 'Closes #${issue_num}', or rerun 'coordination create-pr ${issue_num} --partial'."
+            fi
+        fi
         gh pr merge "$existing_pr" --repo "$REPO" --auto --squash --delete-branch || \
             echo "warning: auto-merge not available (branch protection may not be set up)"
         if [[ "$partial" == true ]]; then
@@ -1051,7 +1066,17 @@ cmd_check_blocked() {
 
         local deps
         deps="$(echo "$body" | grep -oE 'depends-on: #[0-9]+' | grep -oE '[0-9]+' || true)"
-        [[ -z "$deps" ]] && continue
+        if [[ -z "$deps" ]]; then
+            # Orphan blocked: no `depends-on:` lines in body. The label was
+            # applied without recording any dependency, so check-blocked has
+            # no condition under which it could ever clear it. Remove and
+            # log so the issue re-enters the work queue.
+            gh issue edit "$num" --repo "$REPO" --remove-label blocked
+            gh issue comment "$num" --repo "$REPO" \
+                --body "Orphan \`blocked\` removed: issue body has no \`depends-on: #N\` lines, so the label could not be auto-cleared. Use \`coordination add-dep\` to record dependencies properly."
+            echo "Cleared orphan blocked on #$num (no depends-on lines in body)"
+            continue
+        fi
 
         local all_closed=true
         while read -r dep_num; do
@@ -1068,6 +1093,51 @@ cmd_check_blocked() {
             gh issue edit "$num" --repo "$REPO" --remove-label blocked
             echo "Unblocked issue #$num (all dependencies resolved)"
         fi
+    done
+}
+
+# --- check-has-pr ---
+# Scan open `has-pr` issues and remove the label from those with no open
+# linked PR (i.e. every PR that referenced the issue via Closes/Fixes/Resolves
+# has merged or been closed without GitHub auto-closing the issue, so the
+# label is stale and silently excludes the issue from the work queue).
+cmd_check_has_pr() {
+    local issues
+    issues="$(gh issue list --repo "$REPO" --label has-pr --state open --limit 50 \
+        --json number,title)"
+
+    echo "$issues" | jq -c '.[]' | \
+    while read -r issue_json; do
+        local num title
+        num="$(echo "$issue_json" | jq -r '.number')"
+        title="$(echo "$issue_json" | jq -r '.title')"
+
+        local open_prs
+        open_prs="$(gh issue view "$num" --repo "$REPO" \
+            --json closedByPullRequestsReferences \
+            --jq '[.closedByPullRequestsReferences[] | select(.state == "OPEN") | .number] | join(",")' \
+            2>/dev/null || true)"
+
+        if [[ -n "$open_prs" ]]; then
+            continue
+        fi
+
+        # No open linked PRs. Collect any closed/merged ones to attribute
+        # in the audit comment.
+        local prior_prs
+        prior_prs="$(gh issue view "$num" --repo "$REPO" \
+            --json closedByPullRequestsReferences \
+            --jq '[.closedByPullRequestsReferences[] | "#\(.number) (\(.state | ascii_downcase))"] | join(", ")' \
+            2>/dev/null || echo "")"
+        local prior_msg=""
+        if [[ -n "$prior_prs" && "$prior_prs" != "" ]]; then
+            prior_msg=" Last linked PRs: ${prior_prs}."
+        fi
+
+        gh issue edit "$num" --repo "$REPO" --remove-label has-pr
+        gh issue comment "$num" --repo "$REPO" \
+            --body "Orphan \`has-pr\` removed: no open PR currently references this issue with \`Closes #${num}\`.${prior_msg} If decomposition is in flight, use \`coordination add-dep\` to record sub-issue dependencies; the directive will become \`blocked\` until they close."
+        echo "Cleared orphan has-pr on #$num ($title)"
     done
 }
 
@@ -1210,6 +1280,7 @@ case "${1:-}" in
     skip)            shift; cmd_skip "$@" ;;
     add-dep)                shift; cmd_add_dep "$@" ;;
     check-blocked)          cmd_check_blocked ;;
+    check-has-pr)           cmd_check_has_pr ;;
     release-stale-claims)   shift; cmd_release_stale_claims "$@" ;;
     lock-planner)           cmd_lock_planner ;;
     unlock-planner)         cmd_unlock_planner ;;
@@ -1223,5 +1294,5 @@ case "${1:-}" in
     set-min-queue)       shift; cmd_set_min_queue "$@" ;;
     read-issue)          shift; cmd_read_issue "$@" ;;
     *)               die "unknown command: ${1:-}
-Usage: coordination {orient|plan [--label L] [--critical-path]|create-pr|claim-fix|close-pr|list-pr-repair|claim-pr-repair|mark-pr-salvaged|close-pr-unsalvageable|list-unclaimed [--label L]|queue-depth [L]|critical-path-depth|claim|skip|add-dep|check-blocked|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner|return-to-human|check-return-to-human|clear-return-to-human|nothing-to-plan|set-target|set-min-queue|read-issue}" ;;
+Usage: coordination {orient|plan [--label L] [--critical-path]|create-pr|claim-fix|close-pr|list-pr-repair|claim-pr-repair|mark-pr-salvaged|close-pr-unsalvageable|list-unclaimed [--label L]|queue-depth [L]|critical-path-depth|claim|skip|add-dep|check-blocked|check-has-pr|release-stale-claims|lock-planner|unlock-planner|lock-status|force-unlock-planner|return-to-human|check-return-to-human|clear-return-to-human|nothing-to-plan|set-target|set-min-queue|read-issue}" ;;
 esac

--- a/tests/test_create_pr_guard.py
+++ b/tests/test_create_pr_guard.py
@@ -1,0 +1,159 @@
+"""Integration test: cmd_create_pr refuses to set has-pr when an
+existing PR's body lacks a closing keyword for the issue.
+
+The bug this guards against: a worker (or human) creates a PR
+manually with body `Partial progress on #N`, then runs
+`coordination create-pr N` (without --partial). Pre-fix, the
+existing-PR branch unconditionally added `has-pr` to issue #N.
+When the PR merged, GitHub did NOT auto-close the issue (no
+`Closes #N`), so the issue stayed `has-pr` forever and was
+silently excluded from the work queue.
+
+The fix dies with a descriptive message before mutating any
+labels, so the worker can either edit the PR body or rerun
+with --partial.
+"""
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+COORDINATION = PROJECT_ROOT / "pod" / "data" / "coordination"
+
+
+def _make_stub_gh(stub_dir: Path, body: str, existing_pr_number: int = 42) -> Path:
+    """Write a stub `gh` shell script that emulates just the API calls
+    `cmd_create_pr` makes before the guard fires."""
+    stub = stub_dir / "gh"
+    stub.write_text(textwrap.dedent(f"""\
+        #!/bin/bash
+        # Minimal gh stub for cmd_create_pr guard test. Routes by argv shape.
+        set -e
+        case "$1 $2" in
+          "repo view")
+            # `gh repo view --json nameWithOwner -q .nameWithOwner` etc.
+            for arg in "$@"; do
+              case "$arg" in
+                .nameWithOwner) echo "owner/repo"; exit 0;;
+                .defaultBranchRef.name) echo "main"; exit 0;;
+              esac
+            done
+            exit 0;;
+          "pr list")
+            # First call: --head BRANCH --json number --jq '.[0].number // empty'
+            echo "{existing_pr_number}"
+            exit 0;;
+          "pr view")
+            # `gh pr view N --repo owner/repo --json body --jq .body`
+            cat <<'EOF_BODY'
+{body}
+EOF_BODY
+            exit 0;;
+          "pr merge")
+            exit 0;;
+          "issue edit")
+            exit 0;;
+          *)
+            # Default: success, empty stdout. Sufficient for any other
+            # incidental call the script makes.
+            exit 0;;
+        esac
+    """))
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return stub
+
+
+def _make_stub_git_push(stub_dir: Path) -> None:
+    """Wrap git so `git push` becomes a no-op; everything else falls
+    through to the real git binary."""
+    real_git = shutil.which("git")
+    assert real_git is not None
+    wrap = stub_dir / "git"
+    wrap.write_text(textwrap.dedent(f"""\
+        #!/bin/bash
+        if [[ "$1" == "push" ]]; then
+            exit 0
+        fi
+        exec "{real_git}" "$@"
+    """))
+    wrap.chmod(wrap.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class CreatePrGuardTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+
+        self.repo = self.tmp / "repo"
+        self.repo.mkdir()
+        # Initialise a tiny git repo on a non-master branch.
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=self.repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=self.repo, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=self.repo, check=True)
+        (self.repo / "f").write_text("x\n")
+        subprocess.run(["git", "add", "f"], cwd=self.repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=self.repo, check=True)
+        subprocess.run(["git", "checkout", "-q", "-b", "agent/12345678"],
+                       cwd=self.repo, check=True)
+        subprocess.run(["git", "remote", "add", "origin", "/dev/null"],
+                       cwd=self.repo, check=True)
+
+        self.stub_dir = self.tmp / "stub-bin"
+        self.stub_dir.mkdir()
+        _make_stub_git_push(self.stub_dir)
+
+        # Wipe any cached repo info from prior runs that could reference
+        # the temp dir's slug (cache key is path-derived).
+        toplevel = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                                  cwd=self.repo, capture_output=True, text=True,
+                                  check=True).stdout.strip()
+        cache_key = toplevel.replace("/", "-")
+        for cache in (f"/tmp/pod-repo-cache{cache_key}",
+                      f"/tmp/pod-base-branch-cache{cache_key}"):
+            try:
+                os.unlink(cache)
+            except FileNotFoundError:
+                pass
+
+    def _run(self, body: str, partial: bool = False):
+        _make_stub_gh(self.stub_dir, body=body)
+        env = os.environ.copy()
+        env["PATH"] = f"{self.stub_dir}:{env['PATH']}"
+        env["POD_SESSION_ID"] = "test-session"
+        argv = [str(COORDINATION), "create-pr", "999"]
+        if partial:
+            argv.append("--partial")
+        return subprocess.run(argv, cwd=self.repo, env=env,
+                              capture_output=True, text=True, timeout=30)
+
+    def test_partial_progress_body_in_full_path_dies(self):
+        r = self._run(body="Partial progress on #999\n\nSome details.\n")
+        self.assertNotEqual(r.returncode, 0,
+            f"expected non-zero exit, got {r.returncode}\nstdout={r.stdout!r}\nstderr={r.stderr!r}")
+        combined = r.stdout + r.stderr
+        self.assertIn("does not reference", combined)
+        self.assertIn("--partial", combined)
+
+    def test_closes_body_in_full_path_succeeds(self):
+        # When the body contains `Closes #999`, the guard must not fire.
+        r = self._run(body="Closes #999\n\nSome details.\n")
+        self.assertEqual(r.returncode, 0,
+            f"unexpected non-zero exit\nstdout={r.stdout!r}\nstderr={r.stderr!r}")
+
+    def test_partial_flag_skips_guard(self):
+        # The `--partial` flow does not promise to close the issue, so
+        # the guard must not fire even with a non-closing body.
+        r = self._run(body="Partial progress on #999\n", partial=True)
+        self.assertEqual(r.returncode, 0,
+            f"unexpected non-zero exit\nstdout={r.stdout!r}\nstderr={r.stderr!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orphan_label_helpers.py
+++ b/tests/test_orphan_label_helpers.py
@@ -1,0 +1,128 @@
+"""Tests for the TUI's orphan-label helpers.
+
+`fetch_blocked_deps` must query *all* `blocked` issues (no
+`--label agent-plan` filter), so `human-oversight + blocked` issues
+get their `depends-on:` lines parsed and rendered.
+
+`fetch_has_pr_links` returns, for every open `has-pr` issue, the list
+of its currently-OPEN closing PRs. An empty list is preserved (it
+signals an orphan label that the housekeeping loop will clean up).
+"""
+import json
+import subprocess
+import unittest
+from unittest import mock
+
+from pod import cli
+
+
+class FetchBlockedDepsQueryTests(unittest.TestCase):
+    def test_query_does_not_filter_to_agent_plan(self):
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = list(argv)
+            r = mock.Mock()
+            r.returncode = 0
+            r.stdout = "[]"
+            r.stderr = ""
+            return r
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            cli.fetch_blocked_deps()
+
+        argv = captured["argv"]
+        self.assertEqual(argv[0], "gh")
+        self.assertIn("--label", argv)
+        # The post-fix query must include `blocked` exactly once and must
+        # NOT include `agent-plan` (which would exclude human-oversight
+        # blocked issues like #2565 in the kim-em/hex repo).
+        label_args = [argv[i + 1] for i, a in enumerate(argv) if a == "--label"]
+        self.assertEqual(label_args, ["blocked"])
+
+    def test_human_oversight_blocked_issue_yields_deps(self):
+        body = ("HO-2 work item.\n\n"
+                "depends-on: #2563\n"
+                "depends-on: #2564\n")
+        list_payload = json.dumps([{"number": 2565, "body": body}])
+        # second call returns the open-issue numbers list
+        open_payload = json.dumps([2563, 2564])
+
+        calls = iter([list_payload, open_payload])
+
+        def fake_run(argv, **kwargs):
+            r = mock.Mock()
+            r.returncode = 0
+            r.stdout = next(calls)
+            r.stderr = ""
+            return r
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            result = cli.fetch_blocked_deps()
+
+        self.assertEqual(result, {2565: [2563, 2564]})
+
+
+class FetchHasPrLinksTests(unittest.TestCase):
+    def test_records_open_linked_pr(self):
+        list_payload = json.dumps([{"number": 3006}])
+        view_payload = json.dumps([3015])
+
+        calls = iter([list_payload, view_payload])
+
+        def fake_run(argv, **kwargs):
+            r = mock.Mock()
+            r.returncode = 0
+            r.stdout = next(calls)
+            r.stderr = ""
+            return r
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            result = cli.fetch_has_pr_links()
+
+        self.assertEqual(result, {3006: [3015]})
+
+    def test_orphan_has_pr_yields_empty_list(self):
+        # The TUI relies on the *presence* of the key (with empty list)
+        # to render `[PR ?]`, so the orphan stands out before housekeeping
+        # clears it. The key must be retained, not dropped.
+        list_payload = json.dumps([{"number": 2564}])
+        view_payload = "[]"
+
+        calls = iter([list_payload, view_payload])
+
+        def fake_run(argv, **kwargs):
+            r = mock.Mock()
+            r.returncode = 0
+            r.stdout = next(calls)
+            r.stderr = ""
+            return r
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            result = cli.fetch_has_pr_links()
+
+        self.assertEqual(result, {2564: []})
+
+    def test_no_has_pr_issues_returns_empty_without_view_calls(self):
+        list_payload = "[]"
+        view_called = False
+
+        def fake_run(argv, **kwargs):
+            nonlocal view_called
+            if argv[:3] == ["gh", "issue", "view"]:
+                view_called = True
+            r = mock.Mock()
+            r.returncode = 0
+            r.stdout = list_payload
+            r.stderr = ""
+            return r
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            result = cli.fetch_has_pr_links()
+
+        self.assertEqual(result, {})
+        self.assertFalse(view_called)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR closes a class of bug where issues silently fall out of the work queue because the `has-pr` or `blocked` label has been hand-applied or left dangling after the underlying PR/dependency went away. The motivating incident in `kim-em/hex` left an important `human-oversight` directive (HO-1, the BHKS van Hoeij CLD rewrite) parked under `has-pr` for three days with no PR; the PR that justified the parking had been closed without merging.

Root cause was twofold: (1) planner agents were treating `has-pr` as a manual "park this directive while sub-issues do the work" flag, applied without any matching PR; (2) workers were creating "Partial progress on #N" PRs and then running `coordination create-pr N` without `--partial`, which set `has-pr` even though the PR body did not contain `Closes #N`, so GitHub never auto-closed the issue at merge.

Changes:

- `cmd_create_pr` defensive guard for the existing-PR branch: refuse to set `has-pr` unless the existing PR's body contains `Closes #N` / `Fixes #N` / `Resolves #N`. The error message tells the worker to either edit the PR body or rerun with `--partial`.
- New `coordination check-has-pr`: scans open `has-pr` issues, removes the label from any with no currently-open closing PR, and posts an audit comment naming the prior linked PRs and their state. Wired into the housekeeping loop alongside `check-blocked`.
- Extend `coordination check-blocked`: in addition to the existing "all deps closed → unblock" path, remove the orphan `blocked` label from issues whose body has no `depends-on:` lines (and comment to attribute the cleanup).
- Pod TUI: parse `depends-on:` lines for *all* `blocked` issues, not just `agent-plan` ones. Pre-fix, `human-oversight + blocked` issues like #2565 in `kim-em/hex` rendered as `blocked` with no dependency annotation despite having `depends-on:` lines in the body.
- Pod TUI: when an issue has `has-pr`, show `[PR #N]` next to the title (parallel to `[Blocked on #M]`). Orphan `has-pr` renders `[PR ?]` so the human notices before the auto-cleaner runs.
- Doctrine in `agent-worker-flow/SKILL.md` and `plan.md`: planners must never hand-apply `has-pr`. To park a decomposed human-oversight directive, run `coordination add-dep <directive> <sub>` for each open sub-issue; the directive becomes `blocked` and auto-unblocks when the sub-issues close.
- Tests: pytest coverage for the TUI helpers (`fetch_blocked_deps`, `fetch_has_pr_links`) and an integration test for the `cmd_create_pr` guard using a temp git repo and a stub `gh`. The full suite (143 tests) is green.

In `kim-em/hex` the three orphan `has-pr` labels (#2762, #2637, #2564) and their proper sub-issue dependencies have already been cleaned up by hand; the doctrine + auto-cleaner changes prevent recurrence.

🤖 Prepared with Claude Code