### PR TITLE
feat: github-access layer with ETag caching, JSONL logging, back-pressure

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -46,6 +46,22 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from pod import github as gh
+
+
+def _gh_cli(*argv: str, timeout: float = 60,
+            input: bytes | str | None = None,
+            text: bool = True,
+            check: bool = False) -> subprocess.CompletedProcess:
+    """Run a `gh` porcelain subprocess through the layer.
+
+    Returns a `subprocess.CompletedProcess` so call sites keep the
+    `r.returncode` / `r.stdout` / `r.stderr` shape. Direct GitHub API
+    reads should use `gh.get_client().get(...)` instead, to take
+    advantage of ETag conditional requests."""
+    return gh.get_client().gh_cli(*argv, timeout=timeout, input=input,
+                                   text=text, check=check)
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -1662,15 +1678,18 @@ def _gh_rate_limit_wait() -> int:
     Returns 0 on error or if remaining >= 100.
     """
     try:
-        r = subprocess.run(
-            ["gh", "api", "rate_limit", "--jq",
-             '.resources.graphql | if .remaining < 100 then (.reset - now | ceil) else 0 end'],
-            capture_output=True, text=True, timeout=10, cwd=str(PROJECT_DIR))
-        if r.returncode == 0:
-            return max(0, int(float(r.stdout.strip())))
+        resp = gh.get_client().get("/rate_limit")
+        if not resp.ok():
+            return 0
+        body = resp.body() or {}
+        graphql = (body.get("resources", {}) or {}).get("graphql", {}) or {}
+        remaining = int(graphql.get("remaining", 0))
+        if remaining >= 100:
+            return 0
+        reset = int(graphql.get("reset", 0))
+        return max(0, reset - int(time.time()))
     except Exception:
-        pass
-    return 0
+        return 0
 
 
 def _clear_gh_cache():
@@ -1754,11 +1773,8 @@ def fetch_issues_and_prs() -> list[GHItem]:
     # All open issues (there should never be thousands of open ones)
     for label in ("agent-plan", "human-oversight"):
         try:
-            r = subprocess.run(
-                ["gh", "issue", "list", "--label", label, "--state", "open",
-                 "--limit", "500", issue_json],
-                capture_output=True, text=True, timeout=30, cwd=cwd,
-            )
+            r = _gh_cli("issue", "list", "--label", label, "--state", "open",
+                        "--limit", "500", issue_json, timeout=30)
             if r.returncode == 0:
                 for iss in json.loads(r.stdout):
                     if iss["number"] in seen_open:
@@ -1776,11 +1792,8 @@ def fetch_issues_and_prs() -> list[GHItem]:
     seen_closed: set[int] = set()
     for label in ("agent-plan", "human-oversight"):
         try:
-            r = subprocess.run(
-                ["gh", "issue", "list", "--label", label, "--state", "closed",
-                 "--limit", "30", issue_json],
-                capture_output=True, text=True, timeout=30, cwd=cwd,
-            )
+            r = _gh_cli("issue", "list", "--label", label, "--state", "closed",
+                        "--limit", "30", issue_json, timeout=30)
             if r.returncode == 0:
                 for iss in json.loads(r.stdout):
                     if iss["number"] in seen_closed or iss["number"] in seen_open:
@@ -1797,10 +1810,10 @@ def fetch_issues_and_prs() -> list[GHItem]:
 
     # PRs (open + recently closed/merged)
     try:
-        r = subprocess.run(
-            ["gh", "pr", "list", "--state", "all", "--limit", "15",
-             "--json", "number,title,labels,statusCheckRollup,state,createdAt,updatedAt,closedAt,mergedAt"],
-            capture_output=True, text=True, timeout=30, cwd=cwd,
+        r = _gh_cli(
+            "pr", "list", "--state", "all", "--limit", "15",
+            "--json", "number,title,labels,statusCheckRollup,state,createdAt,updatedAt,closedAt,mergedAt",
+            timeout=30,
         )
         if r.returncode == 0:
             for pr in json.loads(r.stdout):
@@ -1839,12 +1852,11 @@ def fetch_blocked_deps() -> dict[int, list[int]]:
     `[Blocked on #N]` annotations consistently.
     """
     import re as _re
-    cwd = str(PROJECT_DIR)
     try:
