### PR TITLE
feat: cross-bucket fallback for the security gate + low-water quota warning

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -2819,6 +2819,135 @@ def _security_fail(slug: str, msg: str, *, auth_hint: bool = False) -> None:
     sys.exit(1)
 
 
+def _fetch_repo_security_meta(slug: str) -> tuple[dict | None, int | None]:
+    """Fetch visibility + interaction-limit metadata for `slug`.
+
+    Tries GraphQL first (one round-trip, the B3 burner shape), then falls
+    back to REST (two calls: `GET /repos/{slug}` and `GET
+    /repos/{slug}/interaction-limits`) when GraphQL is unusable. The two
+    REST buckets are independent of the GraphQL bucket on GitHub, so this
+    fallback is the difference between "pod refuses to start" and "pod
+    starts" when GraphQL is rate-limited.
+
+    Returns `(meta, last_status)`:
+      meta — dict `{"visibility": str, "ability": dict | None}` on success,
+             or `None` if both transports failed.
+             `ability` is `None` when no interaction limit is set, else
+             `{"limit": str (lowercased), "expiresAt": str | None}`.
+      last_status — the HTTP status of the last failing transport, used
+             by the caller to print an auth hint on 401/403. `None` when
+             the failure was non-HTTP (exception, empty body).
+
+    Raises `FileNotFoundError` if `gh` is missing — caller handles.
+    """
+    owner, _, name = slug.partition("/")
+    client = gh.get_client()
+    last_status: int | None = None
+
+    def _normalize_gql(body: dict) -> dict | None:
+        repo_node = ((body.get("data") or {}).get("repository") or {})
+        visibility = (repo_node.get("visibility") or "").lower()
+        if not visibility:
+            return None
+        ability_raw = repo_node.get("interactionAbility") or None
+        if ability_raw:
+            have_raw = ability_raw.get("limit") or ""
+            ability = {
+                "limit": have_raw.lower() if isinstance(have_raw, str) else "",
+                "expiresAt": ability_raw.get("expiresAt"),
+            }
+        else:
+            ability = None
+        return {"visibility": visibility, "ability": ability}
+
+    # Smart routing: GraphQL is one round-trip vs REST's two, so we prefer
+    # it normally. But if its bucket is near-empty while REST has budget,
+    # skip straight to REST — a guaranteed-to-fail GraphQL call burns the
+    # bucket further and delays the inevitable fallback.
+    skip_graphql = False
+    try:
+        rates = client.rate()
+        g = rates.get("graphql")
+        c = rates.get("core")
+        if (g is not None and g.limit and g.remaining < 100
+                and c is not None and c.limit and c.remaining > 200):
+            skip_graphql = True
+    except Exception:
+        pass
+
+    # --- GraphQL attempt ---
+    if not skip_graphql:
+        try:
+            resp = client.graphql(
+                "query($owner: String!, $name: String!) {"
+                "  repository(owner: $owner, name: $name) {"
+                "    visibility"
+                "    interactionAbility { limit expiresAt origin }"
+                "  }"
+                "}",
+                variables={"owner": owner, "name": name},
+            )
+        except FileNotFoundError:
+            raise
+        except Exception:
+            resp = None
+        if resp is not None:
+            if resp.ok():
+                meta = _normalize_gql(resp.body() or {})
+                if meta is not None:
+                    return (meta, None)
+                # Status 200 but empty data (GraphQL `errors` block,
+                # typically RATE_LIMITED) — fall through to REST.
+            else:
+                last_status = resp.status
+
+    # --- REST fallback (independent rate-limit bucket) ---
+    try:
+        repo_resp = client.get(f"/repos/{slug}")
+    except FileNotFoundError:
+        raise
+    except Exception:
+        return (None, last_status)
+    if not repo_resp.ok():
+        return (None, repo_resp.status)
+    repo_body = repo_resp.body() or {}
+    visibility = (repo_body.get("visibility") or "").lower()
+    if not visibility:
+        # Older REST shape lacks `visibility`; derive from the `private`
+        # boolean, which has always been present.
+        priv = repo_body.get("private")
+        if priv is True:
+            visibility = "private"
+        elif priv is False:
+            visibility = "public"
+        else:
+            return (None, repo_resp.status)
+    if visibility != "public":
+        return ({"visibility": visibility, "ability": None}, None)
+
+    try:
+        lim_resp = client.get(f"/repos/{slug}/interaction-limits")
+    except FileNotFoundError:
+        raise
+    except Exception:
+        return (None, None)
+    # The endpoint returns 204 No Content, or 200 with an empty / no-limit
+    # body, when no limit is set.
+    if lim_resp.status == 204:
+        return ({"visibility": visibility, "ability": None}, None)
+    if not lim_resp.ok():
+        return (None, lim_resp.status)
+    lim_body = lim_resp.body() or {}
+    have_raw = lim_body.get("limit") if isinstance(lim_body, dict) else ""
+    if not have_raw:
+        return ({"visibility": visibility, "ability": None}, None)
+    ability = {
+        "limit": have_raw.lower() if isinstance(have_raw, str) else "",
+        "expiresAt": lim_body.get("expires_at"),
+    }
+    return ({"visibility": visibility, "ability": ability}, None)
+
+
 def check_repo_security(config: dict) -> None:
     """Refuse to dispatch agents if the repo's GitHub interaction limits are
     missing, too lax, or expiring soon.
@@ -2850,71 +2979,49 @@ def check_repo_security(config: dict) -> None:
     minimum = sec.get("minimum_interaction_limit", "collaborators_only")
     min_days = sec.get("minimum_expiry_days", 7)
 
-    # REST (`gh api repos/{slug}`) instead of `gh repo view --json` so the
-    # security gate doesn't fail closed when the GraphQL bucket is exhausted.
-    # The slug comes from the local git remote (`_get_repo()`), which is also
-    # API-free.
     slug = _get_repo()
 
-    # Disk cache: skip the REST roundtrip if a successful check for this
+    # Disk cache: skip the API round-trip if a successful check for this
     # repo is on file and still satisfies the current policy. Bounded by
     # _SECURITY_DISK_TTL_SECONDS so transitions are caught.
     if _load_security_cache(slug, minimum, min_days):
         _security_last_ok = now
         return
 
-    # B3 burner rewrite: a single GraphQL query returns visibility +
-    # interactionAbility in one round-trip instead of two REST calls.
-    owner, _, name = slug.partition("/")
     try:
-        resp = gh.get_client().graphql(
-            "query($owner: String!, $name: String!) {"
-            "  repository(owner: $owner, name: $name) {"
-            "    visibility"
-            "    interactionAbility { limit expiresAt origin }"
-            "  }"
-            "}",
-            variables={"owner": owner, "name": name},
-        )
+        meta, last_status = _fetch_repo_security_meta(slug)
     except FileNotFoundError:
         print("pod: security: `gh` CLI not found; cannot verify interaction limits.",
               file=sys.stderr)
         sys.exit(1)
-    except Exception as e:
-        print(f"pod: security: failed to query repo: {e}", file=sys.stderr)
-        sys.exit(1)
-    if not resp.ok():
-        err = f"HTTP {resp.status}"
-        print(f"pod: security: cannot determine repo visibility: {err}",
-              file=sys.stderr)
-        if resp.status in (401, 403):
-            print("    → run `gh auth status` / `gh auth login` and retry.",
+    if meta is None:
+        if last_status is not None:
+            print(f"pod: security: cannot determine repo visibility: HTTP {last_status}",
                   file=sys.stderr)
-        sys.exit(1)
-    body = resp.body() or {}
-    repo_node = ((body.get("data") or {}).get("repository") or {})
-    visibility = (repo_node.get("visibility") or "").lower()
-    if not visibility:
-        print("pod: security: cannot determine repo visibility: empty response",
-              file=sys.stderr)
+            if last_status in (401, 403):
+                print("    → run `gh auth status` / `gh auth login` and retry.",
+                      file=sys.stderr)
+        else:
+            print("pod: security: cannot determine repo visibility: "
+                  "GraphQL and REST both unavailable", file=sys.stderr)
+            print("    → run `gh api rate_limit` to inspect; "
+                  "if both buckets are dry, wait for reset.", file=sys.stderr)
         sys.exit(1)
 
+    visibility = meta["visibility"]
     if visibility != "public":
         _save_security_cache(slug, visibility=visibility)
         _security_last_ok = now
         return
 
-    ability = repo_node.get("interactionAbility") or None
+    ability = meta["ability"]
     if not ability:
         _security_fail(slug,
             "no interaction limit set on this public repo. "
             "Random GitHub users can post issues/comments whose contents "
             "feed into pod agent prompts.")
 
-    # GraphQL `InteractionAbility` enum: COLLABORATORS_ONLY / etc.
-    # Convert to lowercase REST shape for ranking against config.
-    have_raw = ability.get("limit") or ""
-    have = have_raw.lower() if isinstance(have_raw, str) else ""
+    have = ability.get("limit") or ""
     if _INTERACTION_LIMIT_RANK.get(have, 0) < _INTERACTION_LIMIT_RANK.get(minimum, 0):
         _security_fail(slug,
             f"interaction limit is `{have or 'unknown'}`, "

--- a/pod/github.py
+++ b/pod/github.py
@@ -27,6 +27,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import threading
 import time
 import urllib.parse
@@ -397,6 +398,10 @@ class GitHubClient:
         self._last_call_at: float = 0.0
         self._rate_cap_hz = rate_cap_hz
         self._backpressure_threshold = backpressure_threshold
+        # Per-reset-window dedupe for the low-water quota warning emitted
+        # by `_record_rate`. Keyed by bucket → the reset_at of the window
+        # for which a warning has already been printed.
+        self._quota_warn_state: dict[str, float] = {}
 
         self._client = httpx.Client(
             base_url=f"https://api.{host}",
@@ -452,7 +457,32 @@ class GitHubClient:
                             observed_at=time.time())
         with self._lock:
             self._rate[resource] = snap
+        self._maybe_warn_quota_low(snap)
         return snap
+
+    # When a bucket falls below this many remaining calls and the reset is
+    # still far enough away that backpressure can't paper over it, emit a
+    # one-shot stderr warning so the user knows quota is being burned and
+    # can investigate via `pod gh-stats`. Tuned slightly above the
+    # backpressure threshold so the warning fires before the layer starts
+    # sleeping.
+    _QUOTA_LOW_THRESHOLD = 100
+
+    def _maybe_warn_quota_low(self, snap: RateSnapshot) -> None:
+        if not snap.limit or snap.remaining >= self._QUOTA_LOW_THRESHOLD:
+            return
+        with self._lock:
+            last = self._quota_warn_state.get(snap.bucket, 0.0)
+            if last == snap.reset_at:
+                return
+            self._quota_warn_state[snap.bucket] = snap.reset_at
+        reset_iso = _iso_at(snap.reset_at) or "unknown"
+        secs_to_reset = max(0, int(snap.reset_at - time.time()))
+        sys.stderr.write(
+            f"pod: gh-quota: {snap.bucket} bucket low: "
+            f"{snap.remaining}/{snap.limit} remaining, "
+            f"resets at {reset_iso} (~{secs_to_reset}s); "
+            f"run `pod gh-stats` to see which callers are burning quota.\n")
 
     def _backpressure(self, bucket: str) -> None:
         """Sleep before the next call if the bucket is near exhaustion or

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -216,7 +216,8 @@ class SecurityCheckTests(unittest.TestCase):
                 cli.check_repo_security({})
 
     def test_gh_api_network_error_fails_closed(self):
