### PR TITLE
feat: stale-render TUI cache + actionable low-water quota warning

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1833,6 +1833,82 @@ query TuiRefresh($owner: String!, $name: String!) {
 _TUI_REFRESH_CACHE: tuple[float, dict | None] = (0.0, None)
 _TUI_REFRESH_TTL = 4.0  # seconds; matches the TUI's fast-path tick cadence
 _TUI_REFRESH_LOCK = threading.Lock()
+# Bump when `_TUI_REFRESH_QUERY` changes shape so an on-disk snapshot from
+# an older pod version is rejected instead of feeding the new code stale
+# data with missing keys (`openAgentPlan`, `blocked`, etc.).
+_TUI_CACHE_SCHEMA = 1
+# One-shot flag: try the disk fallback exactly once per process, on the
+# first refresh tick after start-up. After that we either have live data
+# or we're already serving the in-memory copy.
+_TUI_DISK_CACHE_LOADED = False
+# Shown in the header once the cache crosses these ages. Tuned so a
+# single missed refresh tick doesn't flash the indicator on and off.
+_TUI_STALE_AFTER_S = 60.0
+_TUI_VERY_STALE_AFTER_S = 3600.0
+
+
+def _tui_cache_path() -> Path:
+    return POD_DIR / "tui-cache.json"
+
+
+def _save_tui_cache(fetched_at: float, slug: str, repo_node: dict) -> None:
+    """Atomic write of the latest successful GraphQL response so a
+    later dry-quota startup can serve a stale snapshot rather than an
+    empty items panel. chmod 600 — issue bodies and comments are in the
+    payload."""
+    payload = {
+        "schema": _TUI_CACHE_SCHEMA,
+        "repo": slug,
+        "fetched_at": fetched_at,
+        "body": repo_node,
+    }
+    p = _tui_cache_path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return
+    tmp = p.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(payload))
+        os.chmod(tmp, 0o600)
+        tmp.replace(p)
+    except OSError:
+        pass
+
+
+def _load_tui_cache(slug: str) -> tuple[float, dict] | None:
+    """Returns `(fetched_at, repo_node)` for a previously-saved snapshot
+    of the same repo and schema, or `None` if missing, corrupt, or
+    schema-mismatched. Never raises."""
+    p = _tui_cache_path()
+    if not p.exists():
+        return None
+    try:
+        data = json.loads(p.read_text())
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("schema") != _TUI_CACHE_SCHEMA:
+        return None
+    if data.get("repo") != slug:
+        return None
+    try:
+        fetched_at = float(data.get("fetched_at", 0.0))
+    except (TypeError, ValueError):
+        return None
+    body = data.get("body")
+    if not isinstance(body, dict):
+        return None
+    # Reject snapshots whose top-level keys don't match the current query
+    # shape (defence in depth on top of the schema-version check).
+    required = ("openAgentPlan", "openHumanOversight",
+                "closedAgentPlan", "closedHumanOversight",
+                "blocked", "openIssueNumbers",
+                "hasPrIssues", "pullRequests")
+    if not all(k in body for k in required):
+        return None
+    return (fetched_at, body)
 
 
 def _tui_refresh_batch() -> dict | None:
@@ -1845,17 +1921,37 @@ def _tui_refresh_batch() -> dict | None:
     each firing its own). The layer also ETag-caches the GraphQL
     response (since the cache key includes a hash of the request body),
     so cache-miss hits return 304s.
