### PR TITLE
feat: add `replan` worker type to dispatch

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -2318,6 +2318,29 @@ def _list_pr_repair_count(config: dict) -> int:
     return sum(1 for line in r.stdout.splitlines() if line.strip())
 
 
+def _count_running_replan_agents(agents: list | None = None) -> int:
+    """Count live agents whose worker_type is 'replan'."""
+    if agents is None:
+        agents = read_all_agents()
+    return sum(1 for a in agents
+               if a.worker_type == "replan"
+               and a.status not in ("dead", "stopped", "killed"))
+
+
+def _list_replan_count(config: dict) -> int:
+    """Return the number of replan candidates, or 0 on error.
+
+    Calls `coordination list-replan` and counts output lines.
+    """
+    try:
+        r = coordination(config, "list-replan")
+    except (subprocess.TimeoutExpired, OSError):
+        return 0
+    if r.returncode != 0:
+        return 0
+    return sum(1 for line in r.stdout.splitlines() if line.strip())
+
+
 _gh_quota_cache: dict = {"graphql_remaining": None, "checked_at": 0.0}
 _GH_QUOTA_CHECK_TTL = 30.0  # seconds between `gh api rate_limit` polls
 _GH_QUOTA_PAUSE_THRESHOLD = 100  # pause dispatch below this (of 5000/hr)
