### PR TITLE
fix: release GitHub claim on quota exhaustion + liveness-based orphan sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ it directly for debugging or manual intervention.
 | `add-dep <N> <M>` | Add `depends-on: #M` to issue #N; mark blocked if #M is open |
 | `check-blocked` | Unblock issues whose dependencies are all closed |
 | `release-stale-claims [seconds]` | Release claims older than threshold (default 4h) |
+| `release-orphan-claims` | Release claims whose owning session UUID is not in `.pod/agents/` (no age threshold) |
 
 ### PRs
 

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -3352,7 +3352,8 @@ def cmd_filter_trusted_issues(config: dict, args) -> None:
         sys.stdout.write("\n")
 
 
-def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> bool:
+def _release_claim(issue_str: str, session_uuid: str, restart_count: int,
+                    *, reason: str | None = None) -> bool:
     """Remove the 'claimed' label from an issue and leave an explanatory comment.
     Returns True on success (including idempotent terminal cases — see below),
     False on transient failure (caller may revert history deletion).
@@ -3368,7 +3369,11 @@ def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> boo
     If the `claimed` label is already absent, returns True without spending
     GraphQL quota. If the issue is closed and the label is still present,
     also returns True — pod doesn't read labels off closed issues, and the
-    quota-safe choice is to leave them alone."""
+    quota-safe choice is to leave them alone.
+
+    `reason`, if given, replaces the default "died after N restart attempts"
+    release comment — for callers (e.g. the quota-exhaustion handler) where
+    that wording would mislead."""
     import re as _re
     repo = _get_repo()
 
@@ -3436,8 +3441,9 @@ def _release_claim(issue_str: str, session_uuid: str, restart_count: int) -> boo
     if r1.returncode != 0:
         log(f"Failed to remove claimed label on #{issue_str}: {r1.stderr.strip()}")
         return False
-    msg = (f"Claim released — worker session `{session_uuid}` died after "
-           f"{restart_count} restart attempt(s). Available for reclaim.")
+    msg = reason or (
+        f"Claim released — worker session `{session_uuid}` died after "
+        f"{restart_count} restart attempt(s). Available for reclaim.")
     try:
         r2 = _gh_cli(
             "issue", "comment", issue_str, "--repo", repo,
@@ -3672,7 +3678,14 @@ def reconcile_untracked_github_claims():
     import re as _re
 
     repo = _get_repo()
-    grace_seconds = 600  # 10 minutes — don't release very fresh claims
+    # 60s is enough to cover the window between an agent posting the
+    # "Claimed by session" comment and writing its local claim-history
+    # entry — anything older with a dead owner UUID is a real orphan.
+    # The previous 10-minute setting compounded with the 10-minute
+    # housekeeping cadence to delay orphan cleanup by up to 20 minutes;
+    # a session whose GitHub claim survives 60 seconds past its UUID
+    # disappearing from `read_all_agents()` is unambiguously dead.
+    grace_seconds = 60
     client = gh.get_client()
 
     owner, _, name = repo.partition("/")
@@ -5835,10 +5848,34 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         if _is_quota_exhausted:
             log(f"Agent {short_id}: session stdout indicates quota exhaustion, "
                 f"will re-check quota before next dispatch")
-            # Release claim without replan — issue is fine, just quota-gated
+            # Release claim without replan — issue is fine, just quota-gated.
+            # Must call `_release_claim` (not just `clear_claim`) so the GitHub
+            # `claimed` label is actually removed: this session UUID is about
+            # to be discarded when the next dispatch generates a fresh one,
+            # at which point no live agent owns the GitHub claim and any
+            # `clear_claim`-only path would leak it as an orphan label that
+            # `check_dead_claimed_issues` then skips forever (it ignores
+            # `released:True` entries). On transient GitHub failure (likely
+            # under quota pressure), leave the history entry untouched so the
+            # next housekeeping reconcile picks it up.
             if state.claimed_issue > 0 and state.pr_number == 0:
-                clear_claim(state.claimed_issue, session_uuid=state.uuid)
-                log(f"Agent {short_id}: released claim on #{state.claimed_issue} (quota exhaustion, not replan)")
+                released_ok = False
+                try:
+                    released_ok = _release_claim(
+                        str(state.claimed_issue), state.uuid, 0,
+                        reason=(f"Claim released — worker session "
+                                f"`{state.uuid}` exited due to quota "
+                                f"exhaustion. Available for reclaim."))
+                except _GraphQLRateLimited as e:
+                    log(f"Agent {short_id}: GH rate-limited releasing "
+                        f"#{state.claimed_issue} ({e}); will retry via housekeeping")
+                if released_ok:
+                    clear_claim(state.claimed_issue, session_uuid=state.uuid)
+                    log(f"Agent {short_id}: released claim on #{state.claimed_issue} (quota exhaustion, not replan)")
+                else:
+                    log(f"Agent {short_id}: GitHub release failed for "
+                        f"#{state.claimed_issue} (quota exhaustion); "
+                        f"leaving history entry for housekeeping retry")
             cleanup_worktree(wt_dir, branch)
             state.worktree = ""
             state.branch = ""

--- a/pod/coordination.py
+++ b/pod/coordination.py
@@ -1644,6 +1644,120 @@ def cmd_release_stale_claims(ctx: CoordinationContext,
 
 
 # ---------------------------------------------------------------------------
+# Subcommand: release-orphan-claims
+# ---------------------------------------------------------------------------
+
+def _live_session_uuids(ctx: CoordinationContext) -> set[str] | None:
+    """Read live agent session UUIDs from `<repo>/.pod/agents/*.json`.
+
+    Returns the set, or `None` if the agents directory is unreadable / not
+    found — callers treat `None` as "can't make a liveness decision" and
+    fall back to age-based heuristics.
+    """
+    import json as _json
+    pod_dir = Path(ctx.git_toplevel) / ".pod" / "agents"
+    if not pod_dir.is_dir():
+        return None
+    live: set[str] = set()
+    try:
+        for p in pod_dir.glob("*.json"):
+            if p.name.endswith(".tmp"):
+                continue
+            try:
+                d = _json.loads(p.read_text())
+            except (OSError, _json.JSONDecodeError):
+                continue
+            if d.get("status") in ("dead", "stopped", "killed"):
+                continue
+            uid = d.get("uuid")
+            if isinstance(uid, str) and uid:
+                live.add(uid)
+    except OSError:
+        return None
+    return live
+
+
+def cmd_release_orphan_claims(ctx: CoordinationContext,
+                                argv: list[str]) -> int:
+    """Liveness-based orphan-claim sweep: release any `claimed` issue whose
+    owning session UUID is not present in `.pod/agents/*.json`.
+
+    Complements `release-stale-claims` (age-based) and the housekeeping
+    `reconcile_untracked_github_claims` loop (10-min cadence, 60s grace).
+    Runs on demand, no grace period, no GitHub-time math — local agent
+    state is authoritative for whether a session is still running.
+
+    Exits non-zero if the local agents directory cannot be read, so the
+    caller doesn't mistake an "infrastructure problem" for "no orphans".
+    Otherwise prints one line per released claim and returns 0.
+    """
+    live = _live_session_uuids(ctx)
+    if live is None:
+        sys.stderr.write(
+            "release-orphan-claims: cannot read .pod/agents/ — "
+            "refusing to release without liveness data\n")
+        return 1
+
+    client = gh.get_client()
+    r = client.gh_cli(
+        "issue", "list", "--repo", ctx.repo, "--label", "claimed",
+        "--state", "open", "--limit", "100", "--json", "number,title",
+        timeout=30,
+    )
+    if r.returncode != 0:
+        sys.stderr.write(f"release-orphan-claims: gh issue list failed: "
+                         f"{r.stderr.strip()}\n")
+        return 1
+    issues = _safe_json(r.stdout, default=[]) or []
+
+    claim_re = re.compile(r'Claimed by session `([^`]+)`')
+    released = 0
+    for it in issues:
+        num = it.get("number")
+        title = it.get("title", "") or ""
+        if not isinstance(num, int):
+            continue
+        cr = client.gh_cli(
+            "issue", "view", str(num), "--repo", ctx.repo,
+            "--json", "comments",
+            "--jq",
+            '[.comments[] | select(.body | startswith("Claimed by session"))] '
+            '| sort_by(.createdAt) | last | .body // ""',
+            timeout=30,
+        )
+        body = cr.stdout.strip().strip('"') if cr.returncode == 0 else ""
+        if not body:
+            # No parseable claim comment — leave for age-based sweep.
+            continue
+        m = claim_re.search(body)
+        if not m:
+            continue
+        owner_uuid = m.group(1)
+        if owner_uuid in live:
+            continue  # owner alive — keep
+
+        # Owner not in live set → release.
+        e1 = client.gh_cli("issue", "edit", str(num), "--repo", ctx.repo,
+                            "--remove-label", "claimed", timeout=15)
+        if e1.returncode != 0:
+            sys.stderr.write(f"#{num}: label remove failed: "
+                             f"{e1.stderr.strip()}\n")
+            continue
+        client.gh_cli(
+            "issue", "comment", str(num), "--repo", ctx.repo,
+            "--body",
+            f"Orphan claim released — owning session `{owner_uuid}` is "
+            f"no longer in the local agent table. Available for reclaim.",
+            timeout=30,
+        )
+        print(f"Released orphan claim on #{num} ({title}, owner {owner_uuid[:8]})")
+        released += 1
+    if released == 0:
+        print("No orphan claims found.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Lock family
 # ---------------------------------------------------------------------------
 
@@ -1916,6 +2030,7 @@ _COMMANDS = {
     "check-blocked": cmd_check_blocked,
     "check-has-pr": cmd_check_has_pr,
     "release-stale-claims": cmd_release_stale_claims,
+    "release-orphan-claims": cmd_release_orphan_claims,
     "lock-planner": cmd_lock_planner,
     "unlock-planner": cmd_unlock_planner,
     "lock-status": cmd_lock_status,
@@ -1936,7 +2051,7 @@ _USAGE = (
     "close-pr|list-pr-repair|claim-pr-repair|mark-pr-salvaged|"
     "close-pr-unsalvageable|list-unclaimed [--label L]|queue-depth [L]|"
     "critical-path-depth|claim|skip|add-dep|check-blocked|check-has-pr|"
-    "release-stale-claims|lock-planner|unlock-planner|lock-status|"
+    "release-stale-claims|release-orphan-claims|lock-planner|unlock-planner|lock-status|"
     "force-unlock-planner|return-to-human|check-return-to-human|"
     "clear-return-to-human|nothing-to-plan|set-target|set-min-queue|"
     "read-issue}"

--- a/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
@@ -30,6 +30,7 @@ The `gh` CLI defaults to the current repo, so `--repo` is not needed.
 | `coordination check-blocked` | Unblock issues whose `depends-on` dependencies are all closed; remove orphan `blocked` from issues whose body has no `depends-on:` lines |
 | `coordination check-has-pr` | Remove orphan `has-pr` from open issues that have no currently-open PR closing them (post audit comment) |
 | `coordination release-stale-claims [SECS]` | Release claimed issues with no PR after SECS seconds (default 4h); **manual use only** |
+| `coordination release-orphan-claims` | Release claims whose owning session UUID is no longer in `.pod/agents/` (liveness-based, no age threshold); **manual use only** |
 | `coordination lock-planner` | Acquire advisory planner lock (20min TTL) |
 | `coordination unlock-planner` | Release planner lock early |
 | `coordination critical-path-depth [L]` | Count unclaimed critical-path issues; optional label filter |

--- a/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
@@ -29,6 +29,7 @@ The `gh` CLI defaults to the current repo, so `--repo` is not needed.
 | `coordination add-dep N M` | Add `depends-on: #M` to issue #N's body; adds `blocked` label if #M is open |
 | `coordination check-blocked` | Unblock issues whose `depends-on` dependencies are all closed |
 | `coordination release-stale-claims [SECS]` | Release claimed issues with no PR after SECS seconds (default 4h); **manual use only** |
+| `coordination release-orphan-claims` | Release claims whose owning session UUID is no longer in `.pod/agents/` (liveness-based, no age threshold); **manual use only** |
 | `coordination lock-planner` | Acquire advisory planner lock (20min TTL) |
 | `coordination unlock-planner` | Release planner lock early |
 | `coordination critical-path-depth [L]` | Count unclaimed critical-path issues; optional label filter |

--- a/tests/test_burners.py
+++ b/tests/test_burners.py
@@ -115,9 +115,9 @@ class ReconcileBatchTests(unittest.TestCase):
         self.assertIn(("issue", "comment", "42"), verbs)
 
     def test_grace_period_skips_fresh_claim(self):
-        # 60 seconds old < 600s grace period.
+        # 30 seconds old < 60s grace period.
         node = _claim_node(42, comments=[
-            _claim_comment("dead-uuid", "abcd1234", _iso(seconds_ago=60)),
+            _claim_comment("dead-uuid", "abcd1234", _iso(seconds_ago=30)),
         ])
         with patch_client(routes={
             ("POST", "/graphql"): self._gql_response(node),

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -731,6 +731,108 @@ class CreatePrProtectedFilesTests(unittest.TestCase):
 # Dispatch / main
 # ---------------------------------------------------------------------------
 
+class ReleaseOrphanClaimsTests(unittest.TestCase):
+    """Liveness-based orphan-claim sweep — releases claims whose owning
+    session UUID is no longer in `.pod/agents/`, regardless of age."""
+
+    def _ctx_with_agents(self, tmp: Path, live_uuids: list[str]) -> coordination.CoordinationContext:
+        (tmp / ".pod" / "agents").mkdir(parents=True)
+        for i, u in enumerate(live_uuids):
+            (tmp / ".pod" / "agents" / f"agent{i}.json").write_text(json.dumps({
+                "short_id": f"abcd{i}",
+                "uuid": u,
+                "status": "running",
+                "pid": os.getpid(),
+            }))
+        ctx = _make_ctx()
+        ctx.git_toplevel = str(tmp)
+        return ctx
+
+    def test_releases_when_owner_not_in_local_agents(self):
+        with tempfile.TemporaryDirectory() as td:
+            ctx = self._ctx_with_agents(Path(td), live_uuids=["live-uuid"])
+            calls = []
+            def fake_run(*argv, **kw):
+                calls.append(argv)
+                if argv[:2] == ("issue", "list"):
+                    return _gh_result(stdout=json.dumps([
+                        {"number": 42, "title": "orphan"},
+                    ]))
+                if argv[:2] == ("issue", "view"):
+                    return _gh_result(stdout=json.dumps(
+                        "Claimed by session `dead-uuid` on branch `agent/x`"))
+                return _gh_result()
+            with patch_client(gh_cli_handler=fake_run), _capture_stdout() as out:
+                rc = coordination.cmd_release_orphan_claims(ctx, [])
+            self.assertEqual(rc, 0)
+            # Saw label-remove + comment for the orphan.
+            verbs = [(c[0], c[1], c[2]) for c in calls
+                     if len(c) >= 3 and c[0] == "issue"]
+            self.assertIn(("issue", "edit", "42"), verbs)
+            self.assertIn(("issue", "comment", "42"), verbs)
+            self.assertIn("orphan", out.getvalue().lower())
+
+    def test_skips_when_owner_still_in_local_agents(self):
+        with tempfile.TemporaryDirectory() as td:
+            ctx = self._ctx_with_agents(Path(td), live_uuids=["live-uuid"])
+            calls = []
+            def fake_run(*argv, **kw):
+                calls.append(argv)
+                if argv[:2] == ("issue", "list"):
+                    return _gh_result(stdout=json.dumps([
+                        {"number": 42, "title": "still-claimed"},
+                    ]))
+                if argv[:2] == ("issue", "view"):
+                    return _gh_result(stdout=json.dumps(
+                        "Claimed by session `live-uuid` on branch `agent/x`"))
+                return _gh_result()
+            with patch_client(gh_cli_handler=fake_run), _capture_stdout():
+                rc = coordination.cmd_release_orphan_claims(ctx, [])
+            self.assertEqual(rc, 0)
+            verbs = [(c[0], c[1], c[2]) for c in calls
+                     if len(c) >= 3 and c[0] == "issue"]
+            self.assertNotIn(("issue", "edit", "42"), verbs)
+            self.assertNotIn(("issue", "comment", "42"), verbs)
+
+    def test_skips_dead_status_agents(self):
+        # Agents marked dead/stopped/killed are not considered live owners.
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / ".pod" / "agents").mkdir(parents=True)
+            (Path(td) / ".pod" / "agents" / "a.json").write_text(json.dumps({
+                "short_id": "abcd0", "uuid": "ghost-uuid",
+                "status": "dead", "pid": 0,
+            }))
+            ctx = _make_ctx()
+            ctx.git_toplevel = td
+            calls = []
+            def fake_run(*argv, **kw):
+                calls.append(argv)
+                if argv[:2] == ("issue", "list"):
+                    return _gh_result(stdout=json.dumps([
+                        {"number": 7, "title": "orphan"},
+                    ]))
+                if argv[:2] == ("issue", "view"):
+                    return _gh_result(stdout=json.dumps(
+                        "Claimed by session `ghost-uuid` on branch `agent/x`"))
+                return _gh_result()
+            with patch_client(gh_cli_handler=fake_run), _capture_stdout():
+                rc = coordination.cmd_release_orphan_claims(ctx, [])
+            self.assertEqual(rc, 0)
+            verbs = [(c[0], c[1], c[2]) for c in calls
+                     if len(c) >= 3 and c[0] == "issue"]
+            self.assertIn(("issue", "edit", "7"), verbs)
+
+    def test_refuses_without_agents_directory(self):
+        # No `.pod/agents/` → can't make a liveness decision → exit 1.
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _make_ctx()
+            ctx.git_toplevel = td
+            with patch_client():
+                with contextlib.redirect_stderr(io.StringIO()):
+                    rc = coordination.cmd_release_orphan_claims(ctx, [])
+            self.assertEqual(rc, 1)
+
+
 class DispatchTests(unittest.TestCase):
     def test_unknown_command_dies(self):
         with mock.patch.object(coordination, "_ensure_auth"):


### PR DESCRIPTION
This PR fixes a root-cause bug where the quota-exhaustion path in `agent_process_main` leaks GitHub `claimed` labels as orphans, and adds a liveness-based sweep that detects and fixes orphans regardless of how they arose.

Observed on a live hex pod today: one quota-exhaustion event silently leaked 5 orphan `claimed` labels. Local history showed `released:True`, GitHub still had the label, and neither `check_dead_claimed_issues` (which skips `released:True` entries) nor `reconcile_untracked_github_claims` (which is gated by housekeeping interval × 10-min grace, and silently does nothing under the GraphQL exhaustion that typically *co-occurs* with quota events) recovered them. The queue stalled — six work slots fought over three live claims while six dead claims blocked everything else in the unclaimed pool.

The fix has three parts:

- **Root cause**: the quota-exhaustion handler called `clear_claim` (local-history-only) instead of `_release_claim` (which actually removes the GitHub label). After the session UUID gets rotated on next dispatch, no live agent owns the GitHub claim anymore. Switched to `_release_claim` with a quota-specific comment; on transient GitHub failure the history entry is left intact so the next reconcile retries.
- **Shorter grace**: the `reconcile_untracked_github_claims` grace dropped from 600s → 60s. The grace exists to cover the window between `Claimed by session` comment and local history write; 60s is plenty. Combined with the 10-min housekeeping cadence, this caps orphan dwell time at ~11 minutes instead of ~20.
- **On-demand sweep**: a new `coordination release-orphan-claims` subcommand reads `.pod/agents/*.json` to derive live session UUIDs, scans GitHub for `claimed`-labelled issues, and releases any whose owning UUID isn't in the live set — no age threshold, no grace. Refuses to act when `.pod/agents/` is unreadable so an infrastructure issue doesn't get misread as \"no orphans\".

Tests cover all four orphan-sweep paths (release, skip-live, skip-dead-status, refuse-no-agents-dir) and the burner reconcile-grace test is tightened to 30s for the new threshold. 285/285 pass.

🤖 Prepared with Claude Code