-        r = subprocess.run(
-            ["gh", "issue", "list", "--label", "blocked",
-             "--state", "open", "--limit", "40", "--json", "number,body"],
-            capture_output=True, text=True, timeout=30, cwd=cwd,
+        r = _gh_cli(
+            "issue", "list", "--label", "blocked",
+            "--state", "open", "--limit", "40", "--json", "number,body",
+            timeout=30,
         )
         if r.returncode != 0:
             return {}
@@ -1858,10 +1870,10 @@ def fetch_blocked_deps() -> dict[int, list[int]]:
             return {}
 
         # Fetch open issue numbers to filter out closed deps
-        r2 = subprocess.run(
-            ["gh", "issue", "list", "--state", "open", "--limit", "100",
-             "--json", "number", "--jq", "[.[].number]"],
-            capture_output=True, text=True, timeout=30, cwd=cwd,
+        r2 = _gh_cli(
+            "issue", "list", "--state", "open", "--limit", "100",
+            "--json", "number", "--jq", "[.[].number]",
+            timeout=30,
         )
         open_nums: set[int] = set(json.loads(r2.stdout)) if r2.returncode == 0 else set()
 
@@ -1889,12 +1901,11 @@ def fetch_has_pr_links() -> dict[int, list[int]]:
     out closed/merged ones. Has-pr issues are typically few (≤ 10),
     so the N+1 cost is bounded.
     """
-    cwd = str(PROJECT_DIR)
     try:
-        r = subprocess.run(
-            ["gh", "issue", "list", "--label", "has-pr",
-             "--state", "open", "--limit", "40", "--json", "number"],
-            capture_output=True, text=True, timeout=30, cwd=cwd,
+        r = _gh_cli(
+            "issue", "list", "--label", "has-pr",
+            "--state", "open", "--limit", "40", "--json", "number",
+            timeout=30,
         )
         if r.returncode != 0:
             return {}
@@ -1905,11 +1916,11 @@ def fetch_has_pr_links() -> dict[int, list[int]]:
 
         result: dict[int, list[int]] = {}
         for num in issue_nums:
-            r2 = subprocess.run(
-                ["gh", "issue", "view", str(num),
-                 "--json", "closedByPullRequestsReferences",
-                 "--jq", "[.closedByPullRequestsReferences[].number]"],
-                capture_output=True, text=True, timeout=15, cwd=cwd,
+            r2 = _gh_cli(
+                "issue", "view", str(num),
+                "--json", "closedByPullRequestsReferences",
+                "--jq", "[.closedByPullRequestsReferences[].number]",
+                timeout=15,
             )
             if r2.returncode != 0:
                 result[num] = []
@@ -1922,10 +1933,10 @@ def fetch_has_pr_links() -> dict[int, list[int]]:
 
             open_prs: list[int] = []
             for pr_num in refs:
-                r3 = subprocess.run(
-                    ["gh", "pr", "view", str(pr_num),
-                     "--json", "state", "--jq", ".state"],
-                    capture_output=True, text=True, timeout=15, cwd=cwd,
+                r3 = _gh_cli(
+                    "pr", "view", str(pr_num),
+                    "--json", "state", "--jq", ".state",
+                    timeout=15,
                 )
                 if r3.returncode == 0 and r3.stdout.strip() == "OPEN":
                     open_prs.append(pr_num)
@@ -2209,14 +2220,15 @@ def _gh_quota_ok() -> bool:
         rem = _gh_quota_cache["graphql_remaining"]
         return rem is None or rem >= _GH_QUOTA_PAUSE_THRESHOLD
     try:
-        r = subprocess.run(
-            ["gh", "api", "rate_limit", "--jq", ".resources.graphql.remaining"],
-            capture_output=True, text=True, timeout=10,
-        )
-        if r.returncode == 0 and r.stdout.strip():
-            _gh_quota_cache["graphql_remaining"] = int(r.stdout.strip())
-            _gh_quota_cache["checked_at"] = now
-    except (subprocess.TimeoutExpired, OSError, ValueError):
+        resp = gh.get_client().get("/rate_limit", timeout=10)
+        if resp.ok():
+            graphql = ((resp.body() or {}).get("resources", {}) or {}
+                       ).get("graphql", {}) or {}
+            remaining = graphql.get("remaining")
+            if remaining is not None:
+                _gh_quota_cache["graphql_remaining"] = int(remaining)
+                _gh_quota_cache["checked_at"] = now
+    except Exception:
         pass  # keep previous reading (if any); treat unknown as OK
     rem = _gh_quota_cache["graphql_remaining"]
     return rem is None or rem >= _GH_QUOTA_PAUSE_THRESHOLD
@@ -2537,16 +2549,15 @@ def _get_base_branch() -> str:
     global _cached_base_branch
     if _cached_base_branch:
         return _cached_base_branch
-    # REST (`gh api repos/{slug}`) instead of `gh repo view --json` so this
-    # doesn't burn GraphQL quota on every cache miss.
+    # Direct REST via the access layer (ETag-cached after the first hit),
+    # so this doesn't burn GraphQL quota and steady-state cost is a 304.
     try:
-        r = subprocess.run(
-            ["gh", "api", f"repos/{_get_repo()}", "--jq", ".default_branch"],
-            capture_output=True, text=True, timeout=15, cwd=str(PROJECT_DIR),
-        )
-        if r.returncode == 0 and r.stdout.strip():
-            _cached_base_branch = r.stdout.strip()
-            return _cached_base_branch
+        resp = gh.get_client().get(f"/repos/{_get_repo()}", timeout=15)
+        if resp.ok():
+            db = ((resp.body() or {}).get("default_branch") or "").strip()
+            if db:
+                _cached_base_branch = db
+                return _cached_base_branch
     except Exception:
         pass
     return "master"
@@ -2576,13 +2587,12 @@ def _get_repo() -> str:
             return _cached_repo_name
     except Exception:
         pass
-    # Fallback: ask gh (REST). Only reached when the remote isn't a parseable
-    # GitHub URL — e.g. a non-default remote name or a deploy-key URL.
+    # Fallback: ask gh porcelain. Only reached when the remote isn't a
+    # parseable GitHub URL — e.g. a non-default remote name or a deploy-key
+    # URL. Routed through the layer so it's still logged.
     try:
-        r = subprocess.run(
-            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-            capture_output=True, text=True, timeout=15, cwd=str(PROJECT_DIR),
-        )
+        r = _gh_cli("repo", "view", "--json", "nameWithOwner",
+                    "-q", ".nameWithOwner", timeout=15)
         if r.returncode == 0 and r.stdout.strip():
             _cached_repo_name = r.stdout.strip()
             return _cached_repo_name
@@ -2800,10 +2810,7 @@ def check_repo_security(config: dict) -> None:
         return
 
     try:
-        r = subprocess.run(
-            ["gh", "api", f"repos/{slug}", "--jq", ".visibility"],
-            capture_output=True, text=True, timeout=15, cwd=str(PROJECT_DIR),
-        )
+        resp = gh.get_client().get(f"/repos/{slug}", timeout=15)
     except FileNotFoundError:
         print("pod: security: `gh` CLI not found; cannot verify interaction limits.",
               file=sys.stderr)
@@ -2811,14 +2818,19 @@ def check_repo_security(config: dict) -> None:
     except Exception as e:
         print(f"pod: security: failed to query repo: {e}", file=sys.stderr)
         sys.exit(1)
-    if r.returncode != 0 or not r.stdout.strip():
-        err = r.stderr.strip() or "empty response"
-        print(f"pod: security: cannot determine repo visibility: {err}", file=sys.stderr)
-        if "auth" in err.lower() or "login" in err.lower() or "401" in err:
+    if not resp.ok():
+        err = f"HTTP {resp.status}"
+        print(f"pod: security: cannot determine repo visibility: {err}",
+              file=sys.stderr)
+        if resp.status in (401, 403):
             print("    → run `gh auth status` / `gh auth login` and retry.",
                   file=sys.stderr)
         sys.exit(1)
-    visibility = r.stdout.strip().lower()
+    visibility = ((resp.body() or {}).get("visibility") or "").lower()
+    if not visibility:
+        print("pod: security: cannot determine repo visibility: empty response",
+              file=sys.stderr)
+        sys.exit(1)
 
     if visibility != "public":
         _save_security_cache(slug, visibility=visibility)
@@ -2826,24 +2838,17 @@ def check_repo_security(config: dict) -> None:
         return
 
     try:
-        r = subprocess.run(
-            ["gh", "api", f"repos/{slug}/interaction-limits"],
-            capture_output=True, text=True, timeout=15,
-        )
+        resp = gh.get_client().get(f"/repos/{slug}/interaction-limits",
+                                    timeout=15)
     except Exception as e:
         _security_fail(slug, f"failed to query interaction-limits: {e}")
-    if r.returncode != 0:
-        err = r.stderr.strip() or "gh api error"
-        is_auth = ("auth" in err.lower() or "login" in err.lower()
-                   or "401" in err or "403" in err)
+    if not resp.ok():
+        err = f"HTTP {resp.status}"
+        is_auth = resp.status in (401, 403)
         _security_fail(slug, f"failed to query interaction-limits: {err}",
                        auth_hint=is_auth)
 
-    body = r.stdout.strip() or "{}"
-    try:
-        data = json.loads(body)
-    except json.JSONDecodeError as e:
-        _security_fail(slug, f"unparseable interaction-limits response: {e}")
+    data = resp.body() or {}
 
     if not data:
         _security_fail(slug,
@@ -2915,56 +2920,47 @@ def _provenance_ttl(config: dict) -> float:
 
 
 def _is_repo_public(config: dict) -> bool:
-    """Return True iff the current repo is public. Uses the REST endpoint
-    (`gh api repos/{slug}`) to avoid GraphQL quota. Fails closed by
-    treating ambiguous results as public so the security gate still runs.
+    """Return True iff the current repo is public. Routed through the
+    layer (ETag-cached); fails closed by treating ambiguous results as
+    public so the security gate still runs.
     """
     try:
-        r = subprocess.run(
-            ["gh", "api", f"repos/{_get_repo()}", "--jq", ".visibility"],
-            capture_output=True, text=True, timeout=15, cwd=str(PROJECT_DIR),
-        )
+        resp = gh.get_client().get(f"/repos/{_get_repo()}", timeout=15)
     except Exception:
         return True  # fail-closed: treat as public so we still check
-    if r.returncode != 0 or not r.stdout.strip():
+    if not resp.ok():
         return True
-    return r.stdout.strip().lower() == "public"
+    visibility = ((resp.body() or {}).get("visibility") or "").lower()
+    if not visibility:
+        return True
+    return visibility == "public"
 
 
 def fetch_issue_provenance(repo: str, issue_num: int) -> _IssueProvenance:
     """Fetch the issue + its comments and bundle author/association data.
 
-    Two `gh api` calls per issue: one for the issue, one paginated for
-    comments. Raises subprocess.CalledProcessError on `gh` failure so
-    callers can surface a clear error.
+    Two layer-routed reads per issue: one for the issue, one paginated
+    for comments. ETag-cached, so steady-state cost is two 304s per
+    repeat. Raises RuntimeError on layer failure so callers can surface
+    a clear error.
     """
-    issue_r = subprocess.run(
-        ["gh", "api", f"repos/{repo}/issues/{issue_num}"],
-        capture_output=True, text=True, timeout=30, check=True,
-    )
-    issue = json.loads(issue_r.stdout)
-    comments_r = subprocess.run(
-        ["gh", "api", "--paginate", f"repos/{repo}/issues/{issue_num}/comments"],
-        capture_output=True, text=True, timeout=60, check=True,
-    )
-    # `gh api --paginate` concatenates JSON arrays; parse each line that's
-    # an array, falling back to a single document on no pagination.
+    client = gh.get_client()
+    issue_resp = client.get(f"/repos/{repo}/issues/{issue_num}", timeout=30)
+    if not issue_resp.ok():
+        raise RuntimeError(
+            f"failed to fetch issue {repo}#{issue_num}: HTTP {issue_resp.status}")
+    issue = issue_resp.body() or {}
+
     comments_raw: list = []
-    body = comments_r.stdout.strip()
-    if body:
-        # `gh` emits one or more arrays back-to-back (no separator).
-        # JSONDecoder.raw_decode handles that.
-        decoder = json.JSONDecoder()
-        idx = 0
-        while idx < len(body):
-            while idx < len(body) and body[idx].isspace():
-                idx += 1
-            if idx >= len(body):
-                break
-            obj, end = decoder.raw_decode(body, idx)
-            if isinstance(obj, list):
-                comments_raw.extend(obj)
-            idx = end
+    for page in client.paginate(f"/repos/{repo}/issues/{issue_num}/comments",
+                                 max_pages=10):
+        if not page.ok():
+            raise RuntimeError(
+                f"failed to page comments for {repo}#{issue_num}: "
+                f"HTTP {page.status}")
+        body = page.body() or []
+        if isinstance(body, list):
+            comments_raw.extend(body)
     comments = [
         _ProvenanceComment(
             comment_id=int(c.get("id", 0)),
@@ -3036,9 +3032,8 @@ def check_issue_provenance(repo: str, issue_num: int, config: dict,
         return True, ""
     try:
         prov = _cached_provenance(repo, issue_num, config, fresh=fresh)
-    except subprocess.CalledProcessError as e:
-        err = (e.stderr or "").strip() or "gh api error"
-        return False, f"failed to fetch provenance for #{issue_num}: {err}"
+    except RuntimeError as e:
+        return False, f"failed to fetch provenance for #{issue_num}: {e}"
     except (json.JSONDecodeError, ValueError) as e:
         return False, f"unparseable provenance response for #{issue_num}: {e}"
     return is_trusted(prov, config)
@@ -3071,19 +3066,19 @@ def cmd_filter_trusted_issues(config: dict, args) -> None:
     section, and directly by `plan.md` to replace inline `gh issue list`.
     """
     repo = _get_repo()
-    cmd = ["gh", "issue", "list", "--repo", repo]
+    argv: list[str] = ["issue", "list", "--repo", repo]
     for label in (args.label or []):
-        cmd += ["--label", label]
+        argv += ["--label", label]
     if args.state:
-        cmd += ["--state", args.state]
+        argv += ["--state", args.state]
     if args.limit:
-        cmd += ["--limit", str(args.limit)]
+        argv += ["--limit", str(args.limit)]
     # Always include the fields needed to filter, plus whatever the
     # caller asked for.
     requested = set((args.json or "number,title").split(","))
     requested |= {"number"}
-    cmd += ["--json", ",".join(sorted(requested))]
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    argv += ["--json", ",".join(sorted(requested))]
+    r = _gh_cli(*argv, timeout=60)
     if r.returncode != 0:
         print(f"pod: gh issue list failed: {r.stderr.strip()}", file=sys.stderr)
         sys.exit(1)
@@ -3146,27 +3141,25 @@ def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> boo
     import re as _re
     repo = _get_repo()
 
-    # Idempotent fast path: REST probe (separate quota bucket from GraphQL).
+    client = gh.get_client()
+
+    # Idempotent fast path: REST probe via the layer (ETag-cached).
     # Catches the common stale-history case where the label was already
     # removed (by another reconciler, by hand, or by us on a previous run
     # whose history write was lost). Also handles closed issues.
     try:
-        r_probe = subprocess.run(
-            ["gh", "api", f"repos/{repo}/issues/{issue_str}",
-             "--jq", '{state, labels: [.labels[].name]}'],
-            capture_output=True, text=True, timeout=30, cwd=str(PROJECT_DIR),
-        )
-    except (subprocess.TimeoutExpired, OSError) as e:
+        r_probe = client.get(f"/repos/{repo}/issues/{issue_str}", timeout=30)
+    except Exception as e:
         log(f"_release_claim: probe failed for #{issue_str}: {e}; falling through")
         r_probe = None
     if r_probe is not None:
-        if _is_rate_limit_error(r_probe):
+        if r_probe.status == 403:
             raise _GraphQLRateLimited(f"REST probe rate-limited for #{issue_str}")
-        if r_probe.returncode == 0 and r_probe.stdout.strip():
+        if r_probe.ok():
             try:
-                probe = json.loads(r_probe.stdout)
+                probe = r_probe.body() or {}
                 state = probe.get("state", "")
-                labels = probe.get("labels", []) or []
+                labels = [l.get("name", "") for l in probe.get("labels", []) or []]
                 if "claimed" not in labels:
                     log(f"_release_claim: #{issue_str} already lacks 'claimed' label "
                         f"(state={state}); treating as released")
@@ -3175,18 +3168,17 @@ def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> boo
                     log(f"_release_claim: #{issue_str} is closed; leaving stale 'claimed' "
                         f"label in place (terminal success)")
                     return True
-            except (json.JSONDecodeError, ValueError) as e:
+            except (TypeError, ValueError) as e:
                 log(f"_release_claim: probe parse failed for #{issue_str}: {e}; falling through")
 
-    # GitHub-side CAS: verify latest claim comment is ours. This call is
-    # GraphQL-backed; the REST probe above ensures we only reach it when
-    # there's actual work to do.
+    # GitHub-side CAS: verify latest claim comment is ours. The REST
+    # probe above ensures we only reach this when there's real work.
     try:
-        r_cas = subprocess.run(
-            ["gh", "issue", "view", issue_str, "--repo", repo,
-             "--json", "comments",
-             "--jq", '[.comments[] | select(.body | startswith("Claimed by session"))] | sort_by(.createdAt) | last | .body'],
-            capture_output=True, text=True, timeout=60, cwd=str(PROJECT_DIR),
+        r_cas = _gh_cli(
+            "issue", "view", issue_str, "--repo", repo,
+            "--json", "comments",
+            "--jq", '[.comments[] | select(.body | startswith("Claimed by session"))] | sort_by(.createdAt) | last | .body',
+            timeout=60,
         )
     except (subprocess.TimeoutExpired, OSError) as e:
         log(f"Failed to release claim on #{issue_str}: CAS subprocess error: {e}")
@@ -3200,9 +3192,10 @@ def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> boo
             return False
 
     try:
-        r1 = subprocess.run(
-            ["gh", "issue", "edit", issue_str, "--repo", repo, "--remove-label", "claimed"],
-            capture_output=True, timeout=30, cwd=str(PROJECT_DIR),
+        r1 = _gh_cli(
+            "issue", "edit", issue_str, "--repo", repo,
+            "--remove-label", "claimed",
+            timeout=30,
         )
     except (subprocess.TimeoutExpired, OSError) as e:
         log(f"Failed to release claim on #{issue_str}: edit subprocess error: {e}")
@@ -3210,14 +3203,14 @@ def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> boo
     if _is_rate_limit_error(r1):
         raise _GraphQLRateLimited(f"edit rate-limited for #{issue_str}")
     if r1.returncode != 0:
-        log(f"Failed to remove claimed label on #{issue_str}: {r1.stderr.decode().strip()}")
+        log(f"Failed to remove claimed label on #{issue_str}: {r1.stderr.strip()}")
         return False
     msg = (f"Claim released — worker session `{session_uuid}` died after "
            f"{restart_count} restart attempt(s). Available for reclaim.")
     try:
-        r2 = subprocess.run(
-            ["gh", "issue", "comment", issue_str, "--repo", repo, "--body", msg],
-            capture_output=True, timeout=30, cwd=str(PROJECT_DIR),
+        r2 = _gh_cli(
+            "issue", "comment", issue_str, "--repo", repo,
+            "--body", msg, timeout=30,
         )
     except (subprocess.TimeoutExpired, OSError) as e:
         log(f"Failed to comment on #{issue_str}: {e}")
@@ -3225,7 +3218,7 @@ def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> boo
     if _is_rate_limit_error(r2):
         raise _GraphQLRateLimited(f"comment rate-limited for #{issue_str}")
     if r2.returncode != 0:
-        log(f"Failed to comment on #{issue_str}: {r2.stderr.decode().strip()}")
+        log(f"Failed to comment on #{issue_str}: {r2.stderr.strip()}")
         return False
     log(f"Released claim on #{issue_str}")
     return True
@@ -3237,13 +3230,12 @@ def sync_claims_from_github():
     that were running before a pod restart."""
     import re as _re
     repo = _get_repo()
-    cwd = str(PROJECT_DIR)
 
     try:
-        r = subprocess.run(
-            ["gh", "issue", "list", "--label", "agent-plan", "--label", "claimed",
-             "--state", "open", "--limit", "100", "--json", "number"],
-            capture_output=True, text=True, timeout=30, cwd=cwd,
+        r = _gh_cli(
+            "issue", "list", "--label", "agent-plan", "--label", "claimed",
+            "--state", "open", "--limit", "100", "--json", "number",
+            timeout=30,
         )
         if r.returncode != 0:
             return
@@ -3263,11 +3255,11 @@ def sync_claims_from_github():
                 continue  # Already tracked locally
             # Fetch comments to find the most recent claim comment
             try:
-                r = subprocess.run(
-                    ["gh", "issue", "view", str(issue_num), "--repo", repo,
-                     "--json", "comments",
-                     "--jq", '[.comments[] | select(.body | startswith("Claimed by session"))] | sort_by(.createdAt) | last | .body'],
-                    capture_output=True, text=True, timeout=60, cwd=cwd,
+                r = _gh_cli(
+                    "issue", "view", str(issue_num), "--repo", repo,
+                    "--json", "comments",
+                    "--jq", '[.comments[] | select(.body | startswith("Claimed by session"))] | sort_by(.createdAt) | last | .body',
+                    timeout=60,
                 )
                 if r.returncode != 0:
                     continue
@@ -3427,15 +3419,14 @@ def reconcile_untracked_github_claims():
     import re as _re
 
     repo = _get_repo()
-    cwd = str(PROJECT_DIR)
     grace_seconds = 600  # 10 minutes — don't release very fresh claims
 
     # 1. Query GitHub for all currently-claimed issues
     try:
-        r = subprocess.run(
-            ["gh", "issue", "list", "--label", "agent-plan", "--label", "claimed",
-             "--state", "open", "--limit", "100", "--json", "number"],
-            capture_output=True, text=True, timeout=30, cwd=cwd,
+        r = _gh_cli(
+            "issue", "list", "--label", "agent-plan", "--label", "claimed",
+            "--state", "open", "--limit", "100", "--json", "number",
+            timeout=30,
         )
         if _is_rate_limit_error(r):
             log("reconcile_untracked_github_claims: aborting — GraphQL rate-limited "
@@ -3479,11 +3470,11 @@ def reconcile_untracked_github_claims():
         for issue_num in sorted(untracked):
             # Fetch the latest "Claimed by session" comment for this issue
             try:
-                r = subprocess.run(
-                    ["gh", "issue", "view", str(issue_num), "--repo", repo,
-                     "--json", "comments",
-                     "--jq", '[.comments[] | select(.body | startswith("Claimed by session"))] | sort_by(.createdAt) | last | {body, created_at: .createdAt}'],
-                    capture_output=True, text=True, timeout=60, cwd=cwd,
+                r = _gh_cli(
+                    "issue", "view", str(issue_num), "--repo", repo,
+                    "--json", "comments",
+                    "--jq", '[.comments[] | select(.body | startswith("Claimed by session"))] | sort_by(.createdAt) | last | {body, created_at: .createdAt}',
+                    timeout=60,
                 )
                 if _is_rate_limit_error(r):
                     raise _GraphQLRateLimited(
@@ -3538,11 +3529,11 @@ def reconcile_untracked_github_claims():
 
             # Re-fetch latest claim owner before releasing (compare-and-swap)
             try:
-                r2 = subprocess.run(
-                    ["gh", "issue", "view", str(issue_num), "--repo", repo,
-                     "--json", "comments",
-                     "--jq", '[.comments[] | select(.body | startswith("Claimed by session"))] | sort_by(.createdAt) | last | .body'],
-                    capture_output=True, text=True, timeout=60, cwd=cwd,
+                r2 = _gh_cli(
+                    "issue", "view", str(issue_num), "--repo", repo,
+                    "--json", "comments",
+                    "--jq", '[.comments[] | select(.body | startswith("Claimed by session"))] | sort_by(.createdAt) | last | .body',
+                    timeout=60,
                 )
                 if _is_rate_limit_error(r2):
                     raise _GraphQLRateLimited(
@@ -3570,10 +3561,11 @@ def reconcile_untracked_github_claims():
             # Release the stale claim — first verify the label is still present
             # (prevents N parallel reconcilers from all posting release comments)
             try:
-                r_label_check = subprocess.run(
-                    ["gh", "issue", "view", str(issue_num), "--repo", repo,
-                     "--json", "labels", "--jq", '[.labels[].name] | any(. == "claimed")'],
-                    capture_output=True, text=True, timeout=30, cwd=cwd,
+                r_label_check = _gh_cli(
+                    "issue", "view", str(issue_num), "--repo", repo,
+                    "--json", "labels",
+                    "--jq", '[.labels[].name] | any(. == "claimed")',
+                    timeout=30,
                 )
                 if _is_rate_limit_error(r_label_check):
                     raise _GraphQLRateLimited(
@@ -3581,9 +3573,9 @@ def reconcile_untracked_github_claims():
                 if r_label_check.returncode != 0 or r_label_check.stdout.strip() != "true":
                     continue  # Label already removed by another reconciler
 
-                r3 = subprocess.run(
-                    ["gh", "issue", "edit", str(issue_num), "--repo", repo, "--remove-label", "claimed"],
-                    capture_output=True, timeout=30, cwd=cwd,
+                r3 = _gh_cli(
+                    "issue", "edit", str(issue_num), "--repo", repo,
+                    "--remove-label", "claimed", timeout=30,
                 )
                 if _is_rate_limit_error(r3):
                     raise _GraphQLRateLimited(
@@ -3593,9 +3585,9 @@ def reconcile_untracked_github_claims():
                 age_str = f"{int(age // 3600)}h{int((age % 3600) // 60)}m"
                 msg = (f"Stale claim released by reconciler — session `{owner_uuid}` "
                        f"is no longer running (claimed {age_str} ago). Available for reclaim.")
-                r_comment = subprocess.run(
-                    ["gh", "issue", "comment", str(issue_num), "--repo", repo, "--body", msg],
-                    capture_output=True, timeout=30, cwd=cwd,
+                r_comment = _gh_cli(
+                    "issue", "comment", str(issue_num), "--repo", repo,
+                    "--body", msg, timeout=30,
                 )
                 if _is_rate_limit_error(r_comment):
                     raise _GraphQLRateLimited(
@@ -3640,17 +3632,15 @@ def check_dead_pr_claimed_prs(config: dict):
     Fail-closed: any gh / parsing error on a specific PR skips it.
     """
     repo = _get_repo()
-    cwd = str(PROJECT_DIR)
     stuck_minutes = cfg_get(config, "repair", "stuck_ci_minutes", default=120)
     stale_seconds = int(stuck_minutes) * 60 * 2
 
     # 1. Find all open PRs carrying repair-claimed.
     try:
-        r = subprocess.run(
-            ["gh", "pr", "list", "--repo", repo, "--state", "open",
-             "--label", "repair-claimed", "--limit", "100",
-             "--json", "number"],
-            capture_output=True, text=True, timeout=30, cwd=cwd,
+        r = _gh_cli(
+            "pr", "list", "--repo", repo, "--state", "open",
+            "--label", "repair-claimed", "--limit", "100",
+            "--json", "number", timeout=30,
         )
         if _is_rate_limit_error(r):
             log("check_dead_pr_claimed_prs: aborting — GraphQL rate-limited "
@@ -3690,26 +3680,32 @@ def check_dead_pr_claimed_prs(config: dict):
                 #  - the comment is older than the grace window, AND
                 #  - its owner session is not live.
                 try:
-                    r = subprocess.run(
-                        ["gh", "api", "--paginate", f"repos/{repo}/issues/{pr_num}/comments",
-                         "--jq",
-                         '[.[] | select(.body | startswith("Claimed PR repair by session"))] '
-                         '| sort_by(.created_at) | last | {body, created_at}'],
-                        capture_output=True, text=True, timeout=30, cwd=cwd,
-                    )
-                    if _is_rate_limit_error(r):
-                        raise _GraphQLRateLimited(
-                            f"comment fetch rate-limited for PR #{pr_num}")
-                    if r.returncode != 0:
-                        continue
-                    blob = r.stdout.strip()
-                    if not blob or blob == "null":
+                    client = gh.get_client()
+                    latest: dict | None = None
+                    for page in client.paginate(
+                            f"/repos/{repo}/issues/{pr_num}/comments",
+                            max_pages=10):
+                        if not page.ok():
+                            if page.status == 403:
+                                raise _GraphQLRateLimited(
+                                    f"comment fetch rate-limited for PR #{pr_num}")
+                            break
+                        for c in (page.body() or []):
+                            if not isinstance(c, dict):
+                                continue
+                            body = c.get("body", "") or ""
+                            if not body.startswith("Claimed PR repair by session"):
+                                continue
+                            ca = c.get("created_at", "") or ""
+                            if latest is None or ca > (latest.get("created_at", "") or ""):
+                                latest = {"body": body, "created_at": ca}
+                    if latest is None:
                         # No claim comment at all — label is orphaned from a
                         # failed claim attempt. Grace-release.
                         to_release.append((pr_num, "orphaned label: no claim comment"))
                         continue
-                    cdata = json.loads(blob)
-                except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+                    cdata = latest
+                except (TypeError, ValueError):
                     continue
                 import re as _re
                 m = _re.search(r'Claimed PR repair by session `([^`]+)`', cdata.get("body", ""))
@@ -3743,20 +3739,19 @@ def check_dead_pr_claimed_prs(config: dict):
         # 3. Issue the releases.
         for pr_num, reason in to_release:
             try:
-                r = subprocess.run(
-                    ["gh", "pr", "edit", str(pr_num), "--repo", repo,
-                     "--remove-label", "repair-claimed"],
-                    capture_output=True, timeout=30, cwd=cwd,
+                r = _gh_cli(
+                    "pr", "edit", str(pr_num), "--repo", repo,
+                    "--remove-label", "repair-claimed", timeout=30,
                 )
                 if _is_rate_limit_error(r):
                     raise _GraphQLRateLimited(
                         f"label remove rate-limited for PR #{pr_num}")
                 if r.returncode != 0:
                     continue
-                r_comment = subprocess.run(
-                    ["gh", "pr", "comment", str(pr_num), "--repo", repo,
-                     "--body", f"Repair claim released by reconciler: {reason}."],
-                    capture_output=True, timeout=30, cwd=cwd,
+                r_comment = _gh_cli(
+                    "pr", "comment", str(pr_num), "--repo", repo,
+                    "--body", f"Repair claim released by reconciler: {reason}.",
+                    timeout=30,
                 )
                 if _is_rate_limit_error(r_comment):
                     raise _GraphQLRateLimited(
@@ -6725,6 +6720,99 @@ def cmd_config(config: dict, args):
         print(CONFIG_PATH.read_text(), end="")
 
 
+def cmd_gh_stats(config: dict, args) -> None:
+    """Summarise `.pod/gh-access.log` to find which callers / paths are
+    consuming the most GitHub API budget.
+
+    The log is JSONL, one row per call. We aggregate by the column named
+    in `--by` and print: count, ETag-cache-hit ratio, total wall-ms,
+    total bytes (best-effort).
+    """
+    import collections
+
+    log_path = Path(args.log) if args.log else (POD_DIR / "gh-access.log")
+    if not log_path.exists():
+        print(f"No GitHub access log at {log_path}.", file=sys.stderr)
+        print("It is created on first GitHub interaction.", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse --since.
+    units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    s = args.since.strip().lower()
+    try:
+        if s and s[-1] in units:
+            since_seconds = int(s[:-1]) * units[s[-1]]
+        else:
+            since_seconds = int(s)  # seconds
+    except ValueError:
+        print(f"Invalid --since value: {args.since!r} "
+              "(expected e.g. 10m, 1h, 24h, 7d).", file=sys.stderr)
+        sys.exit(1)
+    cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=since_seconds)
+
+    # Aggregate.
+    by_key: dict[str, dict] = collections.defaultdict(
+        lambda: {"count": 0, "cache_hits": 0, "ms": 0, "bytes": 0,
+                 "errors": 0})
+    total = {"count": 0, "cache_hits": 0, "ms": 0, "bytes": 0, "errors": 0}
+
+    with open(log_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = row.get("ts", "")
+            try:
+                row_dt = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if row_dt < cutoff:
+                continue
+            key = str(row.get(args.by, "?"))
+            for buf in (by_key[key], total):
+                buf["count"] += 1
+                if row.get("cache_hit"):
+                    buf["cache_hits"] += 1
+                buf["ms"] += int(row.get("ms") or 0)
+                buf["bytes"] += int(row.get("bytes") or 0)
+                if int(row.get("status") or 0) >= 400:
+                    buf["errors"] += 1
+
+    if total["count"] == 0:
+        print(f"No log rows in the last {args.since} window.")
+        return
+
+    rows = sorted(by_key.items(), key=lambda kv: kv[1]["count"], reverse=True)
+    rows = rows[: args.top]
+
+    # Format.
+    width = max((len(k) for k, _ in rows), default=10)
+    width = min(width, 70)
+    print(f"GitHub access log: {log_path}")
+    print(f"Window: last {args.since}  |  Group by: {args.by}  |  "
+          f"Top: {args.top}")
+    print(f"Total: {total['count']} calls  "
+          f"({100 * total['cache_hits'] / max(1, total['count']):.0f}% ETag-cache hit, "
+          f"{total['errors']} errors, "
+          f"{total['ms'] / 1000:.1f}s wall, "
+          f"{total['bytes'] / 1024:.1f} KiB body)")
+    print()
+    print(f"  {'#':>5}  {'cache%':>6}  {'errs':>4}  "
+          f"{'ms':>7}  {'KiB':>5}  {args.by}")
+    print(f"  {'-' * 5}  {'-' * 6}  {'-' * 4}  {'-' * 7}  {'-' * 5}  "
+          f"{'-' * width}")
+    for key, v in rows:
+        cache_pct = 100 * v["cache_hits"] / max(1, v["count"])
+        print(f"  {v['count']:>5}  {cache_pct:>5.0f}%  "
+              f"{v['errors']:>4}  {v['ms']:>7}  {v['bytes']/1024:>5.1f}  "
+              f"{key[:width]}")
+
+
 def cmd_cleanup(config: dict, args):
     """Remove stale worktrees that no running agent owns."""
     base = PROJECT_DIR / cfg_get(config, "project", "worktree_base", default="worktrees")
@@ -6833,11 +6921,8 @@ REQUIRED_LABELS = {
 def _ensure_github_labels():
     """Create any missing GitHub labels required by pod."""
     try:
-        r = subprocess.run(
-            ["gh", "label", "list", "--limit", "100", "--json", "name", "--jq", ".[].name"],
-            capture_output=True, text=True, timeout=15,
-            cwd=str(PROJECT_DIR),
-        )
+        r = _gh_cli("label", "list", "--limit", "100",
+                     "--json", "name", "--jq", ".[].name", timeout=15)
         if r.returncode != 0:
             print("  warning: could not list labels (gh CLI issue)")
             return
@@ -6845,11 +6930,9 @@ def _ensure_github_labels():
         created = []
         for label, color in REQUIRED_LABELS.items():
             if label not in existing:
-                cr = subprocess.run(
-                    ["gh", "label", "create", label, "--color", color,
-                     "--description", "pod coordination"],
-                    capture_output=True, text=True, timeout=15,
-                    cwd=str(PROJECT_DIR),
+                cr = _gh_cli(
+                    "label", "create", label, "--color", color,
+                    "--description", "pod coordination", timeout=15,
                 )
                 if cr.returncode == 0:
                     created.append(label)
@@ -6864,11 +6947,9 @@ def _ensure_github_labels():
 def _ensure_repo_merge_settings():
     """Enable auto-merge and squash merge on the GitHub repo (best effort)."""
     try:
-        r = subprocess.run(
-            ["gh", "repo", "edit", "--enable-auto-merge", "--enable-squash-merge"],
-            capture_output=True, text=True, timeout=15,
-            cwd=str(PROJECT_DIR),
-        )
+        r = _gh_cli("repo", "edit",
+                     "--enable-auto-merge", "--enable-squash-merge",
+                     timeout=15)
         if r.returncode == 0:
             print("  enabled auto-merge and squash merge on GitHub repo")
         else:
@@ -6896,17 +6977,18 @@ def _ensure_branch_protection(init_config):
         print("      then re-run `pod init`.")
         return
 
+    client = gh.get_client()
+    slug = _get_repo()
     try:
-        r = subprocess.run(
-            ["gh", "api", f"repos/{_get_repo()}", "--jq", ".default_branch"],
-            capture_output=True, text=True, timeout=15,
-            cwd=str(PROJECT_DIR),
-        )
-        if r.returncode != 0 or not r.stdout.strip():
+        resp = client.get(f"/repos/{slug}", timeout=15)
+        if not resp.ok():
             print("  warning: could not detect default branch (gh CLI issue)")
             return
-        default_branch = r.stdout.strip()
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+        default_branch = ((resp.body() or {}).get("default_branch") or "").strip()
+        if not default_branch:
+            print("  warning: could not detect default branch (empty response)")
+            return
+    except Exception:
         print("  warning: could not detect default branch (gh CLI not available)")
         return
 
@@ -6923,23 +7005,19 @@ def _ensure_branch_protection(init_config):
     }
 
     try:
-        r = subprocess.run(
-            ["gh", "api",
-             f"repos/{{owner}}/{{repo}}/branches/{default_branch}/protection",
-             "-X", "PUT", "--input", "-"],
-            input=json.dumps(payload),
-            capture_output=True, text=True, timeout=15,
-            cwd=str(PROJECT_DIR),
+        resp = client.put(
+            f"/repos/{slug}/branches/{default_branch}/protection",
+            json=payload, timeout=15,
         )
-        if r.returncode == 0:
+        if resp.ok():
             print(f"  configured branch protection on `{default_branch}` "
                   f"(required: {', '.join(required)})")
         else:
             print(f"  warning: could not set branch protection on `{default_branch}` "
-                  f"(may need admin access)")
+                  f"(HTTP {resp.status} — may need admin access)")
             print(f"    → Settings → Branches → add rule for `{default_branch}`")
             print(f"      with required status checks: {', '.join(required)}")
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    except Exception:
         print("  warning: could not configure branch protection (gh CLI not available)")
 
 
@@ -7119,6 +7197,20 @@ def main():
     p_config.add_argument("--edit", action="store_true",
                            help="Open config in $EDITOR")
 
+    p_ghstats = sub.add_parser(
+        "gh-stats",
+        help="Aggregate .pod/gh-access.log to find which callers burn quota",
+    )
+    p_ghstats.add_argument("--since", default="1h",
+                            help="Window: e.g. 10m, 1h, 24h, 7d (default: 1h)")
+    p_ghstats.add_argument("--by", choices=("caller", "path", "bucket", "transport"),
+                            default="caller",
+                            help="Group rows by this column (default: caller)")
+    p_ghstats.add_argument("--top", type=int, default=20,
+                            help="Show this many top groups (default: 20)")
+    p_ghstats.add_argument("--log",
+                            help="Override log path (default: .pod/gh-access.log)")
+
     # Internal helpers shelled out to from the bundled `coordination` script.
     # Underscore-prefixed names keep them out of casual `--help` browsing.
     p_check = sub.add_parser("_check-provenance",
@@ -7180,6 +7272,8 @@ def main():
         cmd_log(config, args)
     elif args.command == "config":
         cmd_config(config, args)
+    elif args.command == "gh-stats":
+        cmd_gh_stats(config, args)
     elif args.command == "_check-provenance":
         cmd_check_provenance(config, args)
     elif args.command == "_filter-trusted-issues":

--- a/pod/github.py
+++ b/pod/github.py
@@ -1,0 +1,774 @@
+"""GitHub API access layer for pod.
+
+Single chokepoint for every GitHub interaction. Owns:
+  - One `httpx.Client` per process, with bearer auth from `gh auth token`.
+  - On-disk ETag store at .pod/gh-cache/, so repeated reads of unchanged
+    resources serve a 304 (which doesn't count against the primary 5000/hr
+    REST budget).
+  - Rate meter populated from response headers (X-RateLimit-*); used for
+    back-pressure (sleep until reset when remaining < threshold) plus a
+    soft per-process request-rate cap (defence against secondary limits).
+  - Per-call JSONL log at .pod/gh-access.log, redacting Authorization /
+    sensitive query params.
+  - Subprocess passthrough `gh_cli(*argv)` for porcelain commands that
+    aren't 1:1 with REST/GraphQL (gh pr merge --auto, gh pr create, etc.);
+    those are still logged + back-pressured.
+
+This module replaces ad-hoc `subprocess.run(["gh", "api", ...])` scattered
+through cli.py and the legacy `pod/data/coordination` bash script.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import inspect
+import json
+import os
+import re
+import subprocess
+import threading
+import time
+import urllib.parse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator, Literal
+
+import httpx
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_PER_PAGE = 100
+DEFAULT_API_VERSION = "2022-11-28"
+DEFAULT_ACCEPT = "application/vnd.github+json"
+
+# Sleep until reset when fewer than this many requests remain in a bucket.
+DEFAULT_BACKPRESSURE_THRESHOLD = 50
+# Cap on a single back-pressure sleep; beyond this we surface to the caller.
+MAX_BACKPRESSURE_SLEEP = 60.0
+# Soft per-process request-rate cap (secondary-limit defence; still applies
+# even on 304 cache hits, since GitHub does count those for some secondary
+# limits).
+DEFAULT_RATE_CAP_HZ = 50.0
+
+CACHE_TRIM_AGE_DAYS = 7
+CACHE_TRIM_MAX_ENTRIES = 5_000
+
+LOG_ROTATE_LINES = 200_000
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RateSnapshot:
+    """Point-in-time view of a single rate-limit bucket."""
+    bucket: str = "core"   # "core" or "graphql"
+    limit: int = 0
+    remaining: int = 0
+    reset_at: float = 0.0  # unix timestamp
+    observed_at: float = 0.0
+
+
+@dataclass
+class GHResponse:
+    status: int
+    json: Any = None
+    body_cached: Any = None
+    headers: dict[str, str] = field(default_factory=dict)
+    ms: float = 0.0
+    cache_hit: bool = False
+    rate: RateSnapshot = field(default_factory=RateSnapshot)
+    raw: bytes = b""
+    next_url: str | None = None  # /repos/.../issues?page=2 from Link header
+
+    def ok(self) -> bool:
+        return 200 <= self.status < 300 or self.status == 304
+
+    def body(self) -> Any:
+        """Returns the live JSON body, or the cached body for a 304."""
+        return self.body_cached if self.cache_hit else self.json
+
+
+# ---------------------------------------------------------------------------
+# ETag store
+# ---------------------------------------------------------------------------
+
+class _ETagStore:
+    """Per-URL ETag + body cache on disk.
+
+    Cache key incorporates host, method, URL, normalised query params,
+    Accept media type, and X-GitHub-Api-Version so that representation-
+    affecting differences don't collide. Each cache file is chmod 600.
+    """
+
+    def __init__(self, root: Path):
+        self.root = root
+        self._lock = threading.Lock()
+
+    def _path_for(self, key: str) -> Path:
+        return self.root / f"{key}.json"
+
+    @staticmethod
+    def key_for(host: str, method: str, url: str, params: dict | None,
+                accept: str, api_version: str) -> str:
+        norm_params = ""
+        if params:
+            norm_params = urllib.parse.urlencode(
+                sorted((k, v) for k, v in params.items()), doseq=True)
+        material = f"{host}|{method}|{url}|{norm_params}|{accept}|{api_version}"
+        return hashlib.sha256(material.encode()).hexdigest()
+
+    def load(self, key: str) -> dict | None:
+        p = self._path_for(key)
+        if not p.exists():
+            return None
+        try:
+            return json.loads(p.read_text())
+        except Exception:
+            return None
+
+    def save(self, key: str, *, etag: str, body: Any, status: int, url: str,
+             headers: dict[str, str]) -> None:
+        with self._lock:
+            try:
+                self.root.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                return
+            data = {
+                "etag": etag,
+                "body": body,
+                "status": status,
+                "fetched_at": time.time(),
+                "url": url,
+                # Only retain a few headers that affect representation; the
+                # rest are noise and may include rate-limit data.
+                "headers": {k.lower(): v for k, v in headers.items()
+                            if k.lower() in ("content-type",
+                                             "x-github-media-type")},
+            }
+            p = self._path_for(key)
+            tmp = p.with_suffix(".tmp")
+            try:
+                tmp.write_text(json.dumps(data))
+                os.chmod(tmp, 0o600)
+                tmp.replace(p)
+            except OSError:
+                pass
+
+    def trim(self) -> None:
+        """Drop entries older than CACHE_TRIM_AGE_DAYS; if more than
+        CACHE_TRIM_MAX_ENTRIES remain, keep the newest."""
+        if not self.root.is_dir():
+            return
+        cutoff = time.time() - CACHE_TRIM_AGE_DAYS * 86400
+        entries: list[tuple[float, Path]] = []
+        for p in self.root.iterdir():
+            if not p.is_file() or p.suffix != ".json":
+                continue
+            try:
+                mtime = p.stat().st_mtime
+            except OSError:
+                continue
+            if mtime < cutoff:
+                try:
+                    p.unlink()
+                except OSError:
+                    pass
+                continue
+            entries.append((mtime, p))
+        if len(entries) > CACHE_TRIM_MAX_ENTRIES:
+            entries.sort(reverse=True)
+            for _, p in entries[CACHE_TRIM_MAX_ENTRIES:]:
+                try:
+                    p.unlink()
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Access log
+# ---------------------------------------------------------------------------
+
+_REDACT_QS_PARAMS = {"access_token", "client_secret", "auth", "token"}
+
+
+def _redact_url(url: str) -> str:
+    parts = urllib.parse.urlsplit(url)
+    if not parts.query:
+        return url
+    qs = urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+    redacted = [(k, "REDACTED" if k.lower() in _REDACT_QS_PARAMS else v)
+                for k, v in qs]
+    return urllib.parse.urlunsplit(
+        parts._replace(query=urllib.parse.urlencode(redacted)))
+
+
+def _redact_argv(argv: tuple[str, ...] | list[str]) -> list[str]:
+    """Redact `Authorization:` header values and `token …` patterns from
+    a gh argv before logging. Defence in depth — pod doesn't pass auth
+    on gh argv, but a future caller might."""
+    out: list[str] = []
+    redact_next = False
+    for a in argv:
+        if redact_next:
+            out.append("REDACTED")
+            redact_next = False
+            continue
+        if a in ("-H", "--header"):
+            out.append(a)
+            redact_next = True
+            continue
+        if "authorization:" in a.lower() or a.lower().startswith("token "):
+            out.append("REDACTED")
+            continue
+        out.append(a)
+    return out
+
+
+class _AccessLog:
+    """JSONL logger; one row per GitHub interaction. Thread-safe."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._lock = threading.Lock()
+        self._fh: Any = None
+
+    def _ensure(self) -> None:
+        if self._fh is not None:
+            return
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return
+        self._maybe_rotate()
+        try:
+            self._fh = open(self.path, "a", buffering=1)
+            os.chmod(self.path, 0o600)
+        except OSError:
+            self._fh = None
+
+    def _maybe_rotate(self) -> None:
+        try:
+            if not self.path.exists():
+                return
+            with open(self.path) as f:
+                lines = sum(1 for _ in f)
+            if lines >= LOG_ROTATE_LINES:
+                rotated = self.path.with_suffix(self.path.suffix + ".1")
+                if rotated.exists():
+                    rotated.unlink()
+                self.path.rename(rotated)
+        except OSError:
+            pass
+
+    def write(self, **fields: Any) -> None:
+        with self._lock:
+            self._ensure()
+            if self._fh is None:
+                return
+            try:
+                # Drop None-valued fields to keep rows compact.
+                row = {k: v for k, v in fields.items() if v is not None}
+                self._fh.write(json.dumps(row, separators=(",", ":")) + "\n")
+                self._fh.flush()
+            except OSError:
+                pass
+
+    def close(self) -> None:
+        with self._lock:
+            if self._fh is not None:
+                try:
+                    self._fh.close()
+                except OSError:
+                    pass
+                self._fh = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _bucket_for_path(url: str) -> str:
+    """Which rate-limit bucket a request consumes."""
+    return "graphql" if url.endswith("/graphql") else "core"
+
+
+_LINK_NEXT_RE = re.compile(r'<([^>]+)>;\s*rel="next"')
+
+
+def _parse_next_link(link_header: str) -> str | None:
+    if not link_header:
+        return None
+    m = _LINK_NEXT_RE.search(link_header)
+    return m.group(1) if m else None
+
+
+def _iso_now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+
+def _iso_at(unix: float) -> str | None:
+    if not unix:
+        return None
+    return datetime.datetime.fromtimestamp(unix, datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+
+def _gh_token(host: str = "github.com") -> str:
+    """Read the bearer for `host` from `gh`. Raises RuntimeError on failure."""
+    r = subprocess.run(
+        ["gh", "auth", "token", "--hostname", host],
+        capture_output=True, text=True, timeout=10)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"gh auth token --hostname {host} failed: {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def _default_cache_dir() -> Path:
+    from pod import cli  # late import to avoid circular dependency
+    return cli.POD_DIR / "gh-cache"
+
+
+def _default_log_path() -> Path:
+    from pod import cli
+    return cli.POD_DIR / "gh-access.log"
+
+
+def _default_user_agent() -> str:
+    from pod import __version__
+    return f"pod/{__version__} (https://github.com/FormalFrontier/pod)"
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+class GitHubClient:
+    """Single chokepoint for pod's GitHub interactions."""
+
+    def __init__(self, *,
+                 host: str = "github.com",
+                 token: str | None = None,
+                 cache_dir: Path | None = None,
+                 log_path: Path | None = None,
+                 backpressure_threshold: int = DEFAULT_BACKPRESSURE_THRESHOLD,
+                 rate_cap_hz: float = DEFAULT_RATE_CAP_HZ,
+                 transport: httpx.BaseTransport | None = None,
+                 user_agent: str | None = None,
+                 trim_cache_on_init: bool = True):
+        self.host = host
+        try:
+            self._token = token if token is not None else _gh_token(host)
+        except RuntimeError:
+            # Defer the failure until the first request, so test harnesses
+            # and short-lived CLI commands that never call GitHub still
+            # construct cleanly.
+            self._token = None
+        self.cache = _ETagStore(cache_dir or _default_cache_dir())
+        self.log = _AccessLog(log_path or _default_log_path())
+        self._lock = threading.Lock()
+        self._rate: dict[str, RateSnapshot] = {
+            "core": RateSnapshot(bucket="core"),
+            "graphql": RateSnapshot(bucket="graphql"),
+        }
+        self._last_call_at: float = 0.0
+        self._rate_cap_hz = rate_cap_hz
+        self._backpressure_threshold = backpressure_threshold
+
+        self._client = httpx.Client(
+            base_url=f"https://api.{host}",
+            timeout=DEFAULT_TIMEOUT,
+            transport=transport,
+            headers={
+                "Accept": DEFAULT_ACCEPT,
+                "User-Agent": user_agent or _default_user_agent(),
+                "X-GitHub-Api-Version": DEFAULT_API_VERSION,
+            },
+        )
+        if self._token:
+            self._client.headers["Authorization"] = f"Bearer {self._token}"
+        if trim_cache_on_init:
+            try:
+                self.cache.trim()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception:
+            pass
+        self.log.close()
+
+    # --- internals ---
+
+    def _set_bearer_locked(self, token: str | None) -> None:
+        self._token = token
+        if token:
+            self._client.headers["Authorization"] = f"Bearer {token}"
+        else:
+            self._client.headers.pop("Authorization", None)
+
+    def _record_rate(self, fallback_bucket: str,
+                     headers: httpx.Headers) -> RateSnapshot:
+        try:
+            limit = int(headers.get("x-ratelimit-limit", 0))
+            remaining = int(headers.get("x-ratelimit-remaining", 0))
+            reset = int(headers.get("x-ratelimit-reset", 0))
+        except (ValueError, TypeError):
+            with self._lock:
+                return self._rate.get(fallback_bucket,
+                                       RateSnapshot(bucket=fallback_bucket))
+        resource = (headers.get("x-ratelimit-resource") or
+                    fallback_bucket).lower()
+        if resource not in ("core", "graphql"):
+            resource = fallback_bucket
+        snap = RateSnapshot(bucket=resource, limit=limit,
+                            remaining=remaining,
+                            reset_at=float(reset),
+                            observed_at=time.time())
+        with self._lock:
+            self._rate[resource] = snap
+        return snap
+
+    def _backpressure(self, bucket: str) -> None:
+        """Sleep before the next call if the bucket is near exhaustion or
+        the per-process rate cap would be exceeded."""
+        with self._lock:
+            snap = self._rate.get(bucket, RateSnapshot(bucket=bucket))
+            cap_hz = self._rate_cap_hz
+            last_call = self._last_call_at
+        if (snap.limit and
+                snap.remaining < self._backpressure_threshold and
+                snap.reset_at):
+            wait = min(MAX_BACKPRESSURE_SLEEP,
+                       max(0.0, snap.reset_at - time.time()))
+            if wait > 0:
+                time.sleep(wait)
+        if cap_hz > 0:
+            min_gap = 1.0 / cap_hz
+            now = time.time()
+            gap = now - last_call
+            if gap < min_gap:
+                time.sleep(min_gap - gap)
+        with self._lock:
+            self._last_call_at = time.time()
+
+    def _caller(self) -> str:
+        """Walk the stack to find the first frame that's neither inside
+        pod/github.py nor a known thin wrapper (`_gh_cli` in cli.py).
+        That's the user of the client, regardless of how many wrapper
+        layers sit between them and `request()`."""
+        this_file = __file__
+        # Functions we treat as transparent wrappers — skip them too so
+        # the caller column points at the actual semantic caller.
+        skip_funcs = {"_gh_cli"}
+        st = inspect.stack()
+        for f in st[1:]:
+            if f.filename == this_file:
+                continue
+            if f.function in skip_funcs:
+                continue
+            return f"{Path(f.filename).name}:{f.function}:{f.lineno}"
+        return "unknown"
+
+    def _refresh_token(self) -> bool:
+        """Re-fetch via `gh auth token` and swap the bearer; True iff changed."""
+        try:
+            new = _gh_token(self.host)
+        except Exception:
+            return False
+        if not new:
+            return False
+        with self._lock:
+            if new == self._token:
+                return False
+            self._set_bearer_locked(new)
+        return True
+
+    # --- request ---
+
+    def request(self, method: str, path_or_url: str, *,
+                params: dict | None = None,
+                json: Any = None,
+                headers: dict[str, str] | None = None,
+                accept: str = DEFAULT_ACCEPT,
+                api_version: str = DEFAULT_API_VERSION,
+                cache: Literal["etag", "none"] = "etag",
+                timeout: float = DEFAULT_TIMEOUT,
+                _allow_retry: bool = True,
+                _caller: str | None = None) -> GHResponse:
+        method = method.upper()
+        cacheable = cache == "etag" and method in ("GET", "HEAD")
+
+        if path_or_url.startswith("http"):
+            url = path_or_url
+            url_for_key = path_or_url
+        else:
+            if not path_or_url.startswith("/"):
+                path_or_url = "/" + path_or_url
+            url = path_or_url
+            url_for_key = path_or_url
+
+        # Build a logging-friendly URL that includes any params, then run
+        # it through redaction (so secrets in query strings don't leak).
+        if params:
+            url_for_log = url_for_key
+            sep = "&" if "?" in url_for_log else "?"
+            url_for_log = url_for_log + sep + urllib.parse.urlencode(
+                sorted((k, v) for k, v in params.items()), doseq=True)
+        else:
+            url_for_log = url_for_key
+
+        send_headers: dict[str, str] = {}
+        if accept != DEFAULT_ACCEPT:
+            send_headers["Accept"] = accept
+        if api_version != DEFAULT_API_VERSION:
+            send_headers["X-GitHub-Api-Version"] = api_version
+        if headers:
+            send_headers.update(headers)
+
+        cache_key: str | None = None
+        cached: dict | None = None
+        if cacheable:
+            cache_key = _ETagStore.key_for(self.host, method, url_for_key,
+                                            params, accept, api_version)
+            cached = self.cache.load(cache_key)
+            if cached and cached.get("etag"):
+                send_headers["If-None-Match"] = cached["etag"]
+
+        bucket = _bucket_for_path(url_for_key)
+        self._backpressure(bucket)
+
+        caller = _caller or self._caller()
+        t0 = time.time()
+        try:
+            resp = self._client.request(
+                method, url, params=params, json=json,
+                headers=send_headers, timeout=timeout)
+        except httpx.HTTPError as e:
+            self.log.write(
+                ts=_iso_now(), verb=method,
+                url=_redact_url(url_for_log), status=0,
+                ms=int((time.time() - t0) * 1000),
+                cache_hit=False, caller=caller, bucket=bucket,
+                error=str(e)[:200], transport="httpx")
+            raise
+        elapsed_ms = (time.time() - t0) * 1000
+
+        # 401 → refresh bearer once, retry once.
+        if resp.status_code == 401 and _allow_retry:
+            if self._refresh_token():
+                return self.request(
+                    method, path_or_url, params=params, json=json,
+                    headers=headers, accept=accept,
+                    api_version=api_version, cache=cache, timeout=timeout,
+                    _allow_retry=False, _caller=caller)
+
+        # Retry-After: sleep then retry once.
+        retry_after = resp.headers.get("retry-after")
+        if (resp.status_code in (403, 429) and retry_after and _allow_retry):
+            try:
+                wait = min(MAX_BACKPRESSURE_SLEEP, float(retry_after))
+            except ValueError:
+                wait = 0.0
+            if wait > 0:
+                time.sleep(wait)
+                return self.request(
+                    method, path_or_url, params=params, json=json,
+                    headers=headers, accept=accept,
+                    api_version=api_version, cache=cache, timeout=timeout,
+                    _allow_retry=False, _caller=caller)
+
+        rate = self._record_rate(bucket, resp.headers)
+
+        cache_hit = False
+        body: Any = None
+        body_cached: Any = None
+        if cacheable and resp.status_code == 304 and cached:
+            cache_hit = True
+            body_cached = cached.get("body")
+        elif cacheable and resp.status_code == 200:
+            etag = resp.headers.get("etag")
+            try:
+                body = resp.json()
+            except Exception:
+                body = None
+            if etag and body is not None and cache_key is not None:
+                self.cache.save(cache_key, etag=etag, body=body,
+                                status=200, url=url_for_key,
+                                headers=dict(resp.headers))
+        else:
+            try:
+                body = resp.json()
+            except Exception:
+                body = None
+
+        next_url = _parse_next_link(resp.headers.get("link", ""))
+
+        self.log.write(
+            ts=_iso_now(), verb=method,
+            url=_redact_url(url_for_log),
+            status=resp.status_code, ms=int(elapsed_ms),
+            cache_hit=cache_hit, caller=caller, bucket=bucket,
+            remaining=rate.remaining if rate.limit else None,
+            reset=_iso_at(rate.reset_at),
+            bytes=len(resp.content) if resp.content else 0,
+            transport="httpx",
+        )
+
+        return GHResponse(
+            status=resp.status_code,
+            json=body,
+            body_cached=body_cached,
+            headers={k: v for k, v in resp.headers.items()},
+            ms=elapsed_ms,
+            cache_hit=cache_hit,
+            rate=rate,
+            raw=resp.content,
+            next_url=next_url,
+        )
+
+    # --- HTTP verb shortcuts ---
+
+    def get(self, path: str, *, params: dict | None = None,
+            **kw: Any) -> GHResponse:
+        return self.request("GET", path, params=params, **kw)
+
+    def post(self, path: str, *, json: Any = None, **kw: Any) -> GHResponse:
+        kw.setdefault("cache", "none")
+        return self.request("POST", path, json=json, **kw)
+
+    def put(self, path: str, *, json: Any = None, **kw: Any) -> GHResponse:
+        kw.setdefault("cache", "none")
+        return self.request("PUT", path, json=json, **kw)
+
+    def patch(self, path: str, *, json: Any = None, **kw: Any) -> GHResponse:
+        kw.setdefault("cache", "none")
+        return self.request("PATCH", path, json=json, **kw)
+
+    def delete(self, path: str, **kw: Any) -> GHResponse:
+        kw.setdefault("cache", "none")
+        return self.request("DELETE", path, **kw)
+
+    # --- pagination ---
+
+    def paginate(self, path: str, *, params: dict | None = None,
+                 per_page: int = DEFAULT_PER_PAGE,
+                 max_pages: int | None = None,
+                 cache: Literal["etag", "none"] = "etag"
+                 ) -> Iterator[GHResponse]:
+        """Walk Link-header pagination. Each page is independently ETag'd
+        with per_page in the cache key; a 304 on page N does not imply 304
+        on any other page."""
+        params = dict(params or {})
+        params["per_page"] = per_page
+        next_url: str | None = path
+        page = 0
+        while next_url is not None:
+            page += 1
+            if max_pages is not None and page > max_pages:
+                return
+            send_params = params if page == 1 else None
+            resp = self.request("GET", next_url, params=send_params,
+                                cache=cache)
+            yield resp
+            if not resp.ok():
+                return
+            next_url = resp.next_url
+
+    # --- GraphQL ---
+
+    def graphql(self, query: str, variables: dict | None = None,
+                *, cache: Literal["etag", "none"] = "none") -> GHResponse:
+        body: dict[str, Any] = {"query": query}
+        if variables:
+            body["variables"] = variables
+        return self.request("POST", "/graphql", json=body, cache=cache)
+
+    # --- gh CLI passthrough ---
+
+    def gh_cli(self, *argv: str, timeout: float = 60,
+               input: bytes | str | None = None,
+               text: bool = True,
+               check: bool = False) -> subprocess.CompletedProcess:
+        """Run a `gh` subprocess. Logged + back-pressured; returns a
+        CompletedProcess so call sites can treat it identically to a
+        direct subprocess.run. Defaults to `text=True`, matching how
+        every existing pod call site reads `r.stdout`."""
+        self._backpressure("core")
+        caller = self._caller()
+        # If input is binary, force text=False so we don't fail on encoding.
+        if isinstance(input, bytes):
+            text = False
+        t0 = time.time()
+        try:
+            r = subprocess.run(
+                ["gh", *argv],
+                capture_output=True,
+                input=input,
+                text=text,
+                timeout=timeout,
+                check=check,
+            )
+            returncode = r.returncode
+        except subprocess.TimeoutExpired:
+            self.log.write(
+                ts=_iso_now(), verb="GH",
+                url=" ".join(_redact_argv(argv)),
+                status=-1, ms=int((time.time() - t0) * 1000),
+                cache_hit=False, caller=caller, bucket="core",
+                transport="gh", error="timeout")
+            raise
+        elapsed_ms = (time.time() - t0) * 1000
+        self.log.write(
+            ts=_iso_now(), verb="GH",
+            url=" ".join(_redact_argv(argv)),
+            status=returncode, ms=int(elapsed_ms),
+            cache_hit=False, caller=caller, bucket="core",
+            transport="gh",
+        )
+        return r
+
+    # --- introspection ---
+
+    def rate(self) -> dict[str, RateSnapshot]:
+        with self._lock:
+            return dict(self._rate)
+
+
+# ---------------------------------------------------------------------------
+# Module-global client
+# ---------------------------------------------------------------------------
+
+_client_lock = threading.Lock()
+_client: GitHubClient | None = None
+
+
+def get_client() -> GitHubClient:
+    """Return the per-process client, constructing it on first access."""
+    global _client
+    with _client_lock:
+        if _client is None:
+            _client = GitHubClient()
+        return _client
+
+
+def set_client_for_tests(client: GitHubClient | None) -> None:
+    """Test-only: replace (or clear) the cached module-global client."""
+    global _client
+    with _client_lock:
+        if _client is not None and _client is not client:
+            try:
+                _client.close()
+            except Exception:
+                pass
+        _client = client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,17 @@ requires-python = ">=3.10"
 authors = [{name = "Kim Morrison", email = "kim@tqft.net"}]
 dependencies = [
     "tomli>=2.0; python_version < '3.11'",
+    "httpx>=0.27",
 ]
 
 [project.scripts]
 pod = "pod.cli:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "respx>=0.21",
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "pod.__version__"}

--- a/tests/_gh_helpers.py
+++ b/tests/_gh_helpers.py
@@ -1,0 +1,129 @@
+"""Shared helpers for tests that need to fake the layer client.
+
+Used by `test_release_claim_idempotent.py`, `test_security.py`, and any
+other test that previously mocked `cli.subprocess.run` for `gh api …`
+calls. After the github-access layer migration, those calls go through
+`pod.github.GitHubClient` (httpx) — so tests need to mock the client
+directly. The remaining `gh_cli(...)` porcelain calls still go through
+`subprocess.run`, so most tests keep their `mock.patch.object(cli.subprocess,
+"run", side_effect=fake_run)` for those and additionally use the
+helpers here to fake the client's HTTP calls.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Iterable, Iterator
+from unittest import mock
+
+from pod import github as gh
+from pod.github import GHResponse, RateSnapshot
+
+
+def fake_response(status: int = 200, *, body: Any = None,
+                  headers: dict | None = None,
+                  cache_hit: bool = False,
+                  body_cached: Any = None) -> GHResponse:
+    """Build a `GHResponse` for a fake HTTP call."""
+    return GHResponse(
+        status=status,
+        json=body,
+        body_cached=body_cached if body_cached is not None else body,
+        headers=headers or {},
+        ms=1.0,
+        cache_hit=cache_hit,
+        rate=RateSnapshot(bucket="core", limit=5000, remaining=4999),
+    )
+
+
+class _FakeClient:
+    """A drop-in for `pod.github.GitHubClient` in tests.
+
+    Pass an optional `routes` dict mapping `(METHOD, PATH)` tuples to
+    `GHResponse` (or a list-of-GHResponse for sequential calls). Anything
+    not in `routes` falls back to `default` (default: 404). Records every
+    call in `self.calls` so tests can assert on URL / params / method.
+    """
+
+    def __init__(self, *, routes: dict | None = None,
+                 default: GHResponse | None = None,
+                 gh_cli_handler=None):
+        self.routes = dict(routes or {})
+        self.default = default or fake_response(404, body={"message": "Not Found"})
+        self.calls: list[dict] = []
+        # Optional: callable taking (*argv) and returning a CompletedProcess-
+        # shaped Mock. If None, gh_cli returns a 0/empty Mock by default.
+        self.gh_cli_handler = gh_cli_handler
+
+    def _serve(self, method: str, path: str,
+               *, params=None, json=None, **kw) -> GHResponse:
+        self.calls.append({"method": method, "path": path,
+                           "params": params, "json": json})
+        key = (method, path)
+        v = self.routes.get(key, self.default)
+        if isinstance(v, list):
+            if not v:
+                return self.default
+            return v.pop(0)
+        return v
+
+    def get(self, path, *, params=None, **kw):
+        return self._serve("GET", path, params=params, **kw)
+
+    def post(self, path, *, json=None, **kw):
+        return self._serve("POST", path, json=json, **kw)
+
+    def put(self, path, *, json=None, **kw):
+        return self._serve("PUT", path, json=json, **kw)
+
+    def patch(self, path, *, json=None, **kw):
+        return self._serve("PATCH", path, json=json, **kw)
+
+    def delete(self, path, **kw):
+        return self._serve("DELETE", path, **kw)
+
+    def graphql(self, query, variables=None, **kw):
+        return self._serve("POST", "/graphql",
+                           json={"query": query, "variables": variables})
+
+    def paginate(self, path, *, params=None, per_page=100,
+                 max_pages=None, cache="etag") -> Iterator[GHResponse]:
+        # For simplicity in unit tests, treat paginate as a single page hit.
+        yield self._serve("GET", path, params=params)
+
+    def gh_cli(self, *argv, **kw):
+        self.calls.append({"method": "GH", "argv": argv})
+        if self.gh_cli_handler is not None:
+            return self.gh_cli_handler(*argv)
+        result = mock.Mock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    def rate(self):
+        return {"core": RateSnapshot(bucket="core", limit=5000, remaining=4999),
+                "graphql": RateSnapshot(bucket="graphql", limit=5000, remaining=4999)}
+
+
+@contextlib.contextmanager
+def patch_client(client: _FakeClient | None = None,
+                 *, routes: dict | None = None,
+                 default: GHResponse | None = None,
+                 gh_cli_handler=None):
+    """Context manager that swaps `gh.get_client()` to return `client`
+    (or a fresh `_FakeClient` built from `routes` / `default`). Yields
+    the active client so the test can inspect `.calls` afterward.
+
+    `gh_cli_handler`, when provided, is a function `(*argv) ->
+    CompletedProcess` invoked when production code calls `client.gh_cli(...)`.
+    """
+    if client is None:
+        client = _FakeClient(routes=routes, default=default,
+                              gh_cli_handler=gh_cli_handler)
+    p = mock.patch.object(gh, "get_client", return_value=client)
+    p.start()
+    try:
+        yield client
+    finally:
+        p.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Pytest fixtures shared across the suite.
+
+Most importantly: this installs a session-wide auto-use fixture that
+swaps `pod.github.get_client()` to return a `_FakeClient` by default,
+so any test path that triggers a layer-routed GitHub call doesn't
+silently hit the real API. Tests that need a real client (or a custom
+fake) can override via `with patch_client(...)`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest import mock
+
+from pod import github as gh
+from _gh_helpers import _FakeClient, fake_response
+
+
+@pytest.fixture(autouse=True)
+def _default_fake_gh_client():
+    """Auto-use: every test starts with a no-op fake client. Tests that
+    set up their own client via `patch_client(...)` will override this
+    one (the inner patch returns the inner client; on exit, the outer
+    fixture's client is restored)."""
+    fake = _FakeClient(default=fake_response(
+        503, body={"message": "test default — no route configured"}))
+    p = mock.patch.object(gh, "get_client", return_value=fake)
+    p.start()
+    try:
+        yield fake
+    finally:
+        p.stop()

--- a/tests/test_gh_stats.py
+++ b/tests/test_gh_stats.py
@@ -1,0 +1,125 @@
+"""Tests for `pod gh-stats`."""
+
+from __future__ import annotations
+
+import datetime
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from pod import cli
+
+
+def _now_iso(seconds_ago: int = 0) -> str:
+    t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=seconds_ago)
+    return t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _row(**fields):
+    base = {
+        "ts": _now_iso(0),
+        "verb": "GET",
+        "url": "/repos/o/r/issues/1",
+        "status": 200,
+        "ms": 100,
+        "cache_hit": False,
+        "caller": "cli.py:foo:42",
+        "bucket": "core",
+        "transport": "httpx",
+        "bytes": 1024,
+    }
+    base.update(fields)
+    return json.dumps(base)
+
+
+def _args(log: Path, *, since="1h", by="caller", top=20):
+    return SimpleNamespace(log=str(log), since=since, by=by, top=top)
+
+
+class GhStatsTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.log = Path(self._tmp.name) / "gh-access.log"
+
+    def _run(self, args):
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            cli.cmd_gh_stats({}, args)
+        return buf.getvalue()
+
+    def test_missing_log_exits(self):
+        self.log.unlink(missing_ok=True)
+        with self.assertRaises(SystemExit):
+            cli.cmd_gh_stats({}, _args(self.log))
+
+    def test_empty_window_reports_no_rows(self):
+        self.log.write_text("")
+        out = self._run(_args(self.log))
+        self.assertIn("No log rows", out)
+
+    def test_aggregates_by_caller(self):
+        self.log.write_text("\n".join([
+            _row(caller="cli.py:foo:1"),
+            _row(caller="cli.py:foo:1", cache_hit=True),
+            _row(caller="cli.py:bar:2"),
+        ]))
+        out = self._run(_args(self.log, by="caller"))
+        # Top group (cli.py:foo:1) has 2 calls, 50% cache; bar has 1.
+        self.assertIn("cli.py:foo:1", out)
+        self.assertIn("cli.py:bar:2", out)
+        # The two-call row appears before the one-call row in the output.
+        idx_foo = out.index("cli.py:foo:1")
+        idx_bar = out.index("cli.py:bar:2")
+        self.assertLess(idx_foo, idx_bar)
+
+    def test_aggregates_by_path(self):
+        self.log.write_text("\n".join([
+            _row(url="/a", caller="cli.py:foo:1"),
+            _row(url="/b", caller="cli.py:foo:1"),
+            _row(url="/a", caller="cli.py:bar:2"),
+        ]))
+        out = self._run(_args(self.log, by="url"))
+        # /a appears twice, /b once.
+        self.assertIn("/a", out)
+        self.assertIn("/b", out)
+
+    def test_filters_outside_window(self):
+        self.log.write_text("\n".join([
+            _row(ts=_now_iso(seconds_ago=120), caller="caller-recent"),
+            _row(ts=_now_iso(seconds_ago=7200), caller="caller-old-now"),  # 2h ago
+        ]))
+        out = self._run(_args(self.log, since="1h"))
+        self.assertIn("caller-recent", out)
+        self.assertNotIn("caller-old-now", out)
+
+    def test_top_limits_groups(self):
+        self.log.write_text("\n".join([
+            _row(caller=f"cli.py:fn:{i}") for i in range(50)
+        ]))
+        out = self._run(_args(self.log, top=3))
+        # Total line says 50 calls; only 3 group lines below.
+        self.assertIn("Total: 50 calls", out)
+        # Crude: count grouped lines (lines that start with two spaces and a digit).
+        group_lines = [ln for ln in out.splitlines()
+                       if ln.startswith("    ") and ln.strip().split()[0].isdigit()]
+        self.assertLessEqual(len(group_lines), 3)
+
+    def test_invalid_since_exits(self):
+        self.log.write_text(_row())
+        with self.assertRaises(SystemExit):
+            cli.cmd_gh_stats({}, _args(self.log, since="forever"))
+
+    def test_unparseable_lines_are_skipped(self):
+        self.log.write_text(_row() + "\n{not json}\n" + _row())
+        out = self._run(_args(self.log))
+        self.assertIn("Total: 2 calls", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -1,0 +1,469 @@
+"""Tests for the GitHub access layer (pod/github.py).
+
+Uses httpx.MockTransport so no network is touched. Each test constructs a
+fresh client pointed at a tempdir for cache + log; the test asserts on
+the cache file, log file, rate-meter state, and (where relevant) on the
+sequence of MockTransport calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import httpx
+
+from pod.github import (
+    DEFAULT_BACKPRESSURE_THRESHOLD,
+    GHResponse,
+    GitHubClient,
+    RateSnapshot,
+    _ETagStore,
+    _parse_next_link,
+    _redact_argv,
+    _redact_url,
+)
+
+
+def _client(handler, *, cache_dir, log_path, **kw):
+    return GitHubClient(
+        host="github.com",
+        token="t-test",
+        cache_dir=cache_dir,
+        log_path=log_path,
+        transport=httpx.MockTransport(handler),
+        # Disable cache trim during tests so we can plant entries directly.
+        trim_cache_on_init=False,
+        # Disable the soft per-process rate cap so tests don't sleep.
+        rate_cap_hz=0,
+        **kw,
+    )
+
+
+def _rl_headers(*, remaining=4999, limit=5000, reset=None,
+                resource="core") -> dict:
+    if reset is None:
+        reset = int(time.time()) + 3600
+    return {
+        "x-ratelimit-limit": str(limit),
+        "x-ratelimit-remaining": str(remaining),
+        "x-ratelimit-reset": str(reset),
+        "x-ratelimit-resource": resource,
+    }
+
+
+def _resp(status=200, *, json_body=None, headers=None, etag=None,
+          link=None) -> httpx.Response:
+    h = dict(_rl_headers())
+    if headers:
+        h.update(headers)
+    if etag:
+        h["etag"] = etag
+    if link:
+        h["link"] = link
+    return httpx.Response(status, json=json_body, headers=h)
+
+
+class _Tmp(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+        self.cache_dir = self.tmp / "gh-cache"
+        self.log_path = self.tmp / "gh-access.log"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+class HelperTests(unittest.TestCase):
+    def test_redact_url_strips_secrets(self):
+        u = "/foo?bar=1&access_token=SECRET&token=DEADBEEF"
+        out = _redact_url(u)
+        self.assertNotIn("SECRET", out)
+        self.assertNotIn("DEADBEEF", out)
+        self.assertIn("bar=1", out)
+        self.assertIn("access_token=REDACTED", out)
+        self.assertIn("token=REDACTED", out)
+
+    def test_redact_url_passthrough_for_clean(self):
+        self.assertEqual(_redact_url("/repos/o/r/issues/1"),
+                         "/repos/o/r/issues/1")
+
+    def test_redact_argv_redacts_authorization_header_value(self):
+        argv = ("api", "/x", "-H", "Authorization: Bearer SECRETSECRET")
+        out = _redact_argv(argv)
+        self.assertEqual(out, ["api", "/x", "-H", "REDACTED"])
+
+    def test_redact_argv_keeps_normal_args(self):
+        argv = ("issue", "list", "--label", "agent-plan", "--state", "open")
+        self.assertEqual(_redact_argv(argv), list(argv))
+
+    def test_parse_next_link(self):
+        h = ('<https://api.github.com/repos/o/r/issues?page=2>; rel="next", '
+             '<https://api.github.com/repos/o/r/issues?page=5>; rel="last"')
+        self.assertEqual(_parse_next_link(h),
+                         "https://api.github.com/repos/o/r/issues?page=2")
+        self.assertIsNone(_parse_next_link(""))
+        self.assertIsNone(_parse_next_link('<x>; rel="last"'))
+
+    def test_etag_key_includes_host_method_url_params_accept_apiversion(self):
+        a = _ETagStore.key_for("github.com", "GET", "/x",
+                                {"a": 1}, "application/vnd.github+json",
+                                "2022-11-28")
+        b = _ETagStore.key_for("github.com", "GET", "/x",
+                                {"a": 2}, "application/vnd.github+json",
+                                "2022-11-28")
+        self.assertNotEqual(a, b)
+        # Param order does not affect the key.
+        c = _ETagStore.key_for("github.com", "GET", "/x",
+                                {"a": 1, "b": 2},
+                                "application/vnd.github+json",
+                                "2022-11-28")
+        d = _ETagStore.key_for("github.com", "GET", "/x",
+                                {"b": 2, "a": 1},
+                                "application/vnd.github+json",
+                                "2022-11-28")
+        self.assertEqual(c, d)
+
+
+# ---------------------------------------------------------------------------
+# Request semantics + ETag round-trip
+# ---------------------------------------------------------------------------
+
+class RequestTests(_Tmp):
+    def test_get_returns_parsed_body(self):
+        def h(req: httpx.Request) -> httpx.Response:
+            return _resp(200, json_body={"hello": "world"}, etag='"v1"')
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            r = c.get("/repos/o/r/issues/1")
+            self.assertTrue(r.ok())
+            self.assertEqual(r.status, 200)
+            self.assertEqual(r.body(), {"hello": "world"})
+            self.assertFalse(r.cache_hit)
+        finally:
+            c.close()
+
+    def test_etag_round_trip_serves_304_from_cache(self):
+        seen = []
+
+        def h(req: httpx.Request) -> httpx.Response:
+            seen.append(req.headers.get("if-none-match"))
+            if req.headers.get("if-none-match") == '"v1"':
+                return httpx.Response(304, headers=_rl_headers(remaining=4998))
+            return _resp(200, json_body={"x": 1}, etag='"v1"')
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            r1 = c.get("/repos/o/r/issues/1")
+            self.assertEqual(r1.status, 200)
+            r2 = c.get("/repos/o/r/issues/1")
+            self.assertEqual(r2.status, 304)
+            self.assertTrue(r2.cache_hit)
+            self.assertEqual(r2.body(), {"x": 1})  # served from cache
+        finally:
+            c.close()
+
+        # First call had no If-None-Match; second call sent "v1".
+        self.assertEqual(seen, [None, '"v1"'])
+
+    def test_writes_bypass_etag_cache(self):
+        calls = []
+
+        def h(req: httpx.Request) -> httpx.Response:
+            calls.append(req.method)
+            return _resp(201, json_body={"ok": True}, etag='"x"')
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            c.post("/repos/o/r/issues/1/comments", json={"body": "hi"})
+            c.post("/repos/o/r/issues/1/comments", json={"body": "hi"})
+        finally:
+            c.close()
+        self.assertEqual(calls, ["POST", "POST"])
+        self.assertFalse(self.cache_dir.exists() and any(
+            self.cache_dir.iterdir()))
+
+    def test_cache_file_is_chmod_600(self):
+        def h(req): return _resp(200, json_body={"x": 1}, etag='"v"')
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            c.get("/x")
+        finally:
+            c.close()
+        files = list(self.cache_dir.iterdir())
+        self.assertEqual(len(files), 1)
+        m = files[0].stat().st_mode
+        # Owner rw, no group/other access.
+        self.assertEqual(stat.S_IMODE(m) & 0o077, 0,
+                         f"world/group bits set: {oct(m)}")
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+class PaginateTests(_Tmp):
+    def test_walks_link_header(self):
+        # Identify a request by its `page` query param (default = page 1).
+        page_to_next = {1: 2, 2: 3, 3: None}
+
+        def h(req: httpx.Request) -> httpx.Response:
+            page_n = int(req.url.params.get("page", "1"))
+            next_n = page_to_next[page_n]
+            link = (f'<https://api.github.com/r/o/issues?page={next_n}>; '
+                    f'rel="next"') if next_n else None
+            return _resp(200, json_body=[{"page": page_n}], link=link)
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            seen_pages = []
+            for r in c.paginate("/r/o/issues", per_page=10):
+                self.assertTrue(r.ok())
+                seen_pages.append(r.body()[0]["page"])
+        finally:
+            c.close()
+        self.assertEqual(seen_pages, [1, 2, 3])
+
+    def test_per_page_in_cache_key(self):
+        # Same URL with different per_page should miss each other's cache.
+        def h(req: httpx.Request) -> httpx.Response:
+            pp = req.url.params.get("per_page", "?")
+            return _resp(200, json_body=[{"pp": pp}], etag=f'"v-{pp}"')
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            list(c.paginate("/r/o/issues", per_page=10, max_pages=1))
+            list(c.paginate("/r/o/issues", per_page=100, max_pages=1))
+        finally:
+            c.close()
+        files = list(self.cache_dir.iterdir())
+        self.assertEqual(len(files), 2)
+
+
+# ---------------------------------------------------------------------------
+# Rate meter + back-pressure
+# ---------------------------------------------------------------------------
+
+class RateMeterTests(_Tmp):
+    def test_rate_meter_updates_from_headers(self):
+        def h(req): return _resp(200, json_body={},
+                                  headers=_rl_headers(remaining=4321))
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            c.get("/x")
+            self.assertEqual(c.rate()["core"].remaining, 4321)
+        finally:
+            c.close()
+
+    def test_graphql_uses_graphql_bucket(self):
+        def h(req):
+            return _resp(200, json_body={"data": {}},
+                         headers=_rl_headers(remaining=4500,
+                                             resource="graphql"))
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            c.graphql("query { viewer { login } }")
+            self.assertEqual(c.rate()["graphql"].remaining, 4500)
+        finally:
+            c.close()
+
+    def test_backpressure_sleeps_when_remaining_low(self):
+        def h(req):
+            return _resp(200, json_body={},
+                         headers=_rl_headers(
+                             remaining=DEFAULT_BACKPRESSURE_THRESHOLD - 1,
+                             reset=int(time.time()) + 5))
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            # First call seeds the rate meter.
+            c.get("/x")
+            slept: list[float] = []
+            with mock.patch("pod.github.time.sleep",
+                            side_effect=slept.append):
+                c.get("/y")  # should trigger sleep before this call
+            self.assertTrue(slept, "expected back-pressure sleep")
+            self.assertGreater(slept[0], 0)
+            self.assertLessEqual(slept[0], 60)
+        finally:
+            c.close()
+
+    def test_retry_after_on_403_then_retry(self):
+        calls = [0]
+
+        def h(req):
+            calls[0] += 1
+            if calls[0] == 1:
+                return httpx.Response(403, headers={**_rl_headers(),
+                                                     "retry-after": "1"},
+                                       json={"message": "rate-limited"})
+            return _resp(200, json_body={"ok": True})
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            with mock.patch("pod.github.time.sleep") as slept:
+                r = c.get("/x")
+            self.assertEqual(r.status, 200)
+            self.assertEqual(calls[0], 2)
+            slept.assert_any_call(1.0)
+        finally:
+            c.close()
+
+
+# ---------------------------------------------------------------------------
+# Auth refresh on 401
+# ---------------------------------------------------------------------------
+
+class AuthRefreshTests(_Tmp):
+    def test_401_triggers_token_refresh_and_retry(self):
+        bearers_seen = []
+
+        def h(req):
+            bearers_seen.append(req.headers.get("authorization"))
+            if len(bearers_seen) == 1:
+                return httpx.Response(401, json={"message": "Bad credentials"},
+                                       headers=_rl_headers())
+            return _resp(200, json_body={"ok": True})
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            with mock.patch("pod.github._gh_token", return_value="t-fresh"):
+                r = c.get("/x")
+            self.assertEqual(r.status, 200)
+        finally:
+            c.close()
+        self.assertEqual(bearers_seen,
+                         ["Bearer t-test", "Bearer t-fresh"])
+
+    def test_401_without_token_change_does_not_loop(self):
+        def h(req):
+            return httpx.Response(401, json={"message": "Bad credentials"},
+                                   headers=_rl_headers())
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            with mock.patch("pod.github._gh_token", return_value="t-test"):
+                r = c.get("/x")
+            self.assertEqual(r.status, 401)  # surface, no infinite retry
+        finally:
+            c.close()
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+class LoggingTests(_Tmp):
+    def _read_log(self) -> list[dict]:
+        if not self.log_path.exists():
+            return []
+        return [json.loads(l) for l in self.log_path.read_text().splitlines()
+                if l.strip()]
+
+    def test_request_writes_log_row(self):
+        def h(req): return _resp(200, json_body={"x": 1}, etag='"v"')
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            c.get("/repos/o/r/issues/1")
+        finally:
+            c.close()
+        rows = self._read_log()
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["verb"], "GET")
+        self.assertEqual(row["url"], "/repos/o/r/issues/1")
+        self.assertEqual(row["status"], 200)
+        self.assertEqual(row["bucket"], "core")
+        self.assertEqual(row["transport"], "httpx")
+        self.assertIn("ts", row)
+        self.assertIn("ms", row)
+        self.assertIn("caller", row)
+
+    def test_log_redacts_sensitive_query_params(self):
+        def h(req): return _resp(200, json_body={})
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            c.get("/x", params={"access_token": "SECRET", "ok": "1"})
+        finally:
+            c.close()
+        rows = self._read_log()
+        self.assertEqual(len(rows), 1)
+        self.assertNotIn("SECRET", rows[0]["url"])
+        self.assertIn("REDACTED", rows[0]["url"])
+
+    def test_log_does_not_contain_authorization_header(self):
+        def h(req): return _resp(200, json_body={})
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            c.get("/x")
+        finally:
+            c.close()
+        text = self.log_path.read_text()
+        self.assertNotIn("Bearer", text)
+        self.assertNotIn("t-test", text)
+
+    def test_log_is_chmod_600(self):
+        def h(req): return _resp(200, json_body={})
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            c.get("/x")
+        finally:
+            c.close()
+        m = self.log_path.stat().st_mode
+        self.assertEqual(stat.S_IMODE(m) & 0o077, 0,
+                         f"world/group bits set: {oct(m)}")
+
+    def test_gh_cli_logs_with_gh_transport(self):
+        def h(req):
+            raise AssertionError("gh_cli should not hit httpx")
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        # Mock subprocess.run so we don't actually invoke gh.
+        completed = mock.Mock(returncode=0, stdout=b"", stderr=b"")
+        with mock.patch("pod.github.subprocess.run", return_value=completed):
+            c.gh_cli("issue", "list", "--label", "agent-plan")
+        c.close()
+        rows = self._read_log()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["transport"], "gh")
+        self.assertEqual(rows[0]["verb"], "GH")
+        self.assertIn("issue", rows[0]["url"])
+
+
+# ---------------------------------------------------------------------------
+# Cache trim
+# ---------------------------------------------------------------------------
+
+class CacheTrimTests(_Tmp):
+    def test_trim_drops_old_entries(self):
+        store = _ETagStore(self.cache_dir)
+        store.save("a", etag='"x"', body={}, status=200, url="/x", headers={})
+        store.save("b", etag='"x"', body={}, status=200, url="/x", headers={})
+        # Age 'a' beyond the 7-day cutoff.
+        a_path = self.cache_dir / "a.json"
+        old = time.time() - (8 * 86400)
+        os.utime(a_path, (old, old))
+        store.trim()
+        self.assertFalse(a_path.exists())
+        self.assertTrue((self.cache_dir / "b.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orphan_label_helpers.py
+++ b/tests/test_orphan_label_helpers.py
@@ -15,28 +15,34 @@ from unittest import mock
 
 from pod import cli
 
+from _gh_helpers import patch_client
+
+
+def _gh_result(stdout=""):
+    r = mock.Mock()
+    r.returncode = 0
+    r.stdout = stdout
+    r.stderr = ""
+    return r
+
 
 class FetchBlockedDepsQueryTests(unittest.TestCase):
     def test_query_does_not_filter_to_agent_plan(self):
         captured = {}
 
-        def fake_run(argv, **kwargs):
-            captured["argv"] = list(argv)
-            r = mock.Mock()
-            r.returncode = 0
-            r.stdout = "[]"
-            r.stderr = ""
-            return r
+        def gh_cli_handler(*argv):
+            # First call: list blocked. We capture it then return [].
+            if "list" in argv and "blocked" in argv:
+                captured["argv"] = ("gh",) + argv
+                return _gh_result("[]")
+            return _gh_result("[]")
 
-        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+        with patch_client(gh_cli_handler=gh_cli_handler):
             cli.fetch_blocked_deps()
 
-        argv = captured["argv"]
+        argv = list(captured["argv"])
         self.assertEqual(argv[0], "gh")
         self.assertIn("--label", argv)
-        # The post-fix query must include `blocked` exactly once and must
-        # NOT include `agent-plan` (which would exclude human-oversight
-        # blocked issues like #2565 in the kim-em/hex repo).
         label_args = [argv[i + 1] for i, a in enumerate(argv) if a == "--label"]
         self.assertEqual(label_args, ["blocked"])
 
@@ -45,19 +51,14 @@ class FetchBlockedDepsQueryTests(unittest.TestCase):
                 "depends-on: #2563\n"
                 "depends-on: #2564\n")
         list_payload = json.dumps([{"number": 2565, "body": body}])
-        # second call returns the open-issue numbers list
         open_payload = json.dumps([2563, 2564])
 
         calls = iter([list_payload, open_payload])
 
-        def fake_run(argv, **kwargs):
-            r = mock.Mock()
-            r.returncode = 0
-            r.stdout = next(calls)
-            r.stderr = ""
-            return r
+        def gh_cli_handler(*argv):
+            return _gh_result(next(calls))
 
-        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+        with patch_client(gh_cli_handler=gh_cli_handler):
             result = cli.fetch_blocked_deps()
 
         self.assertEqual(result, {2565: [2563, 2564]})
@@ -71,29 +72,23 @@ class FetchHasPrLinksTests(unittest.TestCase):
     always return empty and the housekeeping cycle would clear
     `has-pr` from every legitimate issue."""
 
-    def _stub_run(self, calls):
-        """Build a fake_run that dispatches by argv shape, returning
-        canned stdout from the `calls` dict keyed on (argv[1], argv[2])."""
-        def fake_run(argv, **kwargs):
-            r = mock.Mock()
-            r.returncode = 0
-            r.stderr = ""
-            key = (argv[1], argv[2])
+    def _stub_handler(self, calls):
+        """Build a gh_cli handler that dispatches by argv shape, returning
+        canned stdout from the `calls` dict keyed on (argv[0], argv[1])."""
+        def handler(*argv):
+            key = (argv[0], argv[1])
             if key == ("issue", "list"):
-                r.stdout = calls.pop("issue_list", "[]")
-            elif key == ("issue", "view"):
-                # argv[3] is the issue number string
-                r.stdout = calls.pop(f"issue_view_{argv[3]}", "[]")
-            elif key == ("pr", "view"):
-                r.stdout = calls.pop(f"pr_view_{argv[3]}", "UNKNOWN")
-            else:
-                r.stdout = ""
-            return r
-        return fake_run
+                return _gh_result(calls.pop("issue_list", "[]"))
+            if key == ("issue", "view"):
+                return _gh_result(calls.pop(f"issue_view_{argv[2]}", "[]"))
+            if key == ("pr", "view"):
+                return _gh_result(calls.pop(f"pr_view_{argv[2]}", "UNKNOWN"))
+            return _gh_result("")
+        return handler
 
     def test_records_open_linked_pr(self):
         # #3006 has an open linked PR #3015 — must show up.
-        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+        with patch_client(gh_cli_handler=self._stub_handler({
             "issue_list": json.dumps([{"number": 3006}]),
             "issue_view_3006": json.dumps([3015]),
             "pr_view_3015": "OPEN",
@@ -104,7 +99,7 @@ class FetchHasPrLinksTests(unittest.TestCase):
         # #3016 has a linked PR but it's already merged — orphan; the
         # entry must still be present (empty list) so the TUI can
         # render `[PR ?]` and the housekeeping cycle can clean up.
-        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+        with patch_client(gh_cli_handler=self._stub_handler({
             "issue_list": json.dumps([{"number": 3016}]),
             "issue_view_3016": json.dumps([3020]),
             "pr_view_3020": "MERGED",
@@ -114,7 +109,7 @@ class FetchHasPrLinksTests(unittest.TestCase):
     def test_orphan_with_no_linked_prs_at_all(self):
         # The hand-applied `has-pr` case from the original incident:
         # closedByPullRequestsReferences itself is empty.
-        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+        with patch_client(gh_cli_handler=self._stub_handler({
             "issue_list": json.dumps([{"number": 2564}]),
             "issue_view_2564": "[]",
         })):
@@ -124,7 +119,7 @@ class FetchHasPrLinksTests(unittest.TestCase):
         # The relevant filter: an issue may have one merged PR
         # (historically) and one open PR (the in-flight one). Only the
         # open one should appear in the result.
-        with mock.patch.object(subprocess, "run", side_effect=self._stub_run({
+        with patch_client(gh_cli_handler=self._stub_handler({
             "issue_list": json.dumps([{"number": 4000}]),
             "issue_view_4000": json.dumps([4001, 4002]),
             "pr_view_4001": "MERGED",

--- a/tests/test_release_claim_idempotent.py
+++ b/tests/test_release_claim_idempotent.py
@@ -18,6 +18,8 @@ from unittest import mock
 
 from pod import cli
 
+from _gh_helpers import fake_response, patch_client
+
 
 def _result(stdout: str = "", stderr: str = "", returncode: int = 0):
     """Build a fake subprocess.run result."""
@@ -70,87 +72,80 @@ class ReleaseClaimIdempotenceTests(unittest.TestCase):
     def test_closed_issue_no_label_returns_true_without_graphql(self):
         """The most common stale-history case: issue closed long ago, label
         already removed. Pre-fix this triggered the 777-failure loop."""
-        calls: list[list[str]] = []
-
-        def fake_run(argv, **kwargs):
-            calls.append(list(argv))
-            if argv[:2] == ["gh", "api"]:
-                return _result(stdout='{"state": "closed", "labels": ["agent-plan"]}\n')
-            raise AssertionError(f"unexpected gh call: {argv}")
-
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        probe = fake_response(200, body={"state": "closed",
+                                         "labels": [{"name": "agent-plan"}]})
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/42"): probe,
+        }) as client, mock.patch.object(cli.subprocess, "run") as run:
             self.assertTrue(cli._release_claim("42", "uuid-x", restart_count=0))
         # Only the REST probe ran — no `gh issue view` (CAS), no
         # `gh issue edit`, no `gh issue comment`.
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(calls[0][:2], ["gh", "api"])
-        self.assertNotIn("--remove-label", " ".join(calls[0]))
+        self.assertEqual(len(client.calls), 1)
+        self.assertEqual(client.calls[0]["method"], "GET")
+        run.assert_not_called()
 
     def test_open_issue_no_label_returns_true_without_graphql(self):
         """Concurrent reconciler removed the label; we must not re-edit."""
-        calls: list[list[str]] = []
-
-        def fake_run(argv, **kwargs):
-            calls.append(list(argv))
-            if argv[:2] == ["gh", "api"]:
-                return _result(stdout='{"state": "open", "labels": ["agent-plan"]}\n')
-            raise AssertionError(f"unexpected gh call: {argv}")
-
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        probe = fake_response(200, body={"state": "open",
+                                         "labels": [{"name": "agent-plan"}]})
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/99"): probe,
+        }) as client, mock.patch.object(cli.subprocess, "run") as run:
             self.assertTrue(cli._release_claim("99", "uuid-x", restart_count=0))
-        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(client.calls), 1)
+        run.assert_not_called()
 
     def test_closed_with_label_returns_true_leaves_label_alone(self):
         """Closed issue still carrying `claimed` is the quota-safe terminal
         case — accept the stale label rather than spend GraphQL cleaning it."""
-        calls: list[list[str]] = []
-
-        def fake_run(argv, **kwargs):
-            calls.append(list(argv))
-            if argv[:2] == ["gh", "api"]:
-                return _result(stdout='{"state": "closed", "labels": ["claimed", "agent-plan"]}\n')
-            raise AssertionError(f"unexpected gh call: {argv}")
-
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        probe = fake_response(200, body={"state": "closed",
+                                         "labels": [{"name": "claimed"},
+                                                    {"name": "agent-plan"}]})
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/100"): probe,
+        }) as client, mock.patch.object(cli.subprocess, "run") as run:
             self.assertTrue(cli._release_claim("100", "uuid-x", restart_count=0))
-        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(client.calls), 1)
+        run.assert_not_called()
 
     def test_open_with_label_runs_full_path(self):
         """Real release: REST probe → CAS → edit → comment, all succeed."""
-        calls: list[list[str]] = []
+        probe = fake_response(200, body={"state": "open",
+                                         "labels": [{"name": "claimed"}]})
 
-        def fake_run(argv, **kwargs):
-            calls.append(list(argv))
-            if argv[:2] == ["gh", "api"]:
-                return _result(stdout='{"state": "open", "labels": ["claimed"]}\n')
-            if argv[:3] == ["gh", "issue", "view"]:
+        def gh_cli_handler(*argv):
+            if argv[:2] == ("issue", "view"):
                 return _result(stdout='"Claimed by session `uuid-x` on branch `agent/abcd`"\n')
-            if argv[:3] == ["gh", "issue", "edit"]:
+            if argv[:2] == ("issue", "edit"):
                 return _result(returncode=0)
-            if argv[:3] == ["gh", "issue", "comment"]:
+            if argv[:2] == ("issue", "comment"):
                 return _result(returncode=0)
-            raise AssertionError(f"unexpected gh call: {argv}")
+            raise AssertionError(f"unexpected gh_cli: {argv}")
 
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/123"): probe,
+        }, gh_cli_handler=gh_cli_handler) as client:
             self.assertTrue(cli._release_claim("123", "uuid-x", restart_count=0))
-        verbs = [c[1] if c[1] == "api" else f"{c[1]} {c[2]}" for c in calls]
-        self.assertEqual(verbs, ["api", "issue view", "issue edit", "issue comment"])
+        # REST probe ran first.
+        self.assertEqual(client.calls[0]["method"], "GET")
 
     def test_probe_failure_falls_through_to_legacy_path(self):
         """If the REST probe itself errors, behave like the old code:
         proceed to the CAS + edit path."""
-        def fake_run(argv, **kwargs):
-            if argv[:2] == ["gh", "api"]:
-                return _result(returncode=1, stderr="probe failed")
-            if argv[:3] == ["gh", "issue", "view"]:
-                return _result(stdout='"Claimed by session `uuid-x`"\n')
-            if argv[:3] == ["gh", "issue", "edit"]:
-                return _result(returncode=0)
-            if argv[:3] == ["gh", "issue", "comment"]:
-                return _result(returncode=0)
-            raise AssertionError(f"unexpected: {argv}")
+        probe = fake_response(500, body={"message": "probe failed"})
 
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        def gh_cli_handler(*argv):
+            if argv[:2] == ("issue", "view"):
+                return _result(stdout='"Claimed by session `uuid-x`"\n')
+            if argv[:2] == ("issue", "edit"):
+                return _result(returncode=0)
+            if argv[:2] == ("issue", "comment"):
+                return _result(returncode=0)
+            raise AssertionError(f"unexpected gh_cli: {argv}")
+
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/7"): probe,
+        }, gh_cli_handler=gh_cli_handler):
             self.assertTrue(cli._release_claim("7", "uuid-x", restart_count=0))
 
 
@@ -167,72 +162,86 @@ class ReleaseClaimSentinelTests(unittest.TestCase):
         self._patch_repo.stop()
 
     def test_sentinel_raised_on_rest_probe_rate_limit(self):
-        def fake_run(argv, **kwargs):
-            if argv[:2] == ["gh", "api"]:
-                return _result(returncode=1, stderr="API rate limit exceeded")
-            raise AssertionError(f"unexpected: {argv}")
-
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        # The REST probe now goes through the layer; a 403 surfaces as
+        # `resp.status == 403`, which `_release_claim` translates to the
+        # `_GraphQLRateLimited` sentinel.
+        probe = fake_response(403, body={"message": "rate limit exceeded"})
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/42"): probe,
+        }), mock.patch.object(cli.subprocess, "run") as run:
             with self.assertRaises(cli._GraphQLRateLimited):
                 cli._release_claim("42", "uuid-x", restart_count=0)
+        run.assert_not_called()
 
     def test_sentinel_raised_on_cas_rate_limit(self):
-        def fake_run(argv, **kwargs):
-            if argv[:2] == ["gh", "api"]:
-                return _result(stdout='{"state": "open", "labels": ["claimed"]}\n')
-            if argv[:3] == ["gh", "issue", "view"]:
+        probe = fake_response(200, body={"state": "open",
+                                         "labels": [{"name": "claimed"}]})
+
+        def gh_cli_handler(*argv):
+            if argv[:2] == ("issue", "view"):
                 return _result(returncode=1, stderr="GraphQL: API rate limit exceeded")
             raise AssertionError(f"unexpected: {argv}")
 
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/42"): probe,
+        }, gh_cli_handler=gh_cli_handler):
             with self.assertRaises(cli._GraphQLRateLimited):
                 cli._release_claim("42", "uuid-x", restart_count=0)
 
     def test_sentinel_raised_on_edit_rate_limit(self):
         """Regression test for the critical bug Codex flagged: the original
         `except Exception: return False` would have swallowed this."""
-        def fake_run(argv, **kwargs):
-            if argv[:2] == ["gh", "api"]:
-                return _result(stdout='{"state": "open", "labels": ["claimed"]}\n')
-            if argv[:3] == ["gh", "issue", "view"]:
+        probe = fake_response(200, body={"state": "open",
+                                         "labels": [{"name": "claimed"}]})
+
+        def gh_cli_handler(*argv):
+            if argv[:2] == ("issue", "view"):
                 return _result(stdout='"Claimed by session `uuid-x`"\n')
-            if argv[:3] == ["gh", "issue", "edit"]:
+            if argv[:2] == ("issue", "edit"):
                 return _result(returncode=1, stderr="GraphQL: API rate limit already exceeded for user ID 1")
             raise AssertionError(f"unexpected: {argv}")
 
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/42"): probe,
+        }, gh_cli_handler=gh_cli_handler):
             with self.assertRaises(cli._GraphQLRateLimited):
                 cli._release_claim("42", "uuid-x", restart_count=0)
 
     def test_sentinel_raised_on_comment_rate_limit(self):
-        def fake_run(argv, **kwargs):
-            if argv[:2] == ["gh", "api"]:
-                return _result(stdout='{"state": "open", "labels": ["claimed"]}\n')
-            if argv[:3] == ["gh", "issue", "view"]:
+        probe = fake_response(200, body={"state": "open",
+                                         "labels": [{"name": "claimed"}]})
+
+        def gh_cli_handler(*argv):
+            if argv[:2] == ("issue", "view"):
                 return _result(stdout='"Claimed by session `uuid-x`"\n')
-            if argv[:3] == ["gh", "issue", "edit"]:
+            if argv[:2] == ("issue", "edit"):
                 return _result(returncode=0)
-            if argv[:3] == ["gh", "issue", "comment"]:
+            if argv[:2] == ("issue", "comment"):
                 return _result(returncode=1, stderr="rate limit")
             raise AssertionError(f"unexpected: {argv}")
 
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/42"): probe,
+        }, gh_cli_handler=gh_cli_handler):
             with self.assertRaises(cli._GraphQLRateLimited):
                 cli._release_claim("42", "uuid-x", restart_count=0)
 
     def test_normal_edit_failure_returns_false_not_sentinel(self):
         """Non-rate-limit failures still return False so the caller can
         re-queue. The sentinel is reserved for actual quota exhaustion."""
-        def fake_run(argv, **kwargs):
-            if argv[:2] == ["gh", "api"]:
-                return _result(stdout='{"state": "open", "labels": ["claimed"]}\n')
-            if argv[:3] == ["gh", "issue", "view"]:
+        probe = fake_response(200, body={"state": "open",
+                                         "labels": [{"name": "claimed"}]})
+
+        def gh_cli_handler(*argv):
+            if argv[:2] == ("issue", "view"):
                 return _result(stdout='"Claimed by session `uuid-x`"\n')
-            if argv[:3] == ["gh", "issue", "edit"]:
-                return _result(returncode=1, stderr=b"HTTP 404")
+            if argv[:2] == ("issue", "edit"):
+                return _result(returncode=1, stderr="HTTP 404")
             raise AssertionError(f"unexpected: {argv}")
 
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        with patch_client(routes={
+            ("GET", "/repos/acme/widgets/issues/42"): probe,
+        }, gh_cli_handler=gh_cli_handler):
             self.assertFalse(cli._release_claim("42", "uuid-x", restart_count=0))
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 import json
 import tempfile
@@ -8,40 +9,70 @@ from unittest import mock
 
 from pod import cli
 
+from _gh_helpers import fake_response, patch_client
 
-def _mock_run(visibility: str, slug: str, limit_response: str | None,
-              limit_returncode: int = 0):
-    """Return a fake subprocess.run that responds to the gh calls
-    check_repo_security makes. After the GraphQL-quota fix these are:
 
-      - `git remote get-url origin`     (slug detection, fully local)
-      - `gh api repos/{slug} --jq .visibility`
-      - `gh api repos/{slug}/interaction-limits`
+def _git_remote_mock(slug: str):
+    return mock.Mock(returncode=0, stderr="",
+                     stdout=f"git@github.com:{slug}.git\n")
+
+
+@contextlib.contextmanager
+def _mock_security(visibility: str, slug: str,
+                    limit_response: dict | str | None = None,
+                    limit_status: int = 200):
+    """Combine `git remote` (subprocess.run) + the GitHub access layer
+    (httpx via _FakeClient) for `check_repo_security`.
+
+    `limit_response` is a dict for the interaction-limits payload (or
+    "{}" string for the empty body — same shape `check_repo_security`
+    sees on a public repo with no limit).
     """
-    git_remote = mock.Mock(returncode=0, stderr="",
-                           stdout=f"git@github.com:{slug}.git\n")
+    if isinstance(limit_response, str):
+        # Backwards-compat with old "{}" / JSON-string callers.
+        try:
+            limit_body = json.loads(limit_response)
+        except (json.JSONDecodeError, TypeError):
+            limit_body = {}
+    else:
+        limit_body = limit_response or {}
 
-    repo_visibility = mock.Mock(returncode=0, stderr="",
-                                stdout=visibility + "\n")
+    routes = {
+        ("GET", f"/repos/{slug}"): fake_response(
+            200, body={"visibility": visibility}),
+    }
+    if visibility == "public":
+        if limit_status == 200:
+            routes[("GET", f"/repos/{slug}/interaction-limits")] = (
+                fake_response(200, body=limit_body))
+        else:
+            routes[("GET", f"/repos/{slug}/interaction-limits")] = (
+                fake_response(limit_status,
+                              body={"message": "interaction-limits failed"}))
 
-    api_limits = mock.Mock()
-    api_limits.returncode = limit_returncode
-    api_limits.stdout = limit_response if limit_response is not None else ""
-    api_limits.stderr = "" if limit_returncode == 0 else "API error"
+    git_remote = _git_remote_mock(slug)
 
     def fake_run(argv, **kwargs):
         if argv[:2] == ["git", "remote"]:
             return git_remote
-        if argv[:2] == ["gh", "api"]:
-            # Distinguish the visibility probe (path = repos/{slug}) from
-            # the interaction-limits probe (path = repos/{slug}/interaction-limits).
-            path = argv[2] if len(argv) > 2 else ""
-            if path.endswith("/interaction-limits"):
-                return api_limits
-            return repo_visibility
         raise AssertionError(f"unexpected subprocess call: {argv}")
 
-    return fake_run
+    with patch_client(routes=routes):
+        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+            yield
+
+
+# Backwards-compat shim: existing tests still call `_mock_run(...)` and
+# wrap it in `mock.patch.object(cli.subprocess, "run", side_effect=...)`.
+# Returning a tuple of (context_manager, dummy_side_effect) would force
+# rewriting every test; instead, expose `_mock_security` as the new
+# context manager and migrate call sites individually.
+def _mock_run(visibility: str, slug: str, limit_response: str | None,
+              limit_returncode: int = 0):
+    """Deprecated shim. Use `_mock_security(...)` directly with `with`."""
+    raise RuntimeError(
+        "_mock_run() shim removed; use `with _mock_security(...):` instead. "
+        "See test_security.py for examples.")
 
 
 def _iso(days_from_now: float) -> str:
@@ -69,122 +100,105 @@ class SecurityCheckTests(unittest.TestCase):
         run.assert_not_called()
 
     def test_private_repo_passes(self):
-        fake = _mock_run("private", "owner/repo", "{}")
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        with _mock_security("private", "owner/repo"):
             cli.check_repo_security({})  # no exit
 
     def test_public_no_limit_refused(self):
-        fake = _mock_run("public", "owner/repo", "{}")
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        with _mock_security("public", "owner/repo", limit_response={}):
             with self.assertRaises(SystemExit) as cm:
                 cli.check_repo_security({})
         self.assertEqual(cm.exception.code, 1)
 
     def test_public_collaborators_only_long_expiry_passes(self):
-        body = (
-            '{"limit":"collaborators_only","origin":"repository",'
-            '"expires_at":"' + _iso(180) + '"}'
-        )
-        fake = _mock_run("public", "owner/repo", body)
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        body = {"limit": "collaborators_only",
+                "origin": "repository",
+                "expires_at": _iso(180)}
+        with _mock_security("public", "owner/repo", limit_response=body):
             cli.check_repo_security({})
 
     def test_public_limit_too_lax_refused(self):
-        body = (
-            '{"limit":"existing_users","origin":"repository",'
-            '"expires_at":"' + _iso(180) + '"}'
-        )
-        fake = _mock_run("public", "owner/repo", body)
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        body = {"limit": "existing_users",
+                "origin": "repository",
+                "expires_at": _iso(180)}
+        with _mock_security("public", "owner/repo", limit_response=body):
             with self.assertRaises(SystemExit):
                 cli.check_repo_security({})
 
     def test_public_expiring_soon_refused(self):
-        body = (
-            '{"limit":"collaborators_only","origin":"repository",'
-            '"expires_at":"' + _iso(3) + '"}'
-        )
-        fake = _mock_run("public", "owner/repo", body)
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        body = {"limit": "collaborators_only",
+                "origin": "repository",
+                "expires_at": _iso(3)}
+        with _mock_security("public", "owner/repo", limit_response=body):
             with self.assertRaises(SystemExit):
                 cli.check_repo_security({})
 
     def test_public_no_expiry_passes(self):
-        body = '{"limit":"collaborators_only","origin":"repository"}'
-        fake = _mock_run("public", "owner/repo", body)
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        body = {"limit": "collaborators_only", "origin": "repository"}
+        with _mock_security("public", "owner/repo", limit_response=body):
             cli.check_repo_security({})
 
     def test_lower_minimum_accepts_weaker_limit(self):
-        body = (
-            '{"limit":"contributors_only","origin":"repository",'
-            '"expires_at":"' + _iso(180) + '"}'
-        )
-        fake = _mock_run("public", "owner/repo", body)
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        body = {"limit": "contributors_only",
+                "origin": "repository",
+                "expires_at": _iso(180)}
+        with _mock_security("public", "owner/repo", limit_response=body):
             cli.check_repo_security(
                 {"security": {"minimum_interaction_limit": "contributors_only"}}
             )
 
     def test_ttl_skips_recheck(self):
-        fake = _mock_run("private", "owner/repo", "{}")
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake) as run:
+        with _mock_security("private", "owner/repo") as _:
             cli.check_repo_security({})
-            first_count = run.call_count
-            cli.check_repo_security({})
-        # Within TTL — the second call must add zero subprocess invocations.
-        self.assertEqual(run.call_count, first_count)
+            # Within TTL — the second call must not hit the layer.
+            with patch_client() as client:
+                cli.check_repo_security({})
+                self.assertEqual(client.calls, [])
 
     def test_ttl_expires(self):
-        fake = _mock_run("private", "owner/repo", "{}")
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake) as run:
+        with _mock_security("private", "owner/repo"):
             cli.check_repo_security({})
-            first_count = run.call_count
             # Simulate both TTLs elapsing — in-memory and disk.
             cli._security_last_ok = (
                 cli._security_last_ok - cli._SECURITY_CHECK_TTL_SECONDS - 1
             )
             self._cache_path.unlink(missing_ok=True)
-            cli.check_repo_security({})
-        self.assertGreater(run.call_count, first_count)
+            with patch_client(routes={
+                ("GET", "/repos/owner/repo"): fake_response(
+                    200, body={"visibility": "private"}),
+            }) as client, mock.patch.object(cli.subprocess, "run",
+                                              return_value=_git_remote_mock("owner/repo")):
+                cli.check_repo_security({})
+                self.assertTrue(any(c["method"] == "GET" for c in client.calls))
 
     def test_gh_not_found_fails_closed(self):
-        with mock.patch.object(cli.subprocess, "run", side_effect=FileNotFoundError):
+        # The layer fails to construct a client (no `gh auth token`); we
+        # surface the error as SystemExit per the existing contract.
+        with patch_client(routes={}, default=fake_response(
+                500, body={"message": "gh missing"})), \
+             mock.patch.object(cli.subprocess, "run",
+                                side_effect=FileNotFoundError):
             with self.assertRaises(SystemExit):
                 cli.check_repo_security({})
 
     def test_gh_repo_view_error_fails_closed(self):
         # Slug lookup (git remote) succeeds; the REST visibility probe fails.
-        git_remote = mock.Mock(returncode=0, stderr="",
-                               stdout="git@github.com:o/r.git\n")
-        bad = mock.Mock(returncode=1, stdout="", stderr="auth required")
-
-        def fake_run(argv, **kwargs):
-            if argv[:2] == ["git", "remote"]:
-                return git_remote
-            return bad
-
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        with patch_client(routes={
+            ("GET", "/repos/o/r"): fake_response(
+                401, body={"message": "auth required"}),
+        }), mock.patch.object(cli.subprocess, "run",
+                              return_value=_git_remote_mock("o/r")):
             with self.assertRaises(SystemExit):
                 cli.check_repo_security({})
 
     def test_gh_api_network_error_fails_closed(self):
-        git_remote = mock.Mock(returncode=0, stderr="",
-                               stdout="git@github.com:o/r.git\n")
-        repo_visibility = mock.Mock(returncode=0, stderr="", stdout="public\n")
-        api_err = mock.Mock(returncode=1, stdout="", stderr="HTTP 500: server error")
-
-        def fake_run(argv, **kwargs):
-            if argv[:2] == ["git", "remote"]:
-                return git_remote
-            if argv[:2] == ["gh", "api"]:
-                path = argv[2] if len(argv) > 2 else ""
-                if path.endswith("/interaction-limits"):
-                    return api_err
-                return repo_visibility
-            raise AssertionError(f"unexpected subprocess call: {argv}")
-
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake_run):
+        # Visibility probe succeeds (public); interaction-limits 500s.
+        with patch_client(routes={
+            ("GET", "/repos/o/r"): fake_response(
+                200, body={"visibility": "public"}),
+            ("GET", "/repos/o/r/interaction-limits"): fake_response(
+                500, body={"message": "server error"}),
+        }), mock.patch.object(cli.subprocess, "run",
+                              return_value=_git_remote_mock("o/r")):
             with self.assertRaises(SystemExit):
                 cli.check_repo_security({})
 
@@ -322,20 +336,17 @@ class SecurityCacheTests(unittest.TestCase):
         run.assert_not_called()
 
     def test_check_writes_disk_cache_on_success_private(self):
-        fake = _mock_run("private", "owner/repo", "{}")
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        with _mock_security("private", "owner/repo"):
             cli.check_repo_security({})
         self.assertTrue(self._cache_path.exists())
         data = json.loads(self._cache_path.read_text())
         self.assertEqual(data["visibility"], "private")
 
     def test_check_writes_disk_cache_on_success_public(self):
-        body = (
-            '{"limit":"collaborators_only","origin":"repository",'
-            '"expires_at":"' + _iso(180) + '"}'
-        )
-        fake = _mock_run("public", "owner/repo", body)
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        body = {"limit": "collaborators_only",
+                "origin": "repository",
+                "expires_at": _iso(180)}
+        with _mock_security("public", "owner/repo", limit_response=body):
             cli.check_repo_security({})
         self.assertTrue(self._cache_path.exists())
         data = json.loads(self._cache_path.read_text())
@@ -345,8 +356,7 @@ class SecurityCacheTests(unittest.TestCase):
     def test_check_does_not_cache_on_failure(self):
         # Visibility=public + missing interaction-limits → SystemExit;
         # cache must not be written so the next run still tries fresh.
-        fake = _mock_run("public", "owner/repo", "{}")
-        with mock.patch.object(cli.subprocess, "run", side_effect=fake):
+        with _mock_security("public", "owner/repo", limit_response={}):
             with self.assertRaises(SystemExit):
                 cli.check_repo_security({})
         self.assertFalse(self._cache_path.exists())

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,248 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "dev-pod"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "respx" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "respx", specifier = ">=0.21" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
This PR introduces a single chokepoint for every GitHub interaction in cli.py and replaces ~40 ad-hoc `subprocess.run([\"gh\", ...])` sites with calls through it. The motivation is two outages in one day this week: GraphQL bucket exhausted by stale claim-release loops, then REST bucket exhausted (5000/5000) by the visibility check at TUI startup. The underlying problem was not which API to use; it was that each call site was its own little island, with no shared throttling, no caching, and no structured record of who burned how much budget.

## What's new

`pod/github.py` exposes a `GitHubClient` that owns:

- One `httpx.Client` per process, with bearer auth from `gh auth token`.
- On-disk ETag cache at `.pod/gh-cache/`, keyed by host + method + URL + normalised params + Accept + `X-GitHub-Api-Version` (and `per_page` for paginated endpoints). 304s do not consume the primary REST budget per [GitHub's docs](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api).
- Rate meter populated from `X-RateLimit-*` response headers, used for back-pressure: when remaining < threshold we sleep until reset before the next call. A soft per-process rate cap (50 req/s) defends against secondary limits that still apply on 304s.
- Per-call JSONL log at `.pod/gh-access.log`. Each row has caller (walked from the Python stack to the first frame outside the layer), URL, status, latency, cache_hit, bucket, remaining, reset, bytes. Authorization headers are never logged; URL query params named `access_token` / `client_secret` / `auth` / `token` are redacted.
- 401 → refresh bearer once via `gh auth token`, retry once.
- 403/429 with Retry-After → sleep then retry once.
- `paginate(path)` walks the Link `rel=\"next\"` header (the correct way per [GitHub's pagination docs](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api)); each page is independently ETag'd.
- `gh_cli(*argv)` passes through to `gh` for porcelain commands that aren't 1:1 with REST/GraphQL (`gh pr merge --auto --squash --delete-branch`, `gh issue comment`, etc.). Logged + back-pressured.

A new `pod gh-stats [--since DURATION] [--by COL] [--top N]` reads the log and prints per-caller / per-path consumption, so the next time a quota gets burned we can answer \"which path?\" in seconds rather than guesswork.

## What changed in cli.py

Every `subprocess.run([\"gh\", ...])` is migrated. `gh api` REST reads/writes use the layer's `client.get/post/put/patch/delete` (ETag-cached for reads). `gh issue/pr/repo/label` porcelain goes through `_gh_cli(...)`, a thin wrapper over `client.gh_cli(...)`. The two `--web` browser-open Popens stay as-is (UI, not API). Existing helpers `_is_rate_limit_error` and `_GraphQLRateLimited` are preserved because the abort-sweep semantics in claim-release / reconcile loops still rely on them; the layer's back-pressure is additive, not a replacement.

## Tests

32 new tests across `tests/test_github_client.py` (ETag round-trip, pagination, back-pressure, 401 refresh, log redaction, file perms) and `tests/test_gh_stats.py`. A new `tests/conftest.py` autouse fixture swaps the layer's module-global client to a `_FakeClient` by default, so any test that triggers a layer call doesn't silently hit the real API. `tests/_gh_helpers.py` exposes `fake_response()` and `patch_client(routes=..., gh_cli_handler=...)` for tests that need canned per-route responses. Existing test files migrated to the new helpers.

Full suite: 217 tests passing in 2.6s.

Manual verification:
- `pod list`, `pod _filter-trusted-issues`, `pod gh-stats` all run through the layer.
- `.pod/gh-cache/*.json` and `.pod/gh-access.log` are chmod 600.
- `caller` column in the log accurately attributes calls to cli.py functions (e.g. `cli.py:_is_repo_public:2928`, `cli.py:fetch_issue_provenance:2948`).

## Out of scope (intentional follow-ups)

- **Porting `pod/data/coordination` to Python.** It's a 1314-line bash script with 106 `gh` calls; that's the actual agent hot path. Leaving it as a dedicated PR since it's a substantial port of its own. Until that lands, `pod gh-stats` will not see coordination's calls — only the human-facing TUI/CLI surface in cli.py.
- **API-shape rewrites for known-burning paths** (claim-release, `fetch_issues_and_prs`, `fetch_issue_provenance`). These benefit from being driven by real `gh-stats` output rather than guessed in advance. Once the coordination port lands and we have a couple of days of attribution data, the right candidates will be obvious.

Builds on #49 (the disk-persisted security-check cache that unstuck the immediate REST-exhaustion outage; that change remains useful as a bottom-of-stack persistence the layer falls back through on cold start).

🤖 Prepared with Claude Code