-        # GraphQL 5xx → fail-closed exit 1.
+        # GraphQL 5xx → REST fallback (no routes set → 404 default) →
+        # fail-closed exit 1.
         with patch_client(routes={
             ("POST", "/graphql"): fake_response(
                 500, body={"message": "server error"}),
@@ -224,6 +225,106 @@ class SecurityCheckTests(unittest.TestCase):
                               return_value=_git_remote_mock("o/r")):
             with self.assertRaises(SystemExit):
                 cli.check_repo_security({})
+
+    def test_rest_fallback_when_graphql_rate_limited(self):
+        # GraphQL returns 200 with a RATE_LIMITED error block and no
+        # `data` — the empty-data path that previously failed-closed.
+        # With the fallback, pod fetches `/repos/{slug}` and
+        # `/repos/{slug}/interaction-limits` via REST and succeeds.
+        rest_repo = {"visibility": "public", "private": False}
+        rest_limit = {"limit": "collaborators_only",
+                      "origin": "repository",
+                      "expires_at": _iso(180)}
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(200, body={
+                "errors": [{"type": "RATE_LIMITED",
+                            "message": "API rate limit exceeded"}],
+                "data": None,
+            }),
+            ("GET", "/repos/owner/repo"): fake_response(200, body=rest_repo),
+            ("GET", "/repos/owner/repo/interaction-limits"):
+                fake_response(200, body=rest_limit),
+        }), mock.patch.object(cli.subprocess, "run",
+                              return_value=_git_remote_mock("owner/repo")):
+            cli.check_repo_security({})  # no exit
+
+    def test_rest_fallback_when_graphql_5xx(self):
+        # GraphQL returns 5xx → REST fallback path serves valid data.
+        rest_repo = {"visibility": "public", "private": False}
+        rest_limit = {"limit": "collaborators_only",
+                      "origin": "repository",
+                      "expires_at": _iso(180)}
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(
+                502, body={"message": "bad gateway"}),
+            ("GET", "/repos/owner/repo"): fake_response(200, body=rest_repo),
+            ("GET", "/repos/owner/repo/interaction-limits"):
+                fake_response(200, body=rest_limit),
+        }), mock.patch.object(cli.subprocess, "run",
+                              return_value=_git_remote_mock("owner/repo")):
+            cli.check_repo_security({})  # no exit
+
+    def test_rest_fallback_visibility_via_private_flag(self):
+        # Older REST shape: no `visibility` field, only `private` boolean.
+        # Private repos skip the interaction-limits requirement.
+        rest_repo = {"private": True}  # no `visibility` key
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(200, body={
+                "errors": [{"type": "RATE_LIMITED"}], "data": None,
+            }),
+            ("GET", "/repos/owner/repo"): fake_response(200, body=rest_repo),
+        }), mock.patch.object(cli.subprocess, "run",
+                              return_value=_git_remote_mock("owner/repo")):
+            cli.check_repo_security({})  # no exit
+
+    def test_rest_fallback_no_limit_set(self):
+        # Public repo, REST interaction-limits returns 204 (no limit set).
+        rest_repo = {"private": False, "visibility": "public"}
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(200, body={
+                "errors": [{"type": "RATE_LIMITED"}], "data": None,
+            }),
+            ("GET", "/repos/owner/repo"): fake_response(200, body=rest_repo),
+            ("GET", "/repos/owner/repo/interaction-limits"):
+                fake_response(204, body=None),
+        }), mock.patch.object(cli.subprocess, "run",
+                              return_value=_git_remote_mock("owner/repo")):
+            with self.assertRaises(SystemExit):
+                cli.check_repo_security({})
+
+    def test_smart_routing_skips_graphql_when_bucket_dry(self):
+        # When `client.rate()` reports graphql near-empty and core
+        # healthy, the helper goes straight to REST and never POSTs to
+        # /graphql. This avoids burning the bucket further on a call
+        # that would fail anyway.
+        from pod.github import RateSnapshot
+
+        rest_repo = {"private": False, "visibility": "public"}
+        rest_limit = {"limit": "collaborators_only",
+                      "origin": "repository",
+                      "expires_at": _iso(180)}
+        routes = {
+            ("GET", "/repos/owner/repo"): fake_response(200, body=rest_repo),
+            ("GET", "/repos/owner/repo/interaction-limits"):
+                fake_response(200, body=rest_limit),
+        }
+        with patch_client(routes=routes) as client, \
+                mock.patch.object(cli.subprocess, "run",
+                                   return_value=_git_remote_mock("owner/repo")):
+            # Override the fake client's `rate()` for this test only.
+            client.rate = lambda: {
+                "core": RateSnapshot(bucket="core", limit=5000,
+                                     remaining=4999),
+                "graphql": RateSnapshot(bucket="graphql", limit=5000,
+                                        remaining=10),  # near-dry
+            }
+            cli.check_repo_security({})
+            # No POST /graphql call should have been issued.
+            self.assertFalse(
+                any(c["method"] == "POST" and c["path"] == "/graphql"
+                    for c in client.calls),
+                f"smart routing failed; calls={client.calls}",
+            )
 
 
 class SecurityCacheTests(unittest.TestCase):


