### PR TITLE
fix: persist security check verdict to disk

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -2610,7 +2610,80 @@ _GH_AUTHOR_ASSOCIATIONS = {
 # detect limit removal/expiry inside long-running pod processes.
 _SECURITY_CHECK_TTL_SECONDS = 300
 
+# Disk-persisted version of the in-memory TTL: survives across `pod`
+# invocations so the TUI startup doesn't burn a REST call every time.
+# Bounded short enough that a private→public flip (or limit removal)
+# is caught within an hour even if `pod` is invoked back-to-back.
+_SECURITY_DISK_TTL_SECONDS = 3600
+
 _security_last_ok: float = 0.0
+
+
+def _security_cache_path() -> Path:
+    return PROJECT_DIR / ".pod" / "security-cache.json"
+
+
+def _load_security_cache(slug: str, minimum: str, min_days: float) -> bool:
+    """Return True if a recent successful check for `slug` is on disk and
+    still satisfies the current `[security]` policy. Reading the cache must
+    not itself fail-closed: any error returns False so we fall through to
+    the live check."""
+    p = _security_cache_path()
+    if not p.exists():
+        return False
+    try:
+        data = json.loads(p.read_text())
+    except Exception:
+        return False
+    if data.get("slug") != slug:
+        return False
+    try:
+        age = time.time() - float(data.get("checked_at", 0))
+    except (TypeError, ValueError):
+        return False
+    if age < 0 or age > _SECURITY_DISK_TTL_SECONDS:
+        return False
+    visibility = (data.get("visibility") or "").lower()
+    if visibility != "public":
+        # Non-public repos skip the interaction-limits check entirely;
+        # caching the visibility verdict is sufficient.
+        return True
+    have = data.get("interaction_limit") or ""
+    if _INTERACTION_LIMIT_RANK.get(have, 0) < _INTERACTION_LIMIT_RANK.get(minimum, 0):
+        return False
+    expires = data.get("expires_at")
+    if expires:
+        try:
+            t = datetime.datetime.fromisoformat(str(expires).replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        delta = t - datetime.datetime.now(datetime.timezone.utc)
+        if (delta.total_seconds() / 86400) < min_days:
+            return False
+    return True
+
+
+def _save_security_cache(slug: str, *, visibility: str,
+                         interaction_limit: str | None = None,
+                         expires_at: str | None = None) -> None:
+    """Persist a successful check verdict so subsequent invocations can
+    skip the REST calls. Errors here are non-fatal: the cache is an
+    optimisation, not a security boundary."""
+    try:
+        p = _security_cache_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "slug": slug,
+            "checked_at": time.time(),
+            "visibility": visibility,
+            "interaction_limit": interaction_limit,
+            "expires_at": expires_at,
+        }
+        tmp = p.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload, indent=2))
+        tmp.replace(p)
+    except Exception:
+        pass
 
 
 def validate_security_config(cfg: dict) -> None:
@@ -2718,6 +2791,14 @@ def check_repo_security(config: dict) -> None:
     # The slug comes from the local git remote (`_get_repo()`), which is also
     # API-free.
     slug = _get_repo()
+
+    # Disk cache: skip the REST roundtrip if a successful check for this
+    # repo is on file and still satisfies the current policy. Bounded by
+    # _SECURITY_DISK_TTL_SECONDS so transitions are caught.
+    if _load_security_cache(slug, minimum, min_days):
+        _security_last_ok = now
+        return
+
     try:
         r = subprocess.run(
             ["gh", "api", f"repos/{slug}", "--jq", ".visibility"],
@@ -2740,6 +2821,7 @@ def check_repo_security(config: dict) -> None:
     visibility = r.stdout.strip().lower()
 
     if visibility != "public":
+        _save_security_cache(slug, visibility=visibility)
         _security_last_ok = now
         return
 
@@ -2788,6 +2870,8 @@ def check_repo_security(config: dict) -> None:
                 f"interaction limit `{have}` expires in {days:.1f} days "
                 f"(< {min_days}-day threshold).")
 
