### PR TITLE
fix: stop draining GraphQL bucket via per-issue provenance fetches

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -3172,7 +3172,10 @@ class _IssueProvenance:
     fetched_at: float
 
 
-# Cache: {(repo, issue_num): _IssueProvenance}.
+# In-process cache: {(repo, issue_num): _IssueProvenance}. Kept for the
+# rare case of repeated checks inside one subprocess (e.g. CLI helpers
+# that read several issues). The cross-process tier below is what
+# actually keeps the GraphQL bucket from draining.
 _provenance_cache: dict[tuple[str, int], _IssueProvenance] = {}
 
 
@@ -3181,13 +3184,134 @@ def _provenance_ttl(config: dict) -> float:
     return float(sec.get("provenance_cache_seconds", 60))
 
 
+class _ProvenanceDiskCache:
+    """Cross-process TTL'd cache for issue provenance.
+
+    `cmd_filter_trusted_issues` runs as a fresh subprocess per
+    `coordination orient` / `list-unclaimed` tick, so an in-process
+    cache can't help across invocations. Each agent worktree ticks
+    independently, so with N agents and M open agent-plan issues the
+    naive cost is N*M GraphQL POSTs per tick. GitHub does not honor
+    `If-None-Match` on `/graphql` POSTs (field data: zero 304s out of
+    ~14k POSTs), so the layer's ETag store can't help either.
+
+    This is a plain on-disk value cache: one JSON file per
+    (repo, issue_num), keyed by sha256 of those fields so we don't
+    collide across repos. Atomic writes via tmp+rename. TTL is read
+    from `security.provenance_cache_seconds` (default 60s).
+    """
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    @staticmethod
+    def _key(repo: str, issue_num: int) -> str:
+        return hashlib.sha256(f"{repo}#{issue_num}".encode()).hexdigest()
+
+    def _path_for(self, repo: str, issue_num: int) -> Path:
+        return self.root / f"{self._key(repo, issue_num)}.json"
+
+    def get(self, repo: str, issue_num: int,
+            ttl: float) -> _IssueProvenance | None:
+        p = self._path_for(repo, issue_num)
+        try:
+            raw = p.read_text()
+        except (OSError, FileNotFoundError):
+            return None
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        fetched_at = float(data.get("fetched_at", 0.0))
+        if (time.time() - fetched_at) >= ttl:
+            return None
+        try:
+            comments = [
+                _ProvenanceComment(
+                    comment_id=int(c["comment_id"]),
+                    login=str(c.get("login", "")),
+                    association=str(c.get("association", "NONE")),
+                )
+                for c in (data.get("comments") or [])
+            ]
+            return _IssueProvenance(
+                repo=str(data["repo"]),
+                issue_num=int(data["issue_num"]),
+                author_login=str(data.get("author_login", "")),
+                author_association=str(
+                    data.get("author_association", "NONE")),
+                comments=comments,
+                fetched_at=fetched_at,
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def put(self, prov: _IssueProvenance) -> None:
+        try:
+            self.root.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return
+        payload = {
+            "repo": prov.repo,
+            "issue_num": prov.issue_num,
+            "author_login": prov.author_login,
+            "author_association": prov.author_association,
+            "comments": [
+                {"comment_id": c.comment_id, "login": c.login,
+                 "association": c.association}
+                for c in prov.comments
+            ],
+            "fetched_at": prov.fetched_at,
+        }
+        p = self._path_for(prov.repo, prov.issue_num)
+        tmp = p.with_suffix(".tmp")
+        try:
+            tmp.write_text(json.dumps(payload, separators=(",", ":")))
+            os.chmod(tmp, 0o600)
+            tmp.replace(p)
+        except OSError:
+            pass
+
+    def invalidate(self, repo: str, issue_num: int) -> None:
+        p = self._path_for(repo, issue_num)
+        try:
+            p.unlink()
+        except (OSError, FileNotFoundError):
+            pass
+
+
+_PROVENANCE_DISK_CACHE: _ProvenanceDiskCache | None = None
+
+
+def _provenance_disk_cache() -> _ProvenanceDiskCache:
+    global _PROVENANCE_DISK_CACHE
+    if _PROVENANCE_DISK_CACHE is None:
+        _PROVENANCE_DISK_CACHE = _ProvenanceDiskCache(
+            POD_DIR / "provenance-cache")
+    return _PROVENANCE_DISK_CACHE
+
+
+# Per-process memoisation. The current repo can't change inside one
+# subprocess, so caching the visibility verdict for the lifetime of the
+# process turns ~3 redundant calls per tick into 1. We still re-check
+# in fresh subprocesses, so a maintainer flipping the repo to private
+# is picked up on the next tick (~seconds, not minutes).
+_REPO_PUBLIC_MEMO: dict[str, bool] = {}
+
+
 def _is_repo_public(config: dict) -> bool:
     """Return True iff the current repo is public. Routed through the
-    layer (ETag-cached); fails closed by treating ambiguous results as
-    public so the security gate still runs.
+    layer (ETag-cached on the REST side); fails closed by treating
+    ambiguous results as public so the security gate still runs.
+
+    Memoised per process: three call sites used to fire on every tick;
+    they now share one round-trip.
     """
+    slug = _get_repo()
+    if slug in _REPO_PUBLIC_MEMO:
+        return _REPO_PUBLIC_MEMO[slug]
     try:
-        resp = gh.get_client().get(f"/repos/{_get_repo()}", timeout=15)
+        resp = gh.get_client().get(f"/repos/{slug}", timeout=15)
     except Exception:
         return True  # fail-closed: treat as public so we still check
     if not resp.ok():
@@ -3195,69 +3319,19 @@ def _is_repo_public(config: dict) -> bool:
     visibility = ((resp.body() or {}).get("visibility") or "").lower()
     if not visibility:
         return True
-    return visibility == "public"
+    result = visibility == "public"
+    _REPO_PUBLIC_MEMO[slug] = result
+    return result
 
 
-_PROVENANCE_QUERY = """
-query Provenance($owner: String!, $name: String!, $num: Int!) {
-  repository(owner: $owner, name: $name) {
-    issue(number: $num) {
-      author { login }
-      authorAssociation
-      comments(first: 100) {
-        nodes {
-          databaseId
-          author { login }
-          authorAssociation
-        }
-        pageInfo { hasNextPage endCursor }
-      }
-    }
-  }
-}
-"""
+def _parse_provenance_node(repo: str, issue_num: int,
+                            issue_node: dict) -> tuple[
+                                _IssueProvenance, bool]:
+    """Pull `_IssueProvenance` out of one GraphQL `issue` node.
 
-
-def fetch_issue_provenance(repo: str, issue_num: int) -> _IssueProvenance:
-    """Fetch the issue + its comments and bundle author/association data.
-
-    Burner-rewrite (B4): one GraphQL query returns issue author +
-    authorAssociation and the first 100 comments (with author +
-    association) in a single round-trip. Falls back to the REST path
-    for the rare case of >100 comments on a single agent-plan issue.
-    Raises RuntimeError on layer failure so callers can surface a
-    clear error.
-
-    ETag-cached: `cmd_filter_trusted_issues` runs as a fresh subprocess
-    per `coordination orient` / `list-unclaimed` tick, so the in-process
-    `_provenance_cache` doesn't help across invocations. The layer's
-    ETag store, on the other hand, lives on disk and is keyed by the
-    GraphQL request body (which includes `issue_num`), so a repeat
-    fetch of an unchanged issue serves a 304 that doesn't count against
-    the GraphQL bucket. This is the dominant GraphQL burner pre-fix.
+    Returns `(prov, has_next_page)`. The caller is responsible for
+    paginating remaining comments via REST when `has_next_page` is True.
     """
-    client = gh.get_client()
-    owner, _, name = repo.partition("/")
-    if not (owner and name):
-        raise RuntimeError(f"unparseable repo slug: {repo!r}")
-
-    resp = client.graphql(_PROVENANCE_QUERY,
-                          variables={"owner": owner, "name": name,
-                                     "num": issue_num},
-                          cache="etag")
-    if not resp.ok():
-        raise RuntimeError(
-            f"failed to fetch provenance for {repo}#{issue_num}: "
-            f"HTTP {resp.status}")
-    body = resp.body() or {}
-    issue_node = (((body.get("data") or {}).get("repository") or {})
-                  .get("issue") or {})
-    if not issue_node:
-        # GraphQL "errors" payload, or issue not found.
-        raise RuntimeError(
-            f"failed to fetch provenance for {repo}#{issue_num}: "
-            "GraphQL returned no issue node")
-
     author = (issue_node.get("author") or {}).get("login") or ""
     author_assoc = issue_node.get("authorAssociation") or "NONE"
 
@@ -3276,36 +3350,6 @@ def fetch_issue_provenance(repo: str, issue_num: int) -> _IssueProvenance:
         comments.append(_ProvenanceComment(
             comment_id=int(cid), login=login, association=assoc))
 
-    # Rare edge case: >100 comments. Fall back to the REST paginate path
-    # so we don't silently miss an untrusted commenter past the 100th
-    # row. This costs one extra page request via httpx.
-    if has_next:
-        for page in client.paginate(
-                f"/repos/{repo}/issues/{issue_num}/comments",
-                max_pages=20):
-            if not page.ok():
-                raise RuntimeError(
-                    f"failed to page comments for {repo}#{issue_num}: "
-                    f"HTTP {page.status}")
-            page_body = page.body() or []
-            if not isinstance(page_body, list):
-                continue
-            # The GraphQL first page already covered the first 100.
-            # The REST endpoint orders by created_at ascending (oldest
-            # first), so we re-extract everything here and deduplicate
-            # by id rather than guessing pagination cursors.
-            for rc in page_body:
-                if not isinstance(rc, dict):
-                    continue
-                rid = int(rc.get("id") or 0)
-                if not rid or any(c.comment_id == rid for c in comments):
-                    continue
-                comments.append(_ProvenanceComment(
-                    comment_id=rid,
-                    login=(rc.get("user") or {}).get("login", "") or "",
-                    association=rc.get("author_association", "NONE") or "NONE",
-                ))
-
     return _IssueProvenance(
         repo=repo,
         issue_num=issue_num,
@@ -3313,7 +3357,129 @@ def fetch_issue_provenance(repo: str, issue_num: int) -> _IssueProvenance:
         author_association=author_assoc,
         comments=comments,
         fetched_at=time.time(),
+    ), has_next
+
+
+def _paginate_comments_into(prov: _IssueProvenance) -> None:
+    """Append comments past the first 100 to `prov` via REST. Used as
+    the rare-case tail for issues with >100 comments. Mutates `prov`."""
+    client = gh.get_client()
+    for page in client.paginate(
+            f"/repos/{prov.repo}/issues/{prov.issue_num}/comments",
+            max_pages=20):
+        if not page.ok():
+            raise RuntimeError(
+                f"failed to page comments for "
+                f"{prov.repo}#{prov.issue_num}: HTTP {page.status}")
+        page_body = page.body() or []
+        if not isinstance(page_body, list):
+            continue
+        for rc in page_body:
+            if not isinstance(rc, dict):
+                continue
+            rid = int(rc.get("id") or 0)
+            if not rid or any(c.comment_id == rid for c in prov.comments):
+                continue
+            prov.comments.append(_ProvenanceComment(
+                comment_id=rid,
+                login=(rc.get("user") or {}).get("login", "") or "",
+                association=rc.get("author_association", "NONE") or "NONE",
+            ))
+
+
+# Cap on aliases per batched GraphQL query. GitHub's documented
+# limits allow much more (node-count caps in the thousands), but
+# response size grows with comment counts, so we keep batches modest.
+_PROVENANCE_BATCH_SIZE = 25
+
+
+def _build_provenance_batch_query(count: int) -> str:
+    """Build a single GraphQL query with `count` aliased `issue(...)`
+    selections. Each alias `i{k}` uses `$num{k}: Int!`."""
+    aliases = "\n".join(
+        f"    i{k}: issue(number: $num{k}) {{\n"
+        f"      author {{ login }}\n"
+        f"      authorAssociation\n"
+        f"      comments(first: 100) {{\n"
+        f"        nodes {{\n"
+        f"          databaseId\n"
+        f"          author {{ login }}\n"
+        f"          authorAssociation\n"
+        f"        }}\n"
+        f"        pageInfo {{ hasNextPage endCursor }}\n"
+        f"      }}\n"
+        f"    }}"
+        for k in range(count)
     )
+    var_decls = ", ".join(f"$num{k}: Int!" for k in range(count))
+    return (
+        f"query ProvenanceBatch($owner: String!, $name: String!, "
+        f"{var_decls}) {{\n"
+        f"  repository(owner: $owner, name: $name) {{\n"
+        f"{aliases}\n"
+        f"  }}\n"
+        f"}}\n"
+    )
+
+
+def fetch_issue_provenances(repo: str,
+                             issue_nums: list[int]
+                             ) -> dict[int, _IssueProvenance]:
+    """Fetch provenance for multiple issues with a single batched
+    GraphQL request per chunk of `_PROVENANCE_BATCH_SIZE` issues.
+
+    Returns a `{issue_num: _IssueProvenance}` dict. Missing or
+    inaccessible issues are simply absent from the result; callers
+    treat absence as a fetch failure (fails-closed via
+    `check_issue_provenance`).
+
+    Does not consult the disk cache itself — callers (i.e.
+    `_cached_provenance`) are expected to filter cached issues out
+    before calling here.
+    """
+    client = gh.get_client()
+    owner, _, name = repo.partition("/")
+    if not (owner and name):
+        raise RuntimeError(f"unparseable repo slug: {repo!r}")
+
+    out: dict[int, _IssueProvenance] = {}
+    nums = list(dict.fromkeys(int(n) for n in issue_nums))  # dedup, ordered
+    for start in range(0, len(nums), _PROVENANCE_BATCH_SIZE):
+        chunk = nums[start:start + _PROVENANCE_BATCH_SIZE]
+        query = _build_provenance_batch_query(len(chunk))
+        variables: dict = {"owner": owner, "name": name}
+        for k, n in enumerate(chunk):
+            variables[f"num{k}"] = n
+        resp = client.graphql(query, variables=variables, cache="none")
+        if not resp.ok():
+            raise RuntimeError(
+                f"failed to fetch batched provenance for {repo}: "
+                f"HTTP {resp.status}")
+        body = resp.body() or {}
+        repo_node = (body.get("data") or {}).get("repository") or {}
+        for k, n in enumerate(chunk):
+            issue_node = repo_node.get(f"i{k}")
+            if not issue_node:
+                continue
+            prov, has_next = _parse_provenance_node(repo, n, issue_node)
+            if has_next:
+                _paginate_comments_into(prov)
+            out[n] = prov
+    return out
+
+
+def fetch_issue_provenance(repo: str, issue_num: int) -> _IssueProvenance:
+    """Single-issue fetch. Thin wrapper around the batched fetcher so
+    the parsing + REST tail-paginate code is shared.
+
+    Raises `RuntimeError` on layer failure or missing issue node.
+    """
+    got = fetch_issue_provenances(repo, [issue_num])
+    if issue_num not in got:
+        raise RuntimeError(
+            f"failed to fetch provenance for {repo}#{issue_num}: "
+            "GraphQL returned no issue node")
+    return got[issue_num]
 
 
 def is_trusted(provenance: _IssueProvenance, config: dict) -> tuple[bool, str]:
@@ -3345,17 +3511,67 @@ def is_trusted(provenance: _IssueProvenance, config: dict) -> tuple[bool, str]:
 
 def _cached_provenance(repo: str, issue_num: int, config: dict,
                         *, fresh: bool) -> _IssueProvenance:
-    """Shared cache entry point. `fresh=True` invalidates and re-fetches."""
+    """Shared cache entry point. Consults in-process first, then the
+    cross-process disk cache. `fresh=True` invalidates both tiers and
+    forces a refetch."""
     key = (repo, issue_num)
+    ttl = _provenance_ttl(config)
+    disk = _provenance_disk_cache()
     if fresh:
         _provenance_cache.pop(key, None)
+        disk.invalidate(repo, issue_num)
     else:
         cached = _provenance_cache.get(key)
-        if cached and (time.time() - cached.fetched_at) < _provenance_ttl(config):
+        if cached and (time.time() - cached.fetched_at) < ttl:
             return cached
+        on_disk = disk.get(repo, issue_num, ttl)
+        if on_disk is not None:
+            _provenance_cache[key] = on_disk
+            return on_disk
     prov = fetch_issue_provenance(repo, issue_num)
     _provenance_cache[key] = prov
+    disk.put(prov)
     return prov
+
+
+def _cached_provenances(repo: str, issue_nums: list[int], config: dict,
+                         *, fresh: bool) -> dict[int, _IssueProvenance]:
+    """Batched cache entry point. For each requested issue, return a
+    cached entry if available within TTL; otherwise group the misses
+    into one batched GraphQL fetch.
+
+    Returns `{issue_num: _IssueProvenance}`. Issues that couldn't be
+    fetched (e.g. deleted, transferred) are absent from the result, so
+    callers must treat absence as a fetch failure.
+    """
+    ttl = _provenance_ttl(config)
+    disk = _provenance_disk_cache()
+    out: dict[int, _IssueProvenance] = {}
+    misses: list[int] = []
+    for n in issue_nums:
+        key = (repo, n)
+        if fresh:
+            _provenance_cache.pop(key, None)
+            disk.invalidate(repo, n)
+            misses.append(n)
+            continue
+        cached = _provenance_cache.get(key)
+        if cached and (time.time() - cached.fetched_at) < ttl:
+            out[n] = cached
+            continue
+        on_disk = disk.get(repo, n, ttl)
+        if on_disk is not None:
+            _provenance_cache[key] = on_disk
+            out[n] = on_disk
+            continue
+        misses.append(n)
+    if misses:
+        fetched = fetch_issue_provenances(repo, misses)
+        for n, prov in fetched.items():
+            _provenance_cache[(repo, n)] = prov
+            disk.put(prov)
+            out[n] = prov
+    return out
 
 
 def check_issue_provenance(repo: str, issue_num: int, config: dict,
@@ -3432,11 +3648,28 @@ def cmd_filter_trusted_issues(config: dict, args) -> None:
     if not (sec_enabled and repo_public):
         filtered = items
     else:
+        # Batch the provenance fetch for every candidate issue in one
+        # GraphQL round-trip (with disk-cache hits short-circuiting
+        # before the network call). Previously this fired one POST per
+        # issue per tick per agent, draining the GraphQL bucket.
+        nums = [int(it.get("number", 0)) for it in items]
+        nums = [n for n in nums if n > 0]
+        try:
+            provs = _cached_provenances(repo, nums, config, fresh=False)
+        except RuntimeError as e:
+            print(f"pod: provenance batch failed: {e}", file=sys.stderr)
+            sys.exit(1)
         for it in items:
             num = int(it.get("number", 0))
             if num <= 0:
                 continue
-            ok, reason = check_issue_provenance(repo, num, config, fresh=False)
+            prov = provs.get(num)
+            if prov is None:
+                reason = (f"failed to fetch provenance for #{num}: "
+                          "no issue node")
+                ok = False
+            else:
+                ok, reason = is_trusted(prov, config)
             if ok:
                 filtered.append(it)
             elif args.include_untrusted:

--- a/pod/github.py
+++ b/pod/github.py
@@ -604,17 +604,15 @@ class GitHubClient:
                 _allow_retry: bool = True,
                 _caller: str | None = None) -> GHResponse:
         method = method.upper()
-        # ETag conditional requests apply to GET/HEAD by spec, plus
-        # POST `/graphql` as a special case: GitHub honors
-        # `If-None-Match` on GraphQL POST queries, and a 304 response
-        # does not consume the primary GraphQL budget. The cache key
-        # incorporates a body hash so distinct queries get distinct
-        # entries (see `_ETagStore.key_for`).
-        is_graphql_post = (method == "POST"
-                            and isinstance(path_or_url, str)
-                            and path_or_url.endswith("/graphql"))
-        cacheable = cache == "etag" and (
-            method in ("GET", "HEAD") or is_graphql_post)
+        # ETag conditional requests are only useful on GET/HEAD. We
+        # used to also send `If-None-Match` on POST `/graphql` on the
+        # belief that GitHub returns 304 for unchanged queries, but
+        # field data (zero 304s out of ~14k GraphQL POSTs over four
+        # hours) shows the server ignores the header and bills every
+        # POST against the GraphQL bucket. The body-keyed value cache
+        # in cli.py (`_ProvenanceDiskCache`) is what actually keeps
+        # provenance fetches off the wire.
+        cacheable = cache == "etag" and method in ("GET", "HEAD")
 
         if path_or_url.startswith("http"):
             url = path_or_url

--- a/tests/test_burners.py
+++ b/tests/test_burners.py
@@ -160,11 +160,28 @@ class ReconcileBatchTests(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class ProvenanceBurnerTests(unittest.TestCase):
+    def setUp(self):
+        # Disk provenance cache leaks across tests (and from real pod
+        # runs in the cwd), so redirect it to a tempdir per test.
+        cli._provenance_cache.clear()
+        self._cache_tmp = tempfile.TemporaryDirectory()
+        self._disk_patch = mock.patch.object(
+            cli, "_PROVENANCE_DISK_CACHE",
+            cli._ProvenanceDiskCache(Path(self._cache_tmp.name)))
+        self._disk_patch.start()
+
+    def tearDown(self):
+        self._disk_patch.stop()
+        self._cache_tmp.cleanup()
+
     def _gql_response(self, *, author="alice",
                        author_assoc="OWNER",
                        comments=(),
-                       has_next=False):
-        body = {"data": {"repository": {"issue": {
+                       has_next=False,
+                       alias="i0"):
+        # The batched provenance query returns aliased nodes (i0, i1,
+        # ...) instead of `issue`. Single-issue fetches use alias `i0`.
+        body = {"data": {"repository": {alias: {
             "author": {"login": author},
             "authorAssociation": author_assoc,
             "comments": {
@@ -211,74 +228,80 @@ class ProvenanceBurnerTests(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 cli.fetch_issue_provenance("o/r", 42)
 
-    def test_etag_cached_repeat_serves_304(self):
-        """A repeat provenance fetch for the same issue must serve a
-        304 from the layer's ETag cache rather than burning a fresh
-        GraphQL call. This is the dominant GraphQL burner pre-fix —
-        `cmd_filter_trusted_issues` runs as a fresh subprocess per
-        `coordination orient` tick, so the in-process
-        `_provenance_cache` doesn't deduplicate across invocations.
-        The on-disk ETag cache does.
+    def test_disk_cache_short_circuits_repeat_fetch(self):
+        """A repeat `check_issue_provenance` for the same issue inside
+        the TTL must serve from the disk cache instead of issuing
+        another GraphQL POST. This is what keeps the GraphQL bucket
+        alive across the fresh subprocesses that `coordination orient`
+        ticks spawn — GitHub does not honor `If-None-Match` on
+        `/graphql` POSTs, so the layer-level ETag store can't help.
         """
-        import httpx
-        from pod import github as gh
-        from pod.github import GitHubClient
+        with patch_client(routes={
+            ("POST", "/graphql"): self._gql_response(
+                author="alice", author_assoc="OWNER",
+                comments=[(1, "alice", "OWNER")],
+            ),
+        }) as client, mock.patch.object(cli, "_is_repo_public",
+                                          return_value=True):
+            ok1, _ = cli.check_issue_provenance("o/r", 42, {})
+            graphql_after_first = sum(
+                1 for c in client.calls
+                if c["method"] == "POST" and c["path"] == "/graphql")
+            # Drop the in-process cache so we exercise the disk tier
+            # (this is what a fresh subprocess would see).
+            cli._provenance_cache.clear()
+            ok2, _ = cli.check_issue_provenance("o/r", 42, {})
+            graphql_after_second = sum(
+                1 for c in client.calls
+                if c["method"] == "POST" and c["path"] == "/graphql")
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
+        self.assertEqual(graphql_after_first, 1)
+        self.assertEqual(graphql_after_second, 1,
+                          "second fetch should hit the disk cache, "
+                          "not issue another GraphQL POST")
 
-        seen_if_none_match: list[str | None] = []
-
-        def handler(req: httpx.Request) -> httpx.Response:
-            seen_if_none_match.append(req.headers.get("if-none-match"))
-            base_headers = {
-                "x-ratelimit-limit": "5000",
-                "x-ratelimit-remaining": "4999",
-                "x-ratelimit-reset": str(int(time.time()) + 3600),
-                "x-ratelimit-resource": "graphql",
-            }
-            if req.headers.get("if-none-match") == '"prov-v1"':
-                return httpx.Response(304, headers=base_headers)
-            body = {"data": {"repository": {"issue": {
+    def test_batched_fetch_issues_one_graphql_per_chunk(self):
+        """`fetch_issue_provenances([n1, n2, ...])` must issue one
+        GraphQL POST per chunk of `_PROVENANCE_BATCH_SIZE` issues —
+        not one POST per issue."""
+        # Build a batched response with aliased issue nodes for the
+        # three requested issues.
+        body = {"data": {"repository": {
+            "i0": {
                 "author": {"login": "alice"},
                 "authorAssociation": "OWNER",
-                "comments": {
-                    "nodes": [{"databaseId": 1,
-                                "author": {"login": "alice"},
-                                "authorAssociation": "OWNER"}],
-                    "pageInfo": {"hasNextPage": False, "endCursor": None},
-                },
-            }}}}
-            return httpx.Response(200, json=body,
-                                   headers={**base_headers,
-                                            "etag": '"prov-v1"'})
-
-        with tempfile.TemporaryDirectory() as td:
-            cache_dir = Path(td) / "gh-cache"
-            log_path = Path(td) / "gh-access.log"
-            client = GitHubClient(
-                host="github.com",
-                token="t-test",
-                cache_dir=cache_dir,
-                log_path=log_path,
-                transport=httpx.MockTransport(handler),
-                trim_cache_on_init=False,
-                rate_cap_hz=0,
-            )
-            try:
-                with mock.patch.object(gh, "get_client",
-                                        return_value=client):
-                    p1 = cli.fetch_issue_provenance("o/r", 42)
-                    p2 = cli.fetch_issue_provenance("o/r", 42)
-            finally:
-                client.close()
-
-        # First call had no If-None-Match (cold cache); second sent
-        # the stored etag.
-        self.assertEqual(seen_if_none_match, [None, '"prov-v1"'])
-        # Both calls must return semantically identical results; the
-        # 304-served second response uses the cached body.
-        self.assertEqual(p1.author_login, p2.author_login)
-        self.assertEqual(p1.author_association, p2.author_association)
-        self.assertEqual([c.comment_id for c in p1.comments],
-                         [c.comment_id for c in p2.comments])
+                "comments": {"nodes": [],
+                              "pageInfo": {"hasNextPage": False,
+                                            "endCursor": None}},
+            },
+            "i1": {
+                "author": {"login": "bob"},
+                "authorAssociation": "MEMBER",
+                "comments": {"nodes": [],
+                              "pageInfo": {"hasNextPage": False,
+                                            "endCursor": None}},
+            },
+            "i2": {
+                "author": {"login": "carol"},
+                "authorAssociation": "COLLABORATOR",
+                "comments": {"nodes": [],
+                              "pageInfo": {"hasNextPage": False,
+                                            "endCursor": None}},
+            },
+        }}}
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(200, body=body),
+        }) as client:
+            got = cli.fetch_issue_provenances("o/r", [10, 20, 30])
+        graphql_calls = [c for c in client.calls
+                          if c["method"] == "POST"
+                          and c["path"] == "/graphql"]
+        self.assertEqual(len(graphql_calls), 1)
+        self.assertEqual(set(got.keys()), {10, 20, 30})
+        self.assertEqual(got[10].author_login, "alice")
+        self.assertEqual(got[20].author_login, "bob")
+        self.assertEqual(got[30].author_login, "carol")
 
     def test_more_than_100_comments_falls_back_to_rest(self):
         # First page (GraphQL) has 100 comments AND hasNextPage=True.

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -314,18 +314,17 @@ class RateMeterTests(_Tmp):
         finally:
             c.close()
 