+
+    Stale-render: if the live call fails (rate limit, 5xx, network),
+    we return whatever's currently in the in-memory cache rather than
+    `None`. That cache is seeded once per process from
+    `.pod/tui-cache.json` on the first cold-start tick, so even a fresh
+    pod startup with the GraphQL bucket dry shows the last successful
+    snapshot (with an `items stale: …` indicator in the header) instead
+    of an empty panel.
     """
-    global _TUI_REFRESH_CACHE
+    global _TUI_REFRESH_CACHE, _TUI_DISK_CACHE_LOADED
     with _TUI_REFRESH_LOCK:
         now = time.time()
         ts, cached = _TUI_REFRESH_CACHE
         if cached is not None and (now - ts) < _TUI_REFRESH_TTL:
             return cached
         slug = _get_repo()
+
+        # One-shot disk load: only fires on the very first refresh
+        # before any live data lands. Carries `fetched_at` from disk
+        # forward so the staleness indicator reflects the original
+        # snapshot age, not now.
+        if cached is None and not _TUI_DISK_CACHE_LOADED:
+            _TUI_DISK_CACHE_LOADED = True
+            disk = _load_tui_cache(slug)
+            if disk is not None:
+                _TUI_REFRESH_CACHE = disk
+                cached = disk[1]
+
         owner, _, name = slug.partition("/")
         if not (owner and name):
-            return None
+            return cached
         try:
             resp = gh.get_client().graphql(
                 _TUI_REFRESH_QUERY,
@@ -1863,14 +1959,15 @@ def _tui_refresh_batch() -> dict | None:
                 cache="etag",
             )
         except Exception:
-            return None
+            return cached  # serve stale
         if not resp.ok():
-            return None
+            return cached
         body = resp.body() or {}
         repo_node = (body.get("data") or {}).get("repository") or {}
         if not repo_node:
-            return None
+            return cached
         _TUI_REFRESH_CACHE = (now, repo_node)
+        _save_tui_cache(now, slug, repo_node)
         return repo_node
 
 
@@ -6276,6 +6373,27 @@ def _tui_main(stdscr, config: dict):
             lock_indicator = " | LOCK"
         if FORCE_QUOTA_FILE.exists():
             lock_indicator += " | FORCE"
+        # Items panel staleness — survives a single missed refresh tick
+        # without flashing the indicator. Computed against the cache's
+        # original `fetched_at`, so a snapshot loaded from disk on
+        # startup shows its true age (potentially hours), not a fresh-
+        # looking few seconds.
+        tui_cache_ts, _tui_cache_body = _TUI_REFRESH_CACHE
+        if tui_cache_ts > 0 and _tui_cache_body is not None:
+            age = time.time() - tui_cache_ts
+            if age >= _TUI_VERY_STALE_AFTER_S:
+                lock_indicator += f" | items very stale: {human_duration(age)}"
+            elif age >= _TUI_STALE_AFTER_S:
+                lock_indicator += f" | items stale: {human_duration(age)}"
+        # Quota low-water indicator — the stderr warning from the layer
+        # gets overwritten by curses, so surface a compact marker here
+        # while the bucket is still in its depleted window.
+        try:
+            low = gh.get_client().low_water_buckets()
+        except Exception:
+            low = set()
+        for b in sorted(low):
+            lock_indicator += f" | {b}:!"
         effective = target  # already computed via get_effective_target() above
         user_t = read_target()
         if effective is not None and user_t is not None and effective < user_t:

--- a/pod/github.py
+++ b/pod/github.py
@@ -24,6 +24,7 @@ import datetime
 import hashlib
 import inspect
 import json
+import collections
 import os
 import re
 import subprocess
@@ -400,8 +401,15 @@ class GitHubClient:
         self._backpressure_threshold = backpressure_threshold
         # Per-reset-window dedupe for the low-water quota warning emitted
         # by `_record_rate`. Keyed by bucket → the reset_at of the window
-        # for which a warning has already been printed.
+        # for which a warning has already been printed. Survives until the
+        # reset_at passes, at which point `low_water_buckets()` stops
+        # reporting the bucket as low.
         self._quota_warn_state: dict[str, float] = {}
+        # Rolling buffer of recent calls, time-pruned on read, count-capped
+        # on write. Used by the low-water warning to embed the top callers
+        # in the last few minutes inline. Both `request()` and `gh_cli()`
+        # append here; transport disambiguates them in summaries.
+        self._recent_calls: collections.deque = collections.deque(maxlen=5000)
 
         self._client = httpx.Client(
             base_url=f"https://api.{host}",
@@ -467,22 +475,66 @@ class GitHubClient:
     # backpressure threshold so the warning fires before the layer starts
     # sleeping.
     _QUOTA_LOW_THRESHOLD = 100
+    # Skip the warning when the bucket is near reset anyway — a bursty
+    # caller hitting 99 remaining with 30s on the clock doesn't need a
+    # stderr nag every reset window.
+    _QUOTA_WARN_MIN_SECS_TO_RESET = 120
+    # Window over which we summarise recent callers in the warning. Tied
+    # to `_recent_calls` capacity (5000 entries) — at the per-process
+    # rate cap of 50/s, this is well over 1 minute of full saturation,
+    # which is plenty for "what caused the drop" diagnosis.
+    _QUOTA_WARN_CALLER_WINDOW_S = 300.0
+
+    def _remember_call(self, ts: float, caller: str, bucket: str,
+                       transport: str) -> None:
+        """Record an attempted call in the rolling buffer used by the
+        low-water warning. Called from both `request()` (before the
+        network round-trip, so attempts that error out still register)
+        and `gh_cli()`. Safe under `self._lock`."""
+        with self._lock:
+            self._recent_calls.append((ts, caller, bucket, transport))
 
     def _maybe_warn_quota_low(self, snap: RateSnapshot) -> None:
         if not snap.limit or snap.remaining >= self._QUOTA_LOW_THRESHOLD:
             return
+        secs_to_reset = max(0, int(snap.reset_at - time.time()))
+        if secs_to_reset < self._QUOTA_WARN_MIN_SECS_TO_RESET:
+            # Bucket will refill before any reasonable mitigation could
+            # take effect; don't bother the user.
+            return
+        cutoff = time.time() - self._QUOTA_WARN_CALLER_WINDOW_S
         with self._lock:
             last = self._quota_warn_state.get(snap.bucket, 0.0)
             if last == snap.reset_at:
                 return
             self._quota_warn_state[snap.bucket] = snap.reset_at
+            recent = [(c, t) for (ts, c, b, t) in self._recent_calls
+                      if ts >= cutoff and b == snap.bucket]
+        counts: collections.Counter = collections.Counter(
+            (c, t) for (c, t) in recent)
+        top = counts.most_common(3)
         reset_iso = _iso_at(snap.reset_at) or "unknown"
-        secs_to_reset = max(0, int(snap.reset_at - time.time()))
-        sys.stderr.write(
-            f"pod: gh-quota: {snap.bucket} bucket low: "
-            f"{snap.remaining}/{snap.limit} remaining, "
-            f"resets at {reset_iso} (~{secs_to_reset}s); "
-            f"run `pod gh-stats` to see which callers are burning quota.\n")
+        msg = (f"pod: gh-quota: {snap.bucket} bucket low: "
+               f"{snap.remaining}/{snap.limit} remaining, "
+               f"resets at {reset_iso} (~{secs_to_reset}s)")
+        if top:
+            parts = []
+            for (caller, transport), n in top:
+                suffix = " (gh-cli)" if transport == "gh" else ""
+                parts.append(f"{caller}{suffix} ×{n}")
+            msg += "; recent callers: " + ", ".join(parts)
+        msg += "; run `pod gh-stats` for full breakdown.\n"
+        sys.stderr.write(msg)
+
+    def low_water_buckets(self) -> set[str]:
+        """Names of buckets that have crossed the low-water threshold and
+        whose reset window has not yet passed. Used by the TUI header to
+        show a `graphql:!` / `core:!` indicator while quota is depleted —
+        keeps the warning visible even when curses overwrites stderr."""
+        now = time.time()
+        with self._lock:
+            return {b for b, ra in self._quota_warn_state.items()
+                    if ra > now}
 
     def _backpressure(self, bucket: str) -> None:
         """Sleep before the next call if the bucket is near exhaustion or