### PR DESCRIPTION
This PR keeps `pod` working when the GraphQL bucket is exhausted, surfaces quota pressure proactively, and avoids burning quota on calls that are guaranteed to fail.

The B3 burner rewrite in #51 collapsed the two REST calls behind `check_repo_security` into a single GraphQL query. That saved quota in the steady state, but it turned the GraphQL bucket into a single point of failure for pod startup: once it ran dry, the security gate failed closed even though the independent REST bucket might be wide open. After hitting this in practice, three changes:

**REST fallback in `check_repo_security`.** `_fetch_repo_security_meta` tries GraphQL first and, on any unusable response (network error, 5xx, 401/403, or the 200-with-empty-data shape that comes back when GraphQL is rate-limited), falls back to `GET /repos/{slug}` plus `GET /repos/{slug}/interaction-limits`. Both transports normalize into the same `(visibility, ability)` dict so the existing policy checks run once at the top of `check_repo_security`. Also handles the older REST shape where `visibility` is absent and only the `private` boolean is set, and the 204 No Content / empty-body responses from `/interaction-limits` when no limit is configured.

**Smart bucket routing.** Before issuing the GraphQL call, the helper peeks at `client.rate()`. If the GraphQL bucket is near-empty (< 100 remaining) while REST has headroom (> 200), it skips GraphQL entirely — calling an exhausted bucket just burns it further and delays the REST attempt by one wasted round-trip.

**Low-water warning.** `_record_rate` now emits a one-shot stderr line per reset window when a bucket dips below `_QUOTA_LOW_THRESHOLD = 100` remaining, with a pointer to `pod gh-stats` for the per-caller breakdown. The warning is deduplicated by `(bucket, reset_at)` so it fires once on threshold crossing and stays quiet for the rest of the window.

281 tests pass (276 existing + 5 new): GraphQL-rate-limited-then-REST-succeeds, GraphQL-5xx-then-REST-succeeds, older-REST-private-only shape, public repo with 204 No Content from `/interaction-limits` (fails closed as before), and smart routing skipping GraphQL when its bucket is reported as near-dry.

🤖 Prepared with Claude Code