-    def test_graphql_post_with_cache_etag_round_trip(self):
-        """GitHub honors `If-None-Match` on GraphQL POST queries (and a
-        304 doesn't consume the primary GraphQL budget). The layer must
-        send the conditional header on a repeated identical query and
-        serve the cached body on 304."""
+    def test_graphql_post_never_sends_if_none_match(self):
+        """GitHub's GraphQL endpoint does not honor conditional
+        requests — field data showed zero 304s out of ~14k POSTs over
+        four hours, with every POST debited from the GraphQL bucket.
+        The layer therefore must not send `If-None-Match` on `/graphql`
+        even when the caller passes `cache="etag"`, and must not
+        persist the response in the ETag store."""
         seen_if_none_match: list[str | None] = []
 
         def h(req: httpx.Request) -> httpx.Response:
             seen_if_none_match.append(req.headers.get("if-none-match"))
-            if req.headers.get("if-none-match") == '"v1"':
-                return httpx.Response(
-                    304, headers=_rl_headers(resource="graphql"))
             return _resp(200,
                           json_body={"data": {"repository": {"x": 1}}},
                           etag='"v1"',
@@ -333,36 +332,14 @@ class RateMeterTests(_Tmp):
 
         c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
         try:
-            r1 = c.graphql("query Q { repository { x } }", cache="etag")
-            self.assertEqual(r1.status, 200)
-            self.assertFalse(r1.cache_hit)
-            r2 = c.graphql("query Q { repository { x } }", cache="etag")
-            self.assertEqual(r2.status, 304)
-            self.assertTrue(r2.cache_hit)
-            self.assertEqual(r2.body(),
-                              {"data": {"repository": {"x": 1}}})
+            c.graphql("query Q { repository { x } }", cache="etag")
+            c.graphql("query Q { repository { x } }", cache="etag")
         finally:
             c.close()
-        self.assertEqual(seen_if_none_match, [None, '"v1"'])
-
-    def test_graphql_body_in_cache_key(self):
-        """Two distinct GraphQL queries produce distinct cache
-        entries (cache key incorporates a body hash)."""
-        def h(req: httpx.Request) -> httpx.Response:
-            body = req.read().decode()
-            tag = '"vA"' if '"query A' in body else '"vB"'
-            return _resp(200, json_body={"q": body[:30]},
-                          etag=tag,
-                          headers={"x-ratelimit-resource": "graphql"})
-
-        c = _client(h, cache_dir=self.cache_dir, log_path=self.log_path)
-        try:
-            c.graphql("query A { ok }", cache="etag")
-            c.graphql("query B { ok }", cache="etag")
-        finally:
-            c.close()
-        files = list(self.cache_dir.iterdir())
-        self.assertEqual(len(files), 2)
+        self.assertEqual(seen_if_none_match, [None, None])
+        # Cache dir should be empty (or absent) — no GraphQL entry.
+        self.assertFalse(self.cache_dir.exists() and any(
+            self.cache_dir.iterdir()))
 
     def test_graphql_default_cache_none_not_cached(self):
         """`graphql()` defaults to cache='none' so plain calls go

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -628,6 +628,18 @@ class IsTrustedTests(unittest.TestCase):
 class ProvenanceCacheTests(unittest.TestCase):
     def setUp(self):
         cli._provenance_cache.clear()
+        # Isolate the cross-process disk cache: each test gets a fresh
+        # tempdir so persisted provenance from a prior test (or a real
+        # pod run in the cwd) can't leak in.
+        self._cache_tmp = tempfile.TemporaryDirectory()
+        self._disk_patch = mock.patch.object(
+            cli, "_PROVENANCE_DISK_CACHE",
+            cli._ProvenanceDiskCache(Path(self._cache_tmp.name)))
+        self._disk_patch.start()
+
+    def tearDown(self):
+        self._disk_patch.stop()
+        self._cache_tmp.cleanup()
 
     def _patch_fetch(self, prov):
         # Patch the fetcher and visibility check; return mock for assertions.
@@ -655,10 +667,14 @@ class ProvenanceCacheTests(unittest.TestCase):
         prov = _prov()
         with self._patch_fetch(prov):
             cli.check_issue_provenance("o/r", 1, {})
-            # Age the cached entry past TTL.
-            cached = cli._provenance_cache[("o/r", 1)]
-            cached.fetched_at -= cli._provenance_ttl({}) + 1
-            cli.check_issue_provenance("o/r", 1, {})
+            # Age the cached entry past TTL by simulating a clock
+            # advance for the next read; both the in-process entry and
+            # the disk entry are stamped at the original fetch time, so
+            # bumping `time.time` past the TTL invalidates both.
+            ttl = cli._provenance_ttl({})
+            with mock.patch.object(cli.time, "time",
+                                    return_value=time.time() + ttl + 1):
+                cli.check_issue_provenance("o/r", 1, {})
             self.assertEqual(cli.fetch_issue_provenance.call_count, 2)
 
     def test_private_repo_short_circuits(self):
@@ -675,6 +691,41 @@ class ProvenanceCacheTests(unittest.TestCase):
                 "o/r", 1, {"security": {"trust_only_collaborators": False}})
         self.assertTrue(ok)
         fetch.assert_not_called()
+
+    def test_disk_cache_serves_across_in_process_clears(self):
+        """Simulate the across-subprocess case: drop the in-process
+        cache and check_issue_provenance must still come back without
+        calling the fetcher because the disk tier holds the value."""
+        prov = _prov()
+        with self._patch_fetch(prov):
+            cli.check_issue_provenance("o/r", 1, {})
+            self.assertEqual(cli.fetch_issue_provenance.call_count, 1)
+            # Pretend we're a brand-new subprocess.
+            cli._provenance_cache.clear()
+            cli.check_issue_provenance("o/r", 1, {})
+            self.assertEqual(cli.fetch_issue_provenance.call_count, 1)
+
+
+class RepoPublicMemoTests(unittest.TestCase):
+    def setUp(self):
+        cli._REPO_PUBLIC_MEMO.clear()
+
+    def tearDown(self):
+        cli._REPO_PUBLIC_MEMO.clear()
+
+    def test_memoised_after_first_call(self):
+        """Three call sites used to hit /repos each tick; the per-
+        process memo must collapse that to one round-trip."""
+        from _gh_helpers import patch_client, fake_response
+        resp = fake_response(200, body={"visibility": "public"})
+        with mock.patch.object(cli, "_get_repo", return_value="o/r"), \
+             patch_client(routes={("GET", "/repos/o/r"): resp}) as client:
+            self.assertTrue(cli._is_repo_public({}))
+            self.assertTrue(cli._is_repo_public({}))
+            self.assertTrue(cli._is_repo_public({}))
+        gets = [c for c in client.calls
+                if c["method"] == "GET" and c["path"] == "/repos/o/r"]
+        self.assertEqual(len(gets), 1)
 
 
 class ValidateProvenanceConfigTests(unittest.TestCase):


### PR DESCRIPTION
This PR fixes the GraphQL bucket exhausting in ~20-35 min after each reset (~4373 GraphQL calls in 23 minutes seen in `.pod/gh-access.log`). Three issues, fixed together.

**The ETag premise was wrong.** [e616c07](https://github.com/FormalFrontier/pod/commit/e616c07) assumed GitHub honors `If-None-Match` on `/graphql` POSTs. Field data on a real workload showed zero 304s out of ~14k POSTs over four hours — the server ignores the header and bills every POST against the GraphQL bucket. The layer no longer sends conditional headers for GraphQL POSTs, and the body-keyed ETag entries that were piling up under `.pod/gh-cache/` for those POSTs no longer get written.

**Per-issue fetches replaced with batching.** With N agent worktrees ticking and M open agent-plan issues, each `coordination orient` was firing N*M GraphQL POSTs. New `fetch_issue_provenances(repo, [n1, n2, …])` builds one aliased query (`i0`, `i1`, …) chunked at 25 issues, and `cmd_filter_trusted_issues` calls it once per tick instead of looping `check_issue_provenance` per item.

**Cross-process disk cache.** `cmd_filter_trusted_issues` runs as a fresh subprocess per tick, so the in-process cache couldn't help across invocations. New `_ProvenanceDiskCache` writes one JSON-per-issue under `.pod/provenance-cache/` (atomic tmp+rename, chmod 600), keyed by sha256(repo|issue_num), TTL'd by `security.provenance_cache_seconds` (default 60s). All worktrees resolve to the same `.pod/` via `_find_project_dir`, so they share hits.

Also memoises `_is_repo_public` per process — three call sites used to fire `/repos/{slug}` every tick; they now share one round-trip.

## Expected impact

For 6 agents, ~14 open agent-plan issues, ~14 ticks/min:

| | GraphQL POSTs/min |
|---|---|
| Before | 6 × 14 × 14 ≈ **1,176** |
| After cold tick (every issue uncached) | 6 × 14 = **84** |
| After warm cache (60s TTL) | ~**6** |

5000/hr quota was draining in 4 min before; should now be untouchable in normal operation. Bump `security.provenance_cache_seconds` for more headroom.

## Tests

305 → 307 passing. Three old tests that encoded the false-belief behaviour (`test_etag_cached_repeat_serves_304`, `test_graphql_post_with_cache_etag_round_trip`, `test_graphql_body_in_cache_key`) replaced with `test_graphql_post_never_sends_if_none_match`, `test_disk_cache_short_circuits_repeat_fetch`, `test_batched_fetch_issues_one_graphql_per_chunk`. New `RepoPublicMemoTests` covers the per-process memo. Disk-cache tests get an isolated tempdir via setUp/tearDown.

🤖 Prepared with Claude Code
