### PR TITLE
fix: dereference linked-PR state via gh pr view

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1881,6 +1881,13 @@ def fetch_has_pr_links() -> dict[int, list[int]]:
     auto-closing it. The caller should still emit the entry so the
     TUI can flag the orphan; auto-cleanup happens in housekeeping
     via `coordination check-has-pr`.
+
+    Note on the two-step lookup: `gh issue view --json
+    closedByPullRequestsReferences` returns objects with
+    `id`/`number`/`repository`/`url` only — no `state` — so we have
+    to dereference each PR via `gh pr view --json state` to filter
+    out closed/merged ones. Has-pr issues are typically few (≤ 10),
+    so the N+1 cost is bounded.
     """
     cwd = str(PROJECT_DIR)
     try:
@@ -1901,17 +1908,28 @@ def fetch_has_pr_links() -> dict[int, list[int]]:
             r2 = subprocess.run(
                 ["gh", "issue", "view", str(num),
                  "--json", "closedByPullRequestsReferences",
-                 "--jq", "[.closedByPullRequestsReferences[] "
-                        "| select(.state == \"OPEN\") | .number]"],
+                 "--jq", "[.closedByPullRequestsReferences[].number]"],
                 capture_output=True, text=True, timeout=15, cwd=cwd,
             )
-            if r2.returncode == 0:
-                try:
-                    result[num] = json.loads(r2.stdout) or []
-                except json.JSONDecodeError:
-                    result[num] = []
-            else:
+            if r2.returncode != 0:
                 result[num] = []
+                continue
+            try:
+                refs = json.loads(r2.stdout) or []
+            except json.JSONDecodeError:
+                result[num] = []
+                continue
+
+            open_prs: list[int] = []
+            for pr_num in refs:
+                r3 = subprocess.run(
+                    ["gh", "pr", "view", str(pr_num),
+                     "--json", "state", "--jq", ".state"],
+                    capture_output=True, text=True, timeout=15, cwd=cwd,
+                )
+                if r3.returncode == 0 and r3.stdout.strip() == "OPEN":
+                    open_prs.append(pr_num)
+            result[num] = open_prs
         return result
     except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
         return {}

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -1112,26 +1112,42 @@ cmd_check_has_pr() {
         num="$(echo "$issue_json" | jq -r '.number')"
         title="$(echo "$issue_json" | jq -r '.title')"
 
-        local open_prs
-        open_prs="$(gh issue view "$num" --repo "$REPO" \
+        # `gh issue view --json closedByPullRequestsReferences` returns
+        # objects without a `state` field, so we have to dereference each
+        # linked PR via `gh pr view --json state` to filter out
+        # closed/merged ones. (A previous version filtered with
+        # `select(.state == "OPEN")` directly on the references and
+        # always returned empty, which would have removed `has-pr` from
+        # every legitimate issue on the next housekeeping cycle.)
+        local pr_nums
+        pr_nums="$(gh issue view "$num" --repo "$REPO" \
             --json closedByPullRequestsReferences \
-            --jq '[.closedByPullRequestsReferences[] | select(.state == "OPEN") | .number] | join(",")' \
+            --jq '.closedByPullRequestsReferences[].number' \
             2>/dev/null || true)"
 
-        if [[ -n "$open_prs" ]]; then
+        local has_open_pr=false
+        local pr_states=""
+        if [[ -n "$pr_nums" ]]; then
+            while read -r pr; do
+                [[ -z "$pr" ]] && continue
+                local pr_state
+                pr_state="$(gh pr view "$pr" --repo "$REPO" --json state --jq .state 2>/dev/null || echo UNKNOWN)"
+                local label
+                label="$(echo "$pr_state" | tr '[:upper:]' '[:lower:]')"
+                pr_states="${pr_states:+$pr_states, }#${pr} (${label})"
+                if [[ "$pr_state" == "OPEN" ]]; then
+                    has_open_pr=true
+                fi
+            done <<< "$pr_nums"
+        fi
+
+        if [[ "$has_open_pr" == true ]]; then
             continue
         fi
 
-        # No open linked PRs. Collect any closed/merged ones to attribute
-        # in the audit comment.
-        local prior_prs
-        prior_prs="$(gh issue view "$num" --repo "$REPO" \
-            --json closedByPullRequestsReferences \
-            --jq '[.closedByPullRequestsReferences[] | "#\(.number) (\(.state | ascii_downcase))"] | join(", ")' \
-            2>/dev/null || echo "")"
         local prior_msg=""
-        if [[ -n "$prior_prs" && "$prior_prs" != "" ]]; then
-            prior_msg=" Last linked PRs: ${prior_prs}."
+        if [[ -n "$pr_states" ]]; then
+            prior_msg=" Last linked PRs: ${pr_states}."
         fi
 
         gh issue edit "$num" --repo "$REPO" --remove-label has-pr

--- a/tests/test_orphan_label_helpers.py
+++ b/tests/test_orphan_label_helpers.py
@@ -64,44 +64,73 @@ class FetchBlockedDepsQueryTests(unittest.TestCase):
 
 
 class FetchHasPrLinksTests(unittest.TestCase):
+    """Three-step lookup: list has-pr issues → look up each issue's
+    closedByPullRequestsReferences → look up each referenced PR's state
+    via `gh pr view`. The reference objects do NOT contain a `state`
+    field, so a one-shot `select(.state == "OPEN")` filter would
+    always return empty and the housekeeping cycle would clear
+    `has-pr` from every legitimate issue."""
+
+    def _stub_run(self, calls):
+        """Build a fake_run that dispatches by argv shape, returning
+        canned stdout from the `calls` dict keyed on (argv[1], argv[2])."""
+        def fake_run(argv, **kwargs):
+            r = mock.Mock()
+            r.returncode = 0
+            r.stderr = ""
+            key = (argv[1], argv[2])
+            if key == ("issue", "list"):
+                r.stdout = calls.pop("issue_list", "[]")
+            elif key == ("issue", "view"):
+                # argv[3] is the issue number string
+                r.stdout = calls.pop(f"issue_view_{argv[3]}", "[]")
+            elif key == ("pr", "view"):
+                r.stdout = calls.pop(f"pr_view_{argv[3]}", "UNKNOWN")
+            else:
+                r.stdout = ""
+            return r
+        return fake_run
+
     def test_records_open_linked_pr(self):
-        list_payload = json.dumps([{"number": 3006}])
-        view_payload = json.dumps([3015])
+        # #3006 has an open linked PR #3015 — must show up.
+        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+            "issue_list": json.dumps([{"number": 3006}]),
+            "issue_view_3006": json.dumps([3015]),
+            "pr_view_3015": "OPEN",
+        })):
+            self.assertEqual(cli.fetch_has_pr_links(), {3006: [3015]})
 
-        calls = iter([list_payload, view_payload])
+    def test_merged_linked_pr_yields_empty_list_orphan(self):
+        # #3016 has a linked PR but it's already merged — orphan; the
+        # entry must still be present (empty list) so the TUI can
+        # render `[PR ?]` and the housekeeping cycle can clean up.
+        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+            "issue_list": json.dumps([{"number": 3016}]),
+            "issue_view_3016": json.dumps([3020]),
+            "pr_view_3020": "MERGED",
+        })):
+            self.assertEqual(cli.fetch_has_pr_links(), {3016: []})
 
-        def fake_run(argv, **kwargs):
-            r = mock.Mock()
-            r.returncode = 0
-            r.stdout = next(calls)
-            r.stderr = ""
-            return r
+    def test_orphan_with_no_linked_prs_at_all(self):
+        # The hand-applied `has-pr` case from the original incident:
+        # closedByPullRequestsReferences itself is empty.
+        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+            "issue_list": json.dumps([{"number": 2564}]),
+            "issue_view_2564": "[]",
+        })):
+            self.assertEqual(cli.fetch_has_pr_links(), {2564: []})
 
-        with mock.patch.object(subprocess, "run", side_effect=fake_run):
-            result = cli.fetch_has_pr_links()
-
-        self.assertEqual(result, {3006: [3015]})
-
-    def test_orphan_has_pr_yields_empty_list(self):
-        # The TUI relies on the *presence* of the key (with empty list)
-        # to render `[PR ?]`, so the orphan stands out before housekeeping
-        # clears it. The key must be retained, not dropped.
-        list_payload = json.dumps([{"number": 2564}])
-        view_payload = "[]"
-
-        calls = iter([list_payload, view_payload])
-
-        def fake_run(argv, **kwargs):
-            r = mock.Mock()
-            r.returncode = 0
-            r.stdout = next(calls)
-            r.stderr = ""
-            return r
-
-        with mock.patch.object(subprocess, "run", side_effect=fake_run):
-            result = cli.fetch_has_pr_links()
-
-        self.assertEqual(result, {2564: []})
+    def test_open_and_closed_links_keeps_only_open(self):
+        # The relevant filter: an issue may have one merged PR
+        # (historically) and one open PR (the in-flight one). Only the
+        # open one should appear in the result.
+        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+            "issue_list": json.dumps([{"number": 4000}]),
+            "issue_view_4000": json.dumps([4001, 4002]),
+            "pr_view_4001": "MERGED",
+            "pr_view_4002": "OPEN",
+        })):
+            self.assertEqual(cli.fetch_has_pr_links(), {4000: [4002]})
 
     def test_no_has_pr_issues_returns_empty_without_view_calls(self):
         list_payload = "[]"
@@ -109,7 +138,7 @@ class FetchHasPrLinksTests(unittest.TestCase):
 
         def fake_run(argv, **kwargs):
             nonlocal view_called
-            if argv[:3] == ["gh", "issue", "view"]:
+            if argv[:3] == ["gh", "issue", "view"] or argv[:3] == ["gh", "pr", "view"]:
                 view_called = True
             r = mock.Mock()
             r.returncode = 0


### PR DESCRIPTION
This PR fixes a critical bug in #47 (orphan-label cleanup): `gh issue view --json closedByPullRequestsReferences` returns objects with `id`/`number`/`repository`/`url` only — no `state` field. The original `select(.state == "OPEN")` filter therefore always evaluated falsy, so:

- the TUI rendered every legitimate `has-pr` issue as `[PR ?]` (false orphan), and
- worse, the next `coordination check-has-pr` housekeeping sweep would have removed `has-pr` from every legitimate issue and posted an "orphan removed" comment on each.

In `kim-em/hex` this was caught before any housekeeping ran (the file-locked stamp from #45 happened to predate the upgrade), so no labels were corrupted in practice.

The fix: in both the Python helper (`fetch_has_pr_links`) and the bash command (`cmd_check_has_pr`), do a two-step lookup — pull the PR numbers off the references, then dereference each via `gh pr view --json state` to filter to the OPEN ones.

Tests cover: open-PR (kept), merged-PR (treated as orphan), no-references-at-all (orphan), and mixed open+closed (only open retained). The full suite (166 tests) is green.

🤖 Prepared with Claude Code