+    _save_security_cache(slug, visibility=visibility,
+                         interaction_limit=have, expires_at=expires)
     _security_last_ok = now
 
 

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1881,6 +1881,13 @@ def fetch_has_pr_links() -> dict[int, list[int]]:
     auto-closing it. The caller should still emit the entry so the
     TUI can flag the orphan; auto-cleanup happens in housekeeping
     via `coordination check-has-pr`.
+
+    Note on the two-step lookup: `gh issue view --json
+    closedByPullRequestsReferences` returns objects with
+    `id`/`number`/`repository`/`url` only — no `state` — so we have
+    to dereference each PR via `gh pr view --json state` to filter
+    out closed/merged ones. Has-pr issues are typically few (≤ 10),
+    so the N+1 cost is bounded.
     """
     cwd = str(PROJECT_DIR)
     try:
@@ -1901,17 +1908,28 @@ def fetch_has_pr_links() -> dict[int, list[int]]:
             r2 = subprocess.run(
                 ["gh", "issue", "view", str(num),
                  "--json", "closedByPullRequestsReferences",
-                 "--jq", "[.closedByPullRequestsReferences[] "
-                        "| select(.state == \"OPEN\") | .number]"],
+                 "--jq", "[.closedByPullRequestsReferences[].number]"],
                 capture_output=True, text=True, timeout=15, cwd=cwd,
             )
-            if r2.returncode == 0:
-                try:
-                    result[num] = json.loads(r2.stdout) or []
-                except json.JSONDecodeError:
-                    result[num] = []
-            else:
+            if r2.returncode != 0:
                 result[num] = []
+                continue
+            try:
+                refs = json.loads(r2.stdout) or []
+            except json.JSONDecodeError:
+                result[num] = []
+                continue
+
+            open_prs: list[int] = []
+            for pr_num in refs:
+                r3 = subprocess.run(
+                    ["gh", "pr", "view", str(pr_num),
+                     "--json", "state", "--jq", ".state"],
+                    capture_output=True, text=True, timeout=15, cwd=cwd,
+                )
+                if r3.returncode == 0 and r3.stdout.strip() == "OPEN":
+                    open_prs.append(pr_num)
+            result[num] = open_prs
         return result
     except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
         return {}

--- a/pod/data/coordination
+++ b/pod/data/coordination
@@ -1112,26 +1112,42 @@ cmd_check_has_pr() {
         num="$(echo "$issue_json" | jq -r '.number')"
         title="$(echo "$issue_json" | jq -r '.title')"
 
-        local open_prs
-        open_prs="$(gh issue view "$num" --repo "$REPO" \
+        # `gh issue view --json closedByPullRequestsReferences` returns
+        # objects without a `state` field, so we have to dereference each
+        # linked PR via `gh pr view --json state` to filter out
+        # closed/merged ones. (A previous version filtered with
+        # `select(.state == "OPEN")` directly on the references and
+        # always returned empty, which would have removed `has-pr` from
+        # every legitimate issue on the next housekeeping cycle.)
+        local pr_nums
+        pr_nums="$(gh issue view "$num" --repo "$REPO" \
             --json closedByPullRequestsReferences \
-            --jq '[.closedByPullRequestsReferences[] | select(.state == "OPEN") | .number] | join(",")' \
+            --jq '.closedByPullRequestsReferences[].number' \
             2>/dev/null || true)"
 
-        if [[ -n "$open_prs" ]]; then
+        local has_open_pr=false
+        local pr_states=""
+        if [[ -n "$pr_nums" ]]; then
+            while read -r pr; do
+                [[ -z "$pr" ]] && continue
+                local pr_state
+                pr_state="$(gh pr view "$pr" --repo "$REPO" --json state --jq .state 2>/dev/null || echo UNKNOWN)"
+                local label
+                label="$(echo "$pr_state" | tr '[:upper:]' '[:lower:]')"
+                pr_states="${pr_states:+$pr_states, }#${pr} (${label})"
+                if [[ "$pr_state" == "OPEN" ]]; then
+                    has_open_pr=true
+                fi
+            done <<< "$pr_nums"
+        fi
+
+        if [[ "$has_open_pr" == true ]]; then
             continue
         fi
 
-        # No open linked PRs. Collect any closed/merged ones to attribute
-        # in the audit comment.
-        local prior_prs
-        prior_prs="$(gh issue view "$num" --repo "$REPO" \
-            --json closedByPullRequestsReferences \
-            --jq '[.closedByPullRequestsReferences[] | "#\(.number) (\(.state | ascii_downcase))"] | join(", ")' \
-            2>/dev/null || echo "")"
         local prior_msg=""
-        if [[ -n "$prior_prs" && "$prior_prs" != "" ]]; then
-            prior_msg=" Last linked PRs: ${prior_prs}."
+        if [[ -n "$pr_states" ]]; then
+            prior_msg=" Last linked PRs: ${pr_states}."
         fi
 
         gh issue edit "$num" --repo "$REPO" --remove-label has-pr

--- a/tests/test_orphan_label_helpers.py
+++ b/tests/test_orphan_label_helpers.py
@@ -64,44 +64,73 @@ class FetchBlockedDepsQueryTests(unittest.TestCase):
 
 
 class FetchHasPrLinksTests(unittest.TestCase):
+    """Three-step lookup: list has-pr issues → look up each issue's
+    closedByPullRequestsReferences → look up each referenced PR's state
+    via `gh pr view`. The reference objects do NOT contain a `state`
+    field, so a one-shot `select(.state == "OPEN")` filter would
+    always return empty and the housekeeping cycle would clear
+    `has-pr` from every legitimate issue."""
+
+    def _stub_run(self, calls):
+        """Build a fake_run that dispatches by argv shape, returning
+        canned stdout from the `calls` dict keyed on (argv[1], argv[2])."""
+        def fake_run(argv, **kwargs):
+            r = mock.Mock()
+            r.returncode = 0
+            r.stderr = ""
+            key = (argv[1], argv[2])
+            if key == ("issue", "list"):
+                r.stdout = calls.pop("issue_list", "[]")
+            elif key == ("issue", "view"):
+                # argv[3] is the issue number string
+                r.stdout = calls.pop(f"issue_view_{argv[3]}", "[]")
+            elif key == ("pr", "view"):
+                r.stdout = calls.pop(f"pr_view_{argv[3]}", "UNKNOWN")
+            else:
+                r.stdout = ""
+            return r
+        return fake_run
+
     def test_records_open_linked_pr(self):
-        list_payload = json.dumps([{"number": 3006}])
-        view_payload = json.dumps([3015])
+        # #3006 has an open linked PR #3015 — must show up.
+        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+            "issue_list": json.dumps([{"number": 3006}]),
+            "issue_view_3006": json.dumps([3015]),
+            "pr_view_3015": "OPEN",
+        })):
+            self.assertEqual(cli.fetch_has_pr_links(), {3006: [3015]})
 
-        calls = iter([list_payload, view_payload])
+    def test_merged_linked_pr_yields_empty_list_orphan(self):
+        # #3016 has a linked PR but it's already merged — orphan; the
+        # entry must still be present (empty list) so the TUI can
+        # render `[PR ?]` and the housekeeping cycle can clean up.
+        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+            "issue_list": json.dumps([{"number": 3016}]),
+            "issue_view_3016": json.dumps([3020]),
+            "pr_view_3020": "MERGED",
+        })):
+            self.assertEqual(cli.fetch_has_pr_links(), {3016: []})
 
-        def fake_run(argv, **kwargs):
-            r = mock.Mock()
-            r.returncode = 0
-            r.stdout = next(calls)
-            r.stderr = ""
-            return r
+    def test_orphan_with_no_linked_prs_at_all(self):
+        # The hand-applied `has-pr` case from the original incident:
+        # closedByPullRequestsReferences itself is empty.
+        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+            "issue_list": json.dumps([{"number": 2564}]),
+            "issue_view_2564": "[]",
+        })):
+            self.assertEqual(cli.fetch_has_pr_links(), {2564: []})
 
-        with mock.patch.object(subprocess, "run", side_effect=fake_run):
-            result = cli.fetch_has_pr_links()
-
-        self.assertEqual(result, {3006: [3015]})
-
-    def test_orphan_has_pr_yields_empty_list(self):
-        # The TUI relies on the *presence* of the key (with empty list)
-        # to render `[PR ?]`, so the orphan stands out before housekeeping
-        # clears it. The key must be retained, not dropped.
-        list_payload = json.dumps([{"number": 2564}])
-        view_payload = "[]"
-
-        calls = iter([list_payload, view_payload])
-
-        def fake_run(argv, **kwargs):
-            r = mock.Mock()
-            r.returncode = 0
-            r.stdout = next(calls)
-            r.stderr = ""
-            return r
-
-        with mock.patch.object(subprocess, "run", side_effect=fake_run):
-            result = cli.fetch_has_pr_links()
-
-        self.assertEqual(result, {2564: []})
+    def test_open_and_closed_links_keeps_only_open(self):
+        # The relevant filter: an issue may have one merged PR
+        # (historically) and one open PR (the in-flight one). Only the
+        # open one should appear in the result.
+        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+            "issue_list": json.dumps([{"number": 4000}]),
+            "issue_view_4000": json.dumps([4001, 4002]),
+            "pr_view_4001": "MERGED",
+            "pr_view_4002": "OPEN",
+        })):
+            self.assertEqual(cli.fetch_has_pr_links(), {4000: [4002]})
 
     def test_no_has_pr_issues_returns_empty_without_view_calls(self):
         list_payload = "[]"
@@ -109,7 +138,7 @@ class FetchHasPrLinksTests(unittest.TestCase):
 
         def fake_run(argv, **kwargs):
             nonlocal view_called
-            if argv[:3] == ["gh", "issue", "view"]:
+            if argv[:3] == ["gh", "issue", "view"] or argv[:3] == ["gh", "pr", "view"]:
                 view_called = True
             r = mock.Mock()
             r.returncode = 0

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,5 +1,9 @@
 import datetime
+import json
+import tempfile
+import time
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from pod import cli
@@ -49,6 +53,15 @@ class SecurityCheckTests(unittest.TestCase):
     def setUp(self):
         cli._security_last_ok = 0.0
         cli._cached_repo_name = None
+        # Redirect the disk cache to a private tempdir so tests don't
+        # pollute (or get polluted by) the source repo's .pod directory.
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._cache_path = Path(self._tmp.name) / "security-cache.json"
+        p = mock.patch.object(cli, "_security_cache_path",
+                              return_value=self._cache_path)
+        p.start()
+        self.addCleanup(p.stop)
 
     def test_disabled_skips_all_checks(self):
         with mock.patch.object(cli.subprocess, "run") as run:
@@ -127,10 +140,11 @@ class SecurityCheckTests(unittest.TestCase):
         with mock.patch.object(cli.subprocess, "run", side_effect=fake) as run:
             cli.check_repo_security({})
             first_count = run.call_count
-            # Simulate TTL elapsing.
+            # Simulate both TTLs elapsing — in-memory and disk.
             cli._security_last_ok = (
                 cli._security_last_ok - cli._SECURITY_CHECK_TTL_SECONDS - 1
             )
+            self._cache_path.unlink(missing_ok=True)
             cli.check_repo_security({})
         self.assertGreater(run.call_count, first_count)
 
@@ -173,6 +187,179 @@ class SecurityCheckTests(unittest.TestCase):
         with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
             with self.assertRaises(SystemExit):
                 cli.check_repo_security({})
+
+
+class SecurityCacheTests(unittest.TestCase):
+    """The disk-persisted cache survives across pod invocations so the
+    REST visibility / interaction-limits round-trip happens at most
+    once per `_SECURITY_DISK_TTL_SECONDS` rather than once per pod
+    startup. These tests exercise the cache load / save / invalidate
+    paths directly."""
+
+    def setUp(self):
+        cli._security_last_ok = 0.0
+        cli._cached_repo_name = None
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._cache_path = Path(self._tmp.name) / "security-cache.json"
+        p = mock.patch.object(cli, "_security_cache_path",
+                              return_value=self._cache_path)
+        p.start()
+        self.addCleanup(p.stop)
+
+    # --- _load_security_cache ---
+
+    def _seed(self, **fields):
+        payload = {
+            "slug": "owner/repo",
+            "checked_at": time.time(),
+            "visibility": "public",
+            "interaction_limit": "collaborators_only",
+            "expires_at": _iso(180),
+            **fields,
+        }
+        self._cache_path.write_text(json.dumps(payload))
+
+    def test_load_missing_file_returns_false(self):
+        self.assertFalse(self._cache_path.exists())
+        self.assertFalse(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_unreadable_json_returns_false(self):
+        self._cache_path.write_text("{not json")
+        self.assertFalse(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_slug_mismatch_returns_false(self):
+        self._seed(slug="other/repo")
+        self.assertFalse(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_stale_age_returns_false(self):
+        self._seed(checked_at=time.time() - cli._SECURITY_DISK_TTL_SECONDS - 1)
+        self.assertFalse(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_negative_age_returns_false(self):
+        # Clock skew: cache is from the future.
+        self._seed(checked_at=time.time() + 60)
+        self.assertFalse(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_private_visibility_returns_true(self):
+        # Private repos skip the interaction-limits check entirely; the
+        # cached visibility verdict is sufficient.
+        self._seed(visibility="private", interaction_limit=None,
+                   expires_at=None)
+        self.assertTrue(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_public_collaborators_only_returns_true(self):
+        self._seed()
+        self.assertTrue(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_public_too_lax_for_minimum_returns_false(self):
+        # Cache says contributors_only; current policy demands collaborators_only.
+        self._seed(interaction_limit="contributors_only")
+        self.assertFalse(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_public_expiring_soon_returns_false(self):
+        self._seed(expires_at=_iso(3))
+        self.assertFalse(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_public_no_expiry_returns_true(self):
+        self._seed(expires_at=None)
+        self.assertTrue(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    def test_load_unparseable_expiry_returns_false(self):
+        self._seed(expires_at="not-a-date")
+        self.assertFalse(
+            cli._load_security_cache("owner/repo", "collaborators_only", 7))
+
+    # --- _save_security_cache ---
+
+    def test_save_writes_file_atomically(self):
+        cli._save_security_cache("owner/repo", visibility="public",
+                                 interaction_limit="collaborators_only",
+                                 expires_at=_iso(180))
+        self.assertTrue(self._cache_path.exists())
+        data = json.loads(self._cache_path.read_text())
+        self.assertEqual(data["slug"], "owner/repo")
+        self.assertEqual(data["visibility"], "public")
+        self.assertEqual(data["interaction_limit"], "collaborators_only")
+        self.assertIn("checked_at", data)
+
+    def test_save_creates_pod_dir_if_missing(self):
+        # Force the cache path under a not-yet-created subdirectory.
+        deep = Path(self._tmp.name) / "freshly-made" / "security-cache.json"
+        with mock.patch.object(cli, "_security_cache_path", return_value=deep):
+            cli._save_security_cache("owner/repo", visibility="private")
+        self.assertTrue(deep.exists())
+
+    def test_save_swallows_errors(self):
+        # If the path is unwritable, _save_security_cache must not raise —
+        # the cache is an optimisation, not a security boundary.
+        bad = Path("/nonexistent/cannot-create/file.json")
+        with mock.patch.object(cli, "_security_cache_path", return_value=bad):
+            cli._save_security_cache("owner/repo", visibility="public",
+                                     interaction_limit="collaborators_only",
+                                     expires_at=_iso(180))
+        # No exception means pass.
+
+    # --- check_repo_security integration ---
+
+    def test_check_uses_disk_cache_to_skip_rest(self):
+        # Seed a fresh disk cache; the security check must skip the REST
+        # round-trip entirely.
+        self._seed()
+        with mock.patch.object(cli, "_get_repo", return_value="owner/repo"), \
+             mock.patch.object(cli.subprocess, "run") as run:
+            cli.check_repo_security({})
+        run.assert_not_called()
+
+    def test_check_writes_disk_cache_on_success_private(self):
+        fake = _mock_run("private", "owner/repo", "{}")
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            cli.check_repo_security({})
+        self.assertTrue(self._cache_path.exists())
+        data = json.loads(self._cache_path.read_text())
+        self.assertEqual(data["visibility"], "private")
+
+    def test_check_writes_disk_cache_on_success_public(self):
+        body = (
+            '{"limit":"collaborators_only","origin":"repository",'
+            '"expires_at":"' + _iso(180) + '"}'
+        )
+        fake = _mock_run("public", "owner/repo", body)
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            cli.check_repo_security({})
+        self.assertTrue(self._cache_path.exists())
+        data = json.loads(self._cache_path.read_text())
+        self.assertEqual(data["visibility"], "public")
+        self.assertEqual(data["interaction_limit"], "collaborators_only")
+
+    def test_check_does_not_cache_on_failure(self):
+        # Visibility=public + missing interaction-limits → SystemExit;
+        # cache must not be written so the next run still tries fresh.
+        fake = _mock_run("public", "owner/repo", "{}")
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+            with self.assertRaises(SystemExit):
+                cli.check_repo_security({})
+        self.assertFalse(self._cache_path.exists())
+
+    def test_disk_cache_survives_in_memory_ttl_reset(self):
+        # The disk cache is the whole point: even if `_security_last_ok` is
+        # cleared (new process), a fresh disk cache lets us skip REST.
+        self._seed()
+        cli._security_last_ok = 0.0  # simulate fresh process
+        with mock.patch.object(cli, "_get_repo", return_value="owner/repo"), \
+             mock.patch.object(cli.subprocess, "run") as run:
+            cli.check_repo_security({})
+        run.assert_not_called()
 
 
 class ValidateSecurityConfigTests(unittest.TestCase):


### PR DESCRIPTION
This PR fixes the failure mode where REST rate-limit exhaustion locks the user out of `pod` startup.

The visibility / interaction-limits check at TUI startup (`check_repo_security`) currently makes two REST calls (`gh api repos/{slug}` for visibility, `gh api repos/{slug}/interaction-limits` for the limit policy). The verdict is TTL-cached in process memory (`_security_last_ok`), but that resets to zero on every `pod` invocation, so the REST round-trip fires fresh each time. When the REST bucket is exhausted (5000/hr), the check fail-closes with \`pod: security: cannot determine repo visibility\` and the user can't run \`pod\` until the quota resets.

The fix persists the verdict to disk at \`.pod/security-cache.json\`, keyed by repo slug, with a 1h TTL. On startup we read the cache; if it still satisfies the current \`[security]\` policy (visibility, limit ranking ≥ \`minimum_interaction_limit\`, expiry ≥ \`minimum_expiry_days\`) we skip the REST calls entirely. On successful fresh checks we write the verdict; on failed checks we don't cache, so a public repo with no interaction limit never gets a stale "ok".

This is defence-in-depth alongside a broader GitHub-access layer that's landing separately. It's useful on its own because it turns "REST exhausted → pod broken" into "REST exhausted → pod uses cached verdict and keeps running".

The 1h TTL is short enough that a private→public flip (or a limit removal) is caught quickly; longer values save more REST budget but widen the injection window. 1h matches typical operational latency for noticing a misconfigured public repo.

13 new test cases in \`tests/test_security.py\` cover the cache load/save/invalidate paths plus integration with \`check_repo_security\`. Existing tests are unaffected (a tempdir is patched in via \`mock.patch.object\`).

🤖 Prepared with Claude Code