@@ -2504,6 +2527,36 @@ def dispatch_queue_balance(config: dict, queue_depth: int,
             log(f"dispatch: repair preferred (candidates={candidates}, "
                 f"running_repair={running_repair})")
             return "repair"
+
+    # Replan preference. After repair, before any planner-lock filling
+    # or queue-draining work, prefer `replan` if there are unclaimed
+    # replan-labelled issues. Unlike `repair` (lock-less), `replan`
+    # shares the `planner` lock with `plan`, so we acquire the lock
+    # here. If it fails, skip the rest of the filling path (which would
+    # try the same lock again) and fall straight to draining — calling
+    # `lock-planner` twice per tick is expensive (posts/sleeps/deletes
+    # a comment).
+    if "replan" in worker_types:
+        replan_candidates = _list_replan_count(config)
+        running_replan = _count_running_replan_agents()
+        if replan_candidates > running_replan:
+            replan_lock = worker_types["replan"].get("lock", "planner")
+            r = coordination(config, f"lock-{replan_lock}")
+            if r.returncode == 0:
+                if state:
+                    state.lock_held = replan_lock
+                    state.write()
+                log(f"dispatch: replan preferred "
+                    f"(candidates={replan_candidates}, "
+                    f"running_replan={running_replan})")
+                return "replan"
+            log(f"dispatch: replan preferred but {replan_lock} lock held; "
+                f"skipping filling, trying draining")
+            draining = {k: v for k, v in worker_types.items()
+                        if not v.get("lock")}
+            if queue_depth > 0 and draining:
+                return _choose_draining(config, draining)
+            return None
 
     config_min_queue = cfg_get(config, "dispatch", "min_queue", default=3)
     planner_min_queue = read_planner_min_queue()

--- a/pod/coordination.py
+++ b/pod/coordination.py
@@ -384,15 +384,16 @@ def _check_provenance(issue_num: int | str) -> tuple[bool, str]:
 # ---------------------------------------------------------------------------
 
 _UNCLAIMED_EXCLUDE = {"claimed", "blocked", "has-pr", "replan"}
+_REPLAN_EXCLUDE = {"claimed", "blocked", "has-pr"}
 
 
-def _unclaimed_filter(items: list[dict]) -> list[dict]:
-    """Apply the bash jq filter inline: exclude {claimed, blocked, has-pr,
-    replan}; sort critical-path first, then by createdAt."""
+def _filtered_issues(items: list[dict], exclude: set[str]) -> list[dict]:
+    """Apply the bash jq filter inline: drop items whose labels intersect
+    `exclude`; sort critical-path first, then by createdAt."""
     out = []
     for it in items:
         names = {l.get("name") for l in (it.get("labels") or [])}
-        if names & _UNCLAIMED_EXCLUDE:
+        if names & exclude:
             continue
         out.append(it)
     out.sort(key=lambda it: (
@@ -401,6 +402,12 @@ def _unclaimed_filter(items: list[dict]) -> list[dict]:
         it.get("createdAt", "") or it.get("created_at", "") or "",
     ))
     return out
+
+
+def _unclaimed_filter(items: list[dict]) -> list[dict]:
+    """Apply the bash jq filter inline: exclude {claimed, blocked, has-pr,
+    replan}; sort critical-path first, then by createdAt."""
+    return _filtered_issues(items, _UNCLAIMED_EXCLUDE)
 
 
 def _unclaimed_issues(ctx: CoordinationContext,
@@ -435,6 +442,23 @@ def _unclaimed_issues(ctx: CoordinationContext,
         if n is not None and n not in seen:
             seen[n] = x
     return _unclaimed_filter(list(seen.values()))
+
+
+def _replan_issues(ctx: CoordinationContext) -> list[dict]:
+    """Return `agent-plan + replan` issues filtered through the trusted-
+    author gate. `human-oversight` is intentionally excluded — those
+    issues have an owner-closes-only policy and must not be auto-replanned.
+    """
+    include = ["--include-untrusted"] if ctx.include_untrusted else []
+    args = ["--label", "agent-plan", "--label", "replan",
+            "--state", "open", "--limit", "500",
+            "--json", "number,title,labels,createdAt", *include]
+    out = _filter_trusted_issues(args)
+    try:
+        items = _safe_json(out, default=[])
+    except ValueError:
+        items = []
+    return _filtered_issues(items, _REPLAN_EXCLUDE)
 
 
 def _safe_json(s: str, default=None):
@@ -994,6 +1018,22 @@ def cmd_list_pr_repair(ctx: CoordinationContext, argv: list[str]) -> int:
                 break
         if is_stuck:
             print(f"#{pr_num} [stuck] {p.get('title','')}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: list-replan
+# ---------------------------------------------------------------------------
+
+def cmd_list_replan(ctx: CoordinationContext, argv: list[str]) -> int:
+    """List `agent-plan + replan` issues ready for /replan triage.
+
+    Goes through the same trusted-author gate as `list-unclaimed`.
+    Excludes `claimed`, `blocked`, `has-pr`. `human-oversight` is
+    excluded by construction (we only ask for `agent-plan`).
+    """
+    for it in _replan_issues(ctx):
+        print(f"#{it.get('number')} {it.get('title','')}")
     return 0
 
 
@@ -2020,6 +2060,7 @@ _COMMANDS = {
     "claim-fix": cmd_claim_fix,
     "close-pr": cmd_close_pr,
     "list-pr-repair": cmd_list_pr_repair,
+    "list-replan": cmd_list_replan,
     "claim-pr-repair": cmd_claim_pr_repair,
     "mark-pr-salvaged": cmd_mark_pr_salvaged,
     "close-pr-unsalvageable": cmd_close_pr_unsalvageable,
@@ -2050,7 +2091,7 @@ _COMMANDS = {
 _USAGE = (
     "Usage: coordination "
     "{orient|plan [--label L] [--critical-path]|create-pr|claim-fix|"
-    "close-pr|list-pr-repair|claim-pr-repair|mark-pr-salvaged|"
+    "close-pr|list-pr-repair|list-replan|claim-pr-repair|mark-pr-salvaged|"
     "close-pr-unsalvageable|list-unclaimed [--label L]|queue-depth [L]|"
     "critical-path-depth|claim|skip|add-dep|check-blocked|check-has-pr|"
     "release-stale-claims|release-orphan-claims|lock-planner|unlock-planner|lock-status|"

--- a/tests/test_replan_dispatch.py
+++ b/tests/test_replan_dispatch.py
@@ -1,0 +1,331 @@
+"""Tests for the `replan` worker-type dispatch path.
+
+Covers:
+- `_filtered_issues` parameterised exclude behaviour
+- `_unclaimed_filter` backward-compat wrapper
+- `_replan_issues` trust-gate + label-set behaviour
+- `_list_replan_count` / `_count_running_replan_agents` shape
+- `dispatch_queue_balance` replan short-circuit ordering, lock handling,
+  draining fallback, and conditional `list-replan` invocation
+"""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pod import cli, coordination
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+def _issue(number: int, labels: list[str], title: str = "x",
+           created: str = "2026-01-01T00:00:00Z") -> dict:
+    return {
+        "number": number,
+        "title": title,
+        "labels": [{"name": n} for n in labels],
+        "createdAt": created,
+    }
+
+
+class FilteredIssuesTests(unittest.TestCase):
+    """`_filtered_issues` drops items whose labels intersect `exclude`."""
+
+    def test_replan_exclude_drops_claimed_blocked_has_pr(self):
+        items = [
+            _issue(1, ["agent-plan", "replan"]),
+            _issue(2, ["agent-plan", "replan", "claimed"]),
+            _issue(3, ["agent-plan", "replan", "blocked"]),
+            _issue(4, ["agent-plan", "replan", "has-pr"]),
+            _issue(5, ["agent-plan", "replan", "critical-path"]),
+        ]
+        out = coordination._filtered_issues(items,
+                                            coordination._REPLAN_EXCLUDE)
+        nums = [it["number"] for it in out]
+        # 5 (critical-path) sorts first; 1 keeps its order; 2/3/4 dropped.
+        self.assertEqual(nums, [5, 1])
+
+    def test_replan_exclude_keeps_replan_label(self):
+        items = [_issue(1, ["agent-plan", "replan"])]
+        out = coordination._filtered_issues(items,
+                                            coordination._REPLAN_EXCLUDE)
+        self.assertEqual([it["number"] for it in out], [1])
+
+    def test_unclaimed_filter_still_excludes_replan(self):
+        items = [
+            _issue(1, ["agent-plan"]),
+            _issue(2, ["agent-plan", "replan"]),
+        ]
+        out = coordination._unclaimed_filter(items)
+        self.assertEqual([it["number"] for it in out], [1])
+
+
+class ReplanIssuesTests(unittest.TestCase):
+    """`_replan_issues` goes through `_filter_trusted_issues` with the
+    `agent-plan + replan` label pair, applies `_REPLAN_EXCLUDE`, and
+    never asks for `human-oversight`."""
+
+    def _ctx(self, include_untrusted: bool = False):
+        c = mock.MagicMock()
+        c.include_untrusted = include_untrusted
+        return c
+
+    def test_passes_agent_plan_and_replan_with_limit_500(self):
+        captured: list[list[str]] = []
+
+        def fake_filter(args):
+            captured.append(list(args))
+            return "[]"
+
+        with mock.patch.object(coordination, "_filter_trusted_issues",
+                               side_effect=fake_filter):
+            coordination._replan_issues(self._ctx())
+
+        self.assertEqual(len(captured), 1)
+        args = captured[0]
+        self.assertIn("--label", args)
+        # Both labels present.
+        label_values = [args[i + 1] for i, a in enumerate(args)
+                        if a == "--label"]
+        self.assertIn("agent-plan", label_values)
+        self.assertIn("replan", label_values)
+        self.assertNotIn("human-oversight", label_values)
+        # Explicit limit (not the gh default).
+        self.assertIn("--limit", args)
+        self.assertEqual(args[args.index("--limit") + 1], "500")
+
+    def test_excludes_claimed_blocked_has_pr_but_keeps_plain_replan(self):
+        items = [
+            _issue(1, ["agent-plan", "replan"]),
+            _issue(2, ["agent-plan", "replan", "claimed"]),
+            _issue(3, ["agent-plan", "replan", "has-pr"]),
+        ]
+        import json
+        with mock.patch.object(coordination, "_filter_trusted_issues",
+                               return_value=json.dumps(items)):
+            out = coordination._replan_issues(self._ctx())
+        self.assertEqual([it["number"] for it in out], [1])
+
+    def test_include_untrusted_passed_through(self):
+        captured: list[list[str]] = []
+        with mock.patch.object(coordination, "_filter_trusted_issues",
+                               side_effect=lambda args: captured.append(args)
+                               or "[]"):
+            coordination._replan_issues(self._ctx(include_untrusted=True))
+        self.assertIn("--include-untrusted", captured[0])
+
+
+class ListReplanCountTests(unittest.TestCase):
+    def test_counts_non_empty_lines(self):
+        with mock.patch.object(
+            cli, "coordination",
+            return_value=_completed(0, "#1 a\n#2 b\n\n#3 c\n"),
+        ):
+            self.assertEqual(cli._list_replan_count({}), 3)
+
+    def test_returns_zero_on_nonzero_exit(self):
+        with mock.patch.object(cli, "coordination",
+                               return_value=_completed(1, "")):
+            self.assertEqual(cli._list_replan_count({}), 0)
+
+    def test_returns_zero_on_subprocess_failure(self):
+        with mock.patch.object(cli, "coordination",
+                               side_effect=subprocess.TimeoutExpired(
+                                   cmd=["coordination"], timeout=60)):
+            self.assertEqual(cli._list_replan_count({}), 0)
+
+
+class CountRunningReplanAgentsTests(unittest.TestCase):
+    def _agent(self, worker_type: str, status: str):
+        a = mock.MagicMock()
+        a.worker_type = worker_type
+        a.status = status
+        return a
+
+    def test_counts_only_live_replan_agents(self):
+        agents = [
+            self._agent("replan", "running"),
+            self._agent("replan", "dead"),
+            self._agent("replan", "killed"),
+            self._agent("plan", "running"),
+            self._agent("repair", "running"),
+            self._agent("replan", "starting"),
+        ]
+        self.assertEqual(cli._count_running_replan_agents(agents), 2)
+
+    def test_empty_list(self):
+        self.assertEqual(cli._count_running_replan_agents([]), 0)
+
+
+class DispatchReplanShortCircuitTests(unittest.TestCase):
+    """Order and lock-handling for the replan short-circuit in
+    `dispatch_queue_balance`."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self._patches = [
+            mock.patch.object(cli, "TARGET_FILE", root / "target"),
+            mock.patch.object(cli, "PLANNER_TARGET_FILE",
+                              root / "planner-target"),
+            mock.patch.object(cli, "PLANNER_MIN_QUEUE_FILE",
+                              root / "planner-min-queue"),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+        cli.write_target(3)
+
+    def _worker_types(self, with_replan: bool = True):
+        wt: dict = {
+            "plan": {"lock": "planner"},
+            "work": {},
+            "repair": {},
+        }
+        if with_replan:
+            wt["replan"] = {"lock": "planner"}
+        return wt
+
+    def test_replan_dispatched_when_candidates_and_lock_free(self):
+        lock_calls: list[tuple] = []
+
+        def fake_coord(config, *args, **kw):
+            lock_calls.append(args)
+            if args == ("lock-planner",):
+                return _completed(0)
+            raise AssertionError(f"unexpected coordination call: {args}")
+
+        with mock.patch.object(cli, "_list_pr_repair_count", return_value=0), \
+             mock.patch.object(cli, "_list_replan_count", return_value=1), \
+             mock.patch.object(cli, "_count_running_replan_agents",
+                               return_value=0), \
+             mock.patch.object(cli, "coordination", side_effect=fake_coord):
+            chosen = cli.dispatch_queue_balance(
+                config={}, queue_depth=0,
+                worker_types=self._worker_types(),
+            )
+        self.assertEqual(chosen, "replan")
+        # Exactly one lock attempt — no double-acquire.
+        self.assertEqual(
+            sum(1 for a in lock_calls if a == ("lock-planner",)), 1)
+
+    def test_lock_held_empty_queue_returns_none_and_one_lock_attempt(self):
+        lock_calls: list[tuple] = []
+
+        def fake_coord(config, *args, **kw):
+            lock_calls.append(args)
+            if args == ("lock-planner",):
+                return _completed(1)  # held by someone else
+            raise AssertionError(f"unexpected coordination call: {args}")
+
+        with mock.patch.object(cli, "_list_pr_repair_count", return_value=0), \
+             mock.patch.object(cli, "_list_replan_count", return_value=1), \
+             mock.patch.object(cli, "_count_running_replan_agents",
+                               return_value=0), \
+             mock.patch.object(cli, "coordination", side_effect=fake_coord):
+            chosen = cli.dispatch_queue_balance(
+                config={}, queue_depth=0,
+                worker_types=self._worker_types(),
+            )
+        self.assertIsNone(chosen)
+        # Must not call `lock-planner` again from the filling iteration.
+        self.assertEqual(
+            sum(1 for a in lock_calls if a == ("lock-planner",)), 1)
+
+    def test_lock_held_with_draining_returns_draining_choice(self):
+        lock_calls: list[tuple] = []
+
+        def fake_coord(config, *args, **kw):
+            lock_calls.append(args)
+            if args == ("lock-planner",):
+                return _completed(1)
+            raise AssertionError(f"unexpected coordination call: {args}")
+
+        with mock.patch.object(cli, "_list_pr_repair_count", return_value=0), \
+             mock.patch.object(cli, "_list_replan_count", return_value=1), \
+             mock.patch.object(cli, "_count_running_replan_agents",
+                               return_value=0), \
+             mock.patch.object(cli, "_choose_draining", return_value="work"), \
+             mock.patch.object(cli, "coordination", side_effect=fake_coord):
+            chosen = cli.dispatch_queue_balance(
+                config={}, queue_depth=5,
+                worker_types=self._worker_types(),
+            )
+        self.assertEqual(chosen, "work")
+        self.assertEqual(
+            sum(1 for a in lock_calls if a == ("lock-planner",)), 1)
+
+    def test_repair_wins_when_both_have_candidates(self):
+        # No `lock-planner` should ever be attempted: repair short-circuits
+        # before the replan block.
+        with mock.patch.object(cli, "_list_pr_repair_count", return_value=1), \
+             mock.patch.object(cli, "_count_running_repair_agents",
+                               return_value=0), \
+             mock.patch.object(cli, "_list_replan_count",
+                               side_effect=AssertionError(
+                                   "list-replan must not be called when "
+                                   "repair has candidates")), \
+             mock.patch.object(cli, "coordination",
+                               side_effect=AssertionError(
+                                   "no coordination call expected")):
+            chosen = cli.dispatch_queue_balance(
+                config={}, queue_depth=0,
+                worker_types=self._worker_types(),
+            )
+        self.assertEqual(chosen, "repair")
+
+    def test_no_replan_worker_type_skips_list_replan(self):
+        # Old hex config (no `[worker_types.replan]`) → the new short-circuit
+        # is a no-op and `list-replan` is never invoked.
+        with mock.patch.object(cli, "_list_pr_repair_count", return_value=0), \
+             mock.patch.object(cli, "_list_replan_count",
+                               side_effect=AssertionError(
+                                   "list-replan must not be called when "
+                                   "worker_types.replan is absent")), \
+             mock.patch.object(cli, "_choose_draining", return_value="work"):
+            chosen = cli.dispatch_queue_balance(
+                config={}, queue_depth=5,
+                worker_types=self._worker_types(with_replan=False),
+            )
+        self.assertEqual(chosen, "work")
+
+    def test_replan_skipped_when_running_count_meets_candidates(self):
+        # Already a /replan agent for the only candidate — don't spawn another.
+        # Fall through to the regular path; draining is available.
+        lock_calls: list[tuple] = []
+
+        def fake_coord(config, *args, **kw):
+            lock_calls.append(args)
+            # Critical-path override may run and consult critical-path-depth.
+            if args[0] == "critical-path-depth":
+                return _completed(0, "0")
+            # Any planner-lock attempt is a regression for this test.
+            if args == ("lock-planner",):
+                raise AssertionError(
+                    "must not attempt planner lock when running >= candidates")
+            return _completed(0, "")
+
+        with mock.patch.object(cli, "_list_pr_repair_count", return_value=0), \
+             mock.patch.object(cli, "_list_replan_count", return_value=1), \
+             mock.patch.object(cli, "_count_running_replan_agents",
+                               return_value=1), \
+             mock.patch.object(cli, "_choose_draining", return_value="work"), \
+             mock.patch.object(cli, "coordination", side_effect=fake_coord):
+            chosen = cli.dispatch_queue_balance(
+                config={}, queue_depth=5,
+                worker_types=self._worker_types(),
+            )
+        self.assertEqual(chosen, "work")
+        self.assertNotIn(("lock-planner",), lock_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a dedicated `replan` worker type to `dispatch_queue_balance`, inserting a short-circuit between the existing `repair` short-circuit and the rest of dispatch (critical-path / filling / draining). Replan-labelled issues currently stall because they're excluded from `list-unclaimed` and `critical-path-depth`, and the only consumer is `/plan` Step 3 — which only runs when the queue is low enough to invoke the planner. The new tier gives them first-class dispatch ordered after `repair` and before `plan`.

`replan` shares the existing `planner` lock so `/plan` and `/replan` cannot race on issue state. The short-circuit acquires the lock inline; on failure it skips the filling iteration (which would otherwise re-attempt the same lock) and falls through to a draining choice. `cmd_lock_planner` costs a comment-post + 3 s race-sleep + comment-delete per attempt, so calling it twice per tick matters.

`cmd_list_replan` goes through `_filter_trusted_issues` with `agent-plan + replan` plus a new `_REPLAN_EXCLUDE = {claimed, blocked, has-pr}` set, factored out of `_unclaimed_filter`. `human-oversight` is intentionally excluded — those issues have an owner-closes-only policy and must not be auto-replanned.

Consumers (the `[worker_types.replan]` config block and the `/replan` slash command) land in the hex repo as a follow-up. The short-circuit is gated by `if "replan" in worker_types`, so until a project opts in, this PR is a no-op.

17 new unit tests cover:
- `_filtered_issues` parameterised exclude and `_unclaimed_filter` backward compat
- `_replan_issues` label set, trust gate, `--limit 500`, `--include-untrusted` pass-through
- `_list_replan_count` line counting, error handling
- `_count_running_replan_agents` status filter
- Six dispatch cases: replan dispatched when lock free; lock held with empty queue → None; lock held with draining work available → draining; repair still wins over replan; missing config no-ops `list-replan`; running ≥ candidates skips the lock attempt

Full suite: 324 passed.

🤖 Prepared with Claude Code