@@ -606,6 +658,10 @@ class GitHubClient:
 
         caller = _caller or self._caller()
         t0 = time.time()
+        # Record the attempt now so a network exception that aborts the
+        # request still shows up in the recent-callers buffer used by
+        # `_maybe_warn_quota_low`.
+        self._remember_call(t0, caller, bucket, "httpx")
         try:
             resp = self._client.request(
                 method, url, params=params, json=json,
@@ -766,6 +822,11 @@ class GitHubClient:
         if isinstance(input, bytes):
             text = False
         t0 = time.time()
+        # `gh_cli` burns the core bucket just like a direct HTTP call.
+        # Record it so PR-heavy workflows that lean on `gh pr ...` show up
+        # in the recent-callers summary instead of silently misattributing
+        # the bucket drain to the few HTTP calls in the window.
+        self._remember_call(t0, caller, "core", "gh")
         try:
             r = subprocess.run(
                 ["gh", *argv],

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -565,5 +565,139 @@ class CacheTrimTests(_Tmp):
         self.assertTrue((self.cache_dir / "b.json").exists())
 
 
+class LowWaterWarningTests(_Tmp):
+    """`_maybe_warn_quota_low` fires once per reset window when a bucket
+    dips below `_QUOTA_LOW_THRESHOLD`, and includes the top callers from
+    the rolling buffer (covering both `request()` and `gh_cli()` paths).
+    Suppressed when the reset is imminent so bursty callers near reset
+    don't get nagged."""
+
+    def _capture_stderr(self):
+        # Patch `sys.stderr.write` at the module level so writes from
+        # `_maybe_warn_quota_low` land in our list.
+        from pod import github as gh_mod
+        chunks: list[str] = []
+        return mock.patch.object(gh_mod.sys.stderr, "write",
+                                 side_effect=chunks.append), chunks
+
+    def test_warning_fires_once_per_reset_window(self):
+        reset = int(time.time()) + 1800  # 30 min away, well past time-gate
+
+        def h(req):
+            return _resp(200, json_body={},
+                         headers=_rl_headers(remaining=10, reset=reset))
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            patcher, chunks = self._capture_stderr()
+            # Below `backpressure_threshold`=50, the layer would sleep
+            # for real between calls. Mute it so the test runs fast.
+            with patcher, mock.patch("pod.github.time.sleep"):
+                c.get("/a")
+                c.get("/b")
+                c.get("/c")
+            # Concatenate emitted stderr writes; should contain exactly
+            # one warning despite three low-bucket responses.
+            blob = "".join(chunks)
+            self.assertEqual(blob.count("pod: gh-quota: core bucket low"), 1,
+                             f"expected exactly one warning, got: {blob!r}")
+        finally:
+            c.close()
+
+    def test_warning_skipped_when_reset_is_imminent(self):
+        # Reset in 30 seconds — under the 120s time-gate.
+        reset = int(time.time()) + 30
+
+        def h(req):
+            return _resp(200, json_body={},
+                         headers=_rl_headers(remaining=5, reset=reset))
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            patcher, chunks = self._capture_stderr()
+            with patcher:
+                c.get("/a")
+            self.assertEqual("".join(chunks), "",
+                             "warning should be suppressed near reset")
+        finally:
+            c.close()
+
+    def test_warning_lists_top_callers(self):
+        reset = int(time.time()) + 1800
+
+        def h(req):
+            return _resp(200, json_body={},
+                         headers=_rl_headers(remaining=50, reset=reset))
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            # Seed the buffer with several "callers" by stuffing the
+            # deque directly — easier than constructing real stack
+            # frames per caller identity.
+            now = time.time()
+            with c._lock:
+                c._recent_calls.extend([
+                    (now, "cli.py:fetch_issues_and_prs:1", "core", "httpx"),
+                    (now, "cli.py:fetch_issues_and_prs:1", "core", "httpx"),
+                    (now, "cli.py:fetch_issues_and_prs:1", "core", "httpx"),
+                    (now, "cli.py:sync_claims:42", "core", "httpx"),
+                    (now, "cli.py:sync_claims:42", "core", "httpx"),
+                    (now, "cli.py:create_pr:99", "core", "gh"),
+                ])
+            patcher, chunks = self._capture_stderr()
+            # Remaining=50 is below backpressure_threshold=50 — the
+            # second call would block on a real sleep without this mute.
+            with patcher, mock.patch("pod.github.time.sleep"):
+                c.get("/trigger-warning")  # forces _maybe_warn_quota_low
+            blob = "".join(chunks)
+            self.assertIn("recent callers", blob)
+            self.assertIn("fetch_issues_and_prs", blob)
+            # gh_cli entries are tagged so the user knows they are
+            # subprocess-shape, not direct HTTP.
+            self.assertIn("(gh-cli)", blob)
+        finally:
+            c.close()
+
+    def test_gh_cli_path_records_in_buffer(self):
+        # `gh_cli` shells out via subprocess — verify the call is logged
+        # into the rolling buffer so the warning surfaces PR-heavy
+        # workflows that don't go through `request()`.
+        def h(req):
+            return _resp(200, json_body={}, headers=_rl_headers())
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            with mock.patch("pod.github.subprocess.run") as run:
+                run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+                c.gh_cli("pr", "view", "42")
+            self.assertEqual(len(c._recent_calls), 1)
+            ts, caller, bucket, transport = c._recent_calls[0]
+            self.assertEqual(bucket, "core")
+            self.assertEqual(transport, "gh")
+        finally:
+            c.close()
+
+    def test_low_water_buckets_clears_after_reset(self):
+        reset_soon = int(time.time()) + 300  # 5 min away, past time-gate
+
+        def h(req):
+            return _resp(200, json_body={},
+                         headers=_rl_headers(remaining=10, reset=reset_soon))
+
+        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
+        try:
+            patcher, _ = self._capture_stderr()
+            with patcher, mock.patch("pod.github.time.sleep"):
+                c.get("/x")
+            # Bucket is in the low state.
+            self.assertEqual(c.low_water_buckets(), {"core"})
+            # Manually age out the warn state.
+            with c._lock:
+                c._quota_warn_state["core"] = time.time() - 10
+            self.assertEqual(c.low_water_buckets(), set())
+        finally:
+            c.close()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tui_cache.py
+++ b/tests/test_tui_cache.py
@@ -1,0 +1,207 @@
+"""Tests for `.pod/tui-cache.json` persistence and the stale-render path
+in `_tui_refresh_batch`.
+
+The TUI's GraphQL batch refresh used to return `None` on any failure
+(rate limit, transient 5xx, network error), which collapsed the items
+panel to zero rows. The cache persists the last successful response
+body to disk and the refresh helper falls back to it on the next failed
+tick, with a freshness marker in the header so the operator knows
+they're looking at history.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pod import cli
+
+from _gh_helpers import fake_response, patch_client
+
+
+_VALID_REPO_NODE = {
+    "openAgentPlan": {"nodes": []},
+    "openHumanOversight": {"nodes": []},
+    "closedAgentPlan": {"nodes": []},
+    "closedHumanOversight": {"nodes": []},
+    "blocked": {"nodes": []},
+    "openIssueNumbers": {"nodes": []},
+    "hasPrIssues": {"nodes": []},
+    "pullRequests": {"nodes": []},
+}
+
+
+def _git_remote_mock(slug: str):
+    return mock.Mock(returncode=0, stderr="",
+                     stdout=f"git@github.com:{slug}.git\n")
+
+
+class TuiCacheRoundTripTests(unittest.TestCase):
+    """`_save_tui_cache` + `_load_tui_cache` exercised directly."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.path = Path(self._tmp.name) / "tui-cache.json"
+        p = mock.patch.object(cli, "_tui_cache_path", return_value=self.path)
+        p.start()
+        self.addCleanup(p.stop)
+
+    def test_round_trip(self):
+        cli._save_tui_cache(123.0, "owner/repo", _VALID_REPO_NODE)
+        loaded = cli._load_tui_cache("owner/repo")
+        self.assertIsNotNone(loaded)
+        ts, body = loaded
+        self.assertEqual(ts, 123.0)
+        self.assertEqual(body, _VALID_REPO_NODE)
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(cli._load_tui_cache("owner/repo"))
+
+    def test_corrupt_json_returns_none(self):
+        self.path.write_text("{not valid json")
+        self.assertIsNone(cli._load_tui_cache("owner/repo"))
+
+    def test_schema_mismatch_rejected(self):
+        self.path.write_text(json.dumps({
+            "schema": cli._TUI_CACHE_SCHEMA + 1,
+            "repo": "owner/repo",
+            "fetched_at": 1.0,
+            "body": _VALID_REPO_NODE,
+        }))
+        self.assertIsNone(cli._load_tui_cache("owner/repo"))
+
+    def test_repo_mismatch_rejected(self):
+        # Snapshot saved while pod was running against a different repo
+        # (e.g. .pod/ copied between projects) must not feed back into
+        # this one.
+        cli._save_tui_cache(1.0, "other/elsewhere", _VALID_REPO_NODE)
+        self.assertIsNone(cli._load_tui_cache("owner/repo"))
+
+    def test_missing_required_keys_rejected(self):
+        # Old-shape snapshot from a prior pod version where the GraphQL
+        # query lacked, say, `hasPrIssues`. The schema-version bump is
+        # the primary defence; this key-set check is belt-and-braces.
+        body = dict(_VALID_REPO_NODE)
+        body.pop("hasPrIssues")
+        self.path.write_text(json.dumps({
+            "schema": cli._TUI_CACHE_SCHEMA,
+            "repo": "owner/repo",
+            "fetched_at": 1.0,
+            "body": body,
+        }))
+        self.assertIsNone(cli._load_tui_cache("owner/repo"))
+
+    def test_save_is_chmod_600(self):
+        cli._save_tui_cache(1.0, "owner/repo", _VALID_REPO_NODE)
+        import os
+        import stat
+        mode = stat.S_IMODE(os.stat(self.path).st_mode)
+        # Issue bodies and comments are in the payload; not world- or
+        # group-readable.
+        self.assertEqual(mode & 0o077, 0)
+
+
+class TuiRefreshBatchTests(unittest.TestCase):
+    """End-to-end refresh helper: live success, live failure with
+    stale-from-disk fallback, schema-mismatch ignored."""
+
+    def setUp(self):
+        # Reset module state between tests.
+        cli._TUI_REFRESH_CACHE = (0.0, None)
+        cli._TUI_DISK_CACHE_LOADED = False
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.cache_path = Path(self._tmp.name) / "tui-cache.json"
+        p = mock.patch.object(cli, "_tui_cache_path",
+                              return_value=self.cache_path)
+        p.start()
+        self.addCleanup(p.stop)
+        # Stub `_get_repo()` so we don't shell out to git.
+        p2 = mock.patch.object(cli, "_get_repo", return_value="owner/repo")
+        p2.start()
+        self.addCleanup(p2.stop)
+
+    def _gql_response(self, *, status=200, body=None):
+        body = body if body is not None else {
+            "data": {"repository": _VALID_REPO_NODE}
+        }
+        return fake_response(status, body=body)
+
+    def test_successful_refresh_writes_disk_cache(self):
+        with patch_client(routes={
+            ("POST", "/graphql"): self._gql_response(),
+        }):
+            out = cli._tui_refresh_batch()
+        self.assertEqual(out, _VALID_REPO_NODE)
+        # Disk cache should be written.
+        self.assertTrue(self.cache_path.exists())
+        data = json.loads(self.cache_path.read_text())
+        self.assertEqual(data["schema"], cli._TUI_CACHE_SCHEMA)
+        self.assertEqual(data["repo"], "owner/repo")
+        self.assertEqual(data["body"], _VALID_REPO_NODE)
+
+    def test_stale_render_when_live_call_fails(self):
+        # Seed disk cache, simulate cold pod start, simulate live
+        # GraphQL failure (500).
+        cli._save_tui_cache(time.time() - 600, "owner/repo",
+                            _VALID_REPO_NODE)
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(500, body={"message": "x"}),
+        }):
+            out = cli._tui_refresh_batch()
+        self.assertEqual(out, _VALID_REPO_NODE,
+                         "stale snapshot should be returned on failure")
+
+    def test_stale_render_when_graphql_rate_limited(self):
+        # GraphQL returns 200 with empty data (RATE_LIMITED shape).
+        cli._save_tui_cache(time.time() - 600, "owner/repo",
+                            _VALID_REPO_NODE)
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(200, body={
+                "errors": [{"type": "RATE_LIMITED"}],
+                "data": None,
+            }),
+        }):
+            out = cli._tui_refresh_batch()
+        self.assertEqual(out, _VALID_REPO_NODE)
+
+    def test_disk_cache_loaded_once_per_process(self):
+        # After the first cold-start tick, even if disk is hit again
+        # (rewritten externally), the in-memory cache is not refreshed
+        # from disk a second time.
+        cli._save_tui_cache(100.0, "owner/repo", _VALID_REPO_NODE)
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(500, body={}),
+        }):
+            cli._tui_refresh_batch()  # first tick: loads disk cache
+            self.assertTrue(cli._TUI_DISK_CACHE_LOADED)
+            ts1, _ = cli._TUI_REFRESH_CACHE
+        # Overwrite disk with a different ts; the next refresh tick
+        # should not pick it up — we already had our one-shot.
+        cli._save_tui_cache(200.0, "owner/repo", _VALID_REPO_NODE)
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(500, body={}),
+        }):
+            cli._tui_refresh_batch()
+            ts2, _ = cli._TUI_REFRESH_CACHE
+        self.assertEqual(ts1, ts2)
+
+    def test_no_disk_cache_no_stale_fallback(self):
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(500, body={}),
+        }):
+            out = cli._tui_refresh_batch()
+        self.assertIsNone(out)
+        # In-memory cache must remain unset so subsequent successful
+        # refreshes can populate it cleanly.
+        ts, body = cli._TUI_REFRESH_CACHE
+        self.assertIsNone(body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR keeps the TUI useful when the GraphQL bucket runs dry and makes the low-water warning self-sufficient — together they address the failure mode from the recent quota-exhaustion incident where `pod` started, security-gated successfully via the REST fallback merged in #53, but then showed an empty items panel with no obvious explanation.

## Disk-persisted TUI snapshot with stale-render

`_tui_refresh_batch` writes the GraphQL response body to `.pod/tui-cache.json` after every successful refresh and, on any subsequent failure (network error, 5xx, the 200-with-empty-data shape that comes back when GraphQL is rate-limited), returns the cached body instead of `None`. The disk cache is one-shot-loaded into memory on the first cold-start refresh, so a brand-new pod process with quota already dry still renders the previous snapshot.

The cache file carries `{schema, repo, fetched_at, body}`. Load-time validation rejects schema drift (so a query-shape change forces a re-fetch instead of feeding the new code stale partial data), repo mismatches (so a `.pod/` directory copied between projects doesn't surface another repo's items), and bodies missing required top-level keys.

The TUI header gains `items stale: <age>` after 60 s and `items very stale: <age>` after 1 h, computed against the cache's original `fetched_at`. A snapshot loaded from disk on startup shows its true age — there is no path that lies about freshness.

## Top callers in the low-water warning

`GitHubClient` keeps a rolling buffer of recent calls (`deque(maxlen=5000)`, time-pruned to the last 5 min at summary time). Both `request()` and `gh_cli()` append to it — the `gh_cli()` path matters because PR-heavy workflows lean on `gh pr ...` and would otherwise be invisible to the warning. When the low-water warning fires, the top three callers in the matching bucket are inlined, with `(gh-cli)` tagging the subprocess entries.

Two new noise gates: the warning is suppressed when the reset is closer than 120 s (bursty callers near reset don't need a stderr nag every window), and the TUI header now reads `client.low_water_buckets()` to show a compact `graphql:!` / `core:!` indicator that survives curses redraws. The stderr warning still emits for non-TUI contexts.

## Verification

17 new tests added (298 total pass):

**TUI cache** — round-trip; missing file; corrupt JSON; schema-version mismatch; repo mismatch; missing-required-keys rejection; `chmod 600`; live-failure stale-render; GraphQL-rate-limited stale-render; disk-load is one-shot per process; no-cache-no-fallback.

**Low-water warning** — fires exactly once per reset window across multiple low responses; suppressed when reset is imminent (<120 s); embeds top callers including `(gh-cli)` tag; `gh_cli()` path records into the ring buffer; `low_water_buckets()` clears once the reset_at passes.

Interactive verification on the next dry-quota incident: confirm `.pod/tui-cache.json` appears after first refresh; confirm items panel renders from cache with `items stale: …` indicator after a forced GraphQL failure; confirm `graphql:!` appears in the header when the low-water warning fires.

🤖 Prepared with Claude Code