### PR TITLE
fix: clear blocked label when depends-on target is a merged PR

### DIFF
--- a/pod/coordination.py
+++ b/pod/coordination.py
@@ -1530,8 +1530,10 @@ def cmd_check_blocked(ctx: CoordinationContext, argv: list[str]) -> int:
                 "issue", "view", str(d), "--repo", ctx.repo,
                 "--json", "state", "--jq", ".state", timeout=15,
             )
+            # PRs share the issue number space; `gh issue view` on a merged
+            # PR returns "MERGED", not "CLOSED". Both count as terminal.
             state = sr.stdout.strip() if sr.returncode == 0 else "UNKNOWN"
-            if state != "CLOSED":
+            if state not in ("CLOSED", "MERGED"):
                 all_closed = False
                 break
         if all_closed:

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -676,6 +676,53 @@ class CheckBlockedTests(unittest.TestCase):
         self.assertIn("Unblocked issue #10", buf.getvalue())
         self.assertIn("--remove-label", edits[0])
 
+    def test_unblocks_when_dep_is_merged_pr(self):
+        # PRs share the issue number space; `gh issue view` on a merged PR
+        # returns "MERGED" not "CLOSED". The label must still be cleared.
+        edits = []
+
+        def handler(*argv):
+            if argv[:2] == ("issue", "list"):
+                return _gh_result(stdout=json.dumps([{
+                    "number": 10,
+                    "body": "depends-on: #5",
+                }]))
+            if argv[:2] == ("issue", "view") and "state" in argv:
+                return _gh_result(stdout="MERGED")
+            if argv[:2] == ("issue", "edit"):
+                edits.append(argv)
+                return _gh_result()
+            return _gh_result()
+
+        with _capture_stdout() as buf, patch_client(gh_cli_handler=handler):
+            rc = coordination.cmd_check_blocked(_make_ctx(), [])
+        self.assertEqual(rc, 0)
+        self.assertIn("Unblocked issue #10", buf.getvalue())
+        self.assertIn("--remove-label", edits[0])
+
+    def test_keeps_blocked_when_dep_state_unknown(self):
+        # A failed `gh issue view` (UNKNOWN state) must not strip the label —
+        # transient gh errors shouldn't silently unblock.
+        edits = []
+
+        def handler(*argv):
+            if argv[:2] == ("issue", "list"):
+                return _gh_result(stdout=json.dumps([{
+                    "number": 10,
+                    "body": "depends-on: #5",
+                }]))
+            if argv[:2] == ("issue", "view") and "state" in argv:
+                return _gh_result(returncode=1, stdout="")
+            if argv[:2] == ("issue", "edit"):
+                edits.append(argv)
+                return _gh_result()
+            return _gh_result()
+
+        with _capture_stdout(), patch_client(gh_cli_handler=handler):
+            rc = coordination.cmd_check_blocked(_make_ctx(), [])
+        self.assertEqual(rc, 0)
+        self.assertEqual(edits, [])
+
     def test_keeps_blocked_when_dep_still_open(self):
         edits = []
 


### PR DESCRIPTION
This PR fixes a stale-label bug in `coordination check-blocked`: the
housekeeping pass that auto-clears the `blocked` label once an issue's
`depends-on:` targets are all resolved was treating a merged PR as if
it were still blocking, leaving issues pinned as `blocked` forever.

`cmd_check_blocked` walked each `depends-on: #N` reference and called
`gh issue view N` to read its state. PRs share the issue number space,
so this works for both — but a merged PR returns `"MERGED"`, not
`"CLOSED"`. The check `if state != "CLOSED"` then short-circuited and
the label was never removed. Symptom in the TUI: the issue rendered
with the `blocked` state badge but the tree-render code from #52
couldn't find an open parent to indent it under, so it floated as a
root row with no `[Blocked on …]` annotation. Concrete instance:
[kim-em/hex#3220](https://github.com/kim-em/hex/issues/3220), whose
deps `#3202` (merged PR) and `#3219` (closed issue) are both terminal.

Accept `"MERGED"` alongside `"CLOSED"`. `"UNKNOWN"` (fetch failed)
still counts as blocking so a transient `gh` error can't silently
strip the label. Two regression tests cover the merged-PR case and
the UNKNOWN-state case.

🤖 Prepared with Claude Code