### PR TITLE
feat: ship `/replan` template and default `[worker_types.replan]`

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -270,6 +270,16 @@ copy_build_cache = true
 prompt = "/repair"
 copy_build_cache = true
 
+# Replan agent: triages issues labelled `replan` (from PRs closed
+# unsalvageable, `coordination skip --replan`, or `create-pr --partial`).
+# Shares the planner lock with `/plan` so the two cannot race on issue
+# state. Dispatched by the replan short-circuit in `dispatch_queue_balance`,
+# ordered after `repair` and before `plan`.
+[worker_types.replan]
+prompt = "/replan"
+lock = "planner"
+copy_build_cache = false
+
 # Example additional worker type:
 # [worker_types.review]
 # prompt = "/review"

--- a/pod/data/agent-config/claude/commands/plan.md
+++ b/pod/data/agent-config/claude/commands/plan.md
@@ -54,37 +54,11 @@ gh pr list --state open \
 
 Never skip this step. Downstream agents are blocked on `main` until merged PRs land.
 
-## Step 3: Triage `replan` issues (before creating new work)
+Replan triage is handled by `/replan`, which dispatch always runs
+before `/plan` when there are `replan`-labelled candidates. Do not
+duplicate that work here.
 
-Fetch the list:
-```
-pod _filter-trusted-issues --label replan --state open --json number,title,body \
-    --jq '.[] | "### #\(.number) \(.title)\n\(.body)\n"'
-```
-
-Process **all** replan issues before creating any new issues.
-For each, exactly one of:
-- **Work already done** (a subsequent PR merged it): close with a note
-- **Plan stale / approach changed**: create a corrected replacement issue, close original linking forward
-- **Partial progress**: create issue for remaining deliverables, close original linking forward
-- **Worker-decomposed**: the worker created sub-issues before releasing
-  the claim. Detect via a comment that starts with `Decomposed into #` and
-  lists the sub-issue numbers (workers must leave this breadcrumb before
-  `coordination skip` or `coordination create-pr --partial`). Read the
-  sub-issues and decide:
-  - sub-issues fully cover the parent → close the parent with a forward
-    link (do NOT re-create the sub-issues);
-  - residual scope remains → narrow the body to that residual and remove
-    the `replan` label so workers can claim it again.
-  In the partial-PR variant the parent will also have a merged or open PR
-  reference; treat it the same way and rely on the merged PR to record the
-  partial work.
-- **Still valid, body still accurate**: remove the `replan` label (`gh issue edit N --remove-label replan`) to re-open for workers
-- **Still valid, body stale**: update the issue body with current state, then remove the `replan` label
-
-**Never delegate replan triage to a worker** — that is the planner's job.
-
-## Step 4: Create fix issues for broken PRs
+## Step 3: Create fix issues for broken PRs
 
 Check for PRs with merge conflicts or failing CI:
 ```bash
@@ -104,7 +78,7 @@ gh issue list --label agent-plan --state open --json number,title \
 If no fix issue exists, **create one immediately** using `coordination plan`.
 These fix issues take priority over all new feature work.
 
-## Step 5: Understand existing plans
+## Step 4: Understand existing plans
 
 Read the **full body** of every open `agent-plan` issue:
 ```
@@ -115,7 +89,7 @@ pod _filter-trusted-issues --label agent-plan --state open --limit 20 \
 Understand what's already planned at the **deliverable level**, not just the title.
 Your work item MUST NOT overlap with any existing issue's deliverables.
 
-## Step 6: Write new issues
+## Step 5: Write new issues
 
 Work types: **`feature`**, **`review`**, **`summarize`**.
 Target roughly 2:1 feature:review during implementation; 1:1 during cleanup.
@@ -182,7 +156,7 @@ gh issue list --label agent-plan --state open --limit 20 \
     --json number,title --jq '.[].title'
 ```
 
-## Step 7: Post and exit
+## Step 6: Post and exit
 
 For each issue, write the plan body to `plans/<UUID-prefix>-N.md`, then post:
 ```

--- a/pod/data/agent-config/claude/commands/replan.md
+++ b/pod/data/agent-config/claude/commands/replan.md
@@ -1,0 +1,72 @@
+# Triage `replan` Issues
+
+You are a **replan** session. Your job is to triage issues labelled
+`replan` — those left behind by PRs closed unsalvageable
+(`coordination close-pr-unsalvageable`), worker skips
+(`coordination skip --replan`), or partial-completion publishes
+(`coordination create-pr --partial`). You do NOT execute any code
+changes and you do NOT create fresh planning work. That is `/plan`'s job.
+
+Replan sits between `repair` and `plan` in dispatch priority and shares
+the planner lock with `/plan`. The lock is managed by `pod` — do NOT
+call `coordination lock-planner` or `coordination unlock-planner`
+yourself.
+
+## Step 1: Orient
+
+1. `git fetch origin master`
+2. Read the last 5 files in `progress/` (sorted by filename) to
+   understand recent work.
+
+## Step 2: Pick up replan candidates
+
+```
+coordination list-replan
+```
+
+Output is one issue per line: `#<number> <title>`. The list goes
+through the same trusted-author gate as `list-unclaimed`. Issues with
+`claimed`, `blocked`, or `has-pr` are filtered out, as are
+`human-oversight` issues (those have an owner-closes-only policy and
+must never be auto-replanned).
+
+If the list is empty, exit cleanly — pod will release the planner lock.
+
+## Step 3: Triage each candidate
+
+For each issue, read the body and any closing comment (from a closed
+PR) to understand why it was abandoned, then apply **exactly one** of
+the following:
+
+- **Work already done** (a subsequent PR merged it):
+  close with a forward link.
+- **Plan stale / approach changed**: create a corrected replacement
+  issue via `coordination plan`, close the original linking forward.
+- **Partial progress**: create an issue for the remaining deliverables,
+  close the original linking forward.
+- **Worker-decomposed**: the worker created sub-issues before releasing
+  the claim. Detect via a comment that starts with `Decomposed into #`
+  and lists the sub-issue numbers. Read the sub-issues and decide:
+  - sub-issues fully cover the parent → close the parent with a
+    forward link (do **not** re-create the sub-issues);
+  - residual scope remains → narrow the body to that residual and
+    remove the `replan` label so workers can claim it again.
+  In the partial-PR variant the parent will also have a merged or open
+  PR reference; treat it the same way and rely on the merged PR to
+  record the partial work.
+- **Still valid, body still accurate**: remove the `replan` label
+  (`gh issue edit N --remove-label replan`) to re-open for workers.
+- **Still valid, body stale**: update the issue body with current
+  state, then remove the `replan` label.
+
+Process **every** candidate from `list-replan` before exiting.
+
+## Step 4: Exit
+
+This session produces no PR — it edits issues directly. After every
+candidate has been disposed of, exit. The harness will release the
+planner lock.
+
+Do **not** create new `agent-plan` issues beyond residual sub-issues
+required to record narrowed scope. Fresh planning is the next
+planner's job, not yours.

--- a/pod/data/agent-config/codex/commands/plan.md
+++ b/pod/data/agent-config/codex/commands/plan.md
@@ -43,37 +43,11 @@ gh pr list --state open \
 
 Never skip this step. Downstream agents are blocked on `main` until merged PRs land.
 
-## Step 3: Triage `replan` issues (before creating new work)
+Replan triage is handled by `/replan`, which dispatch always runs
+before `/plan` when there are `replan`-labelled candidates. Do not
+duplicate that work here.
 
-Fetch the list:
-```
-pod _filter-trusted-issues --label replan --state open --json number,title,body \
-    --jq '.[] | "### #\(.number) \(.title)\n\(.body)\n"'
-```
-
-Process **all** replan issues before creating any new issues.
-For each, exactly one of:
-- **Work already done** (a subsequent PR merged it): close with a note
-- **Plan stale / approach changed**: create a corrected replacement issue, close original linking forward
-- **Partial progress**: create issue for remaining deliverables, close original linking forward
-- **Worker-decomposed**: the worker created sub-issues before releasing
-  the claim. Detect via a comment that starts with `Decomposed into #` and
-  lists the sub-issue numbers (workers must leave this breadcrumb before
-  `coordination skip` or `coordination create-pr --partial`). Read the
-  sub-issues and decide:
-  - sub-issues fully cover the parent → close the parent with a forward
-    link (do NOT re-create the sub-issues);
-  - residual scope remains → narrow the body to that residual and remove
-    the `replan` label so workers can claim it again.
-  In the partial-PR variant the parent will also have a merged or open PR
-  reference; treat it the same way and rely on the merged PR to record the
-  partial work.
-- **Still valid, body still accurate**: remove the `replan` label (`gh issue edit N --remove-label replan`) to re-open for workers
-- **Still valid, body stale**: update the issue body with current state, then remove the `replan` label
-
-**Never delegate replan triage to a worker** — that is the planner's job.
-
-## Step 4: Create fix issues for broken PRs
+## Step 3: Create fix issues for broken PRs
 
 Check for PRs with merge conflicts or failing CI:
 ```bash
@@ -93,7 +67,7 @@ gh issue list --label agent-plan --state open --json number,title \
 If no fix issue exists, **create one immediately** using `coordination plan`.
 These fix issues take priority over all new feature work.
 
-## Step 5: Understand existing plans
+## Step 4: Understand existing plans
 
 Read the **full body** of every open `agent-plan` issue:
 ```
@@ -104,7 +78,7 @@ pod _filter-trusted-issues --label agent-plan --state open --limit 20 \
 Understand what's already planned at the **deliverable level**, not just the title.
 Your work item MUST NOT overlap with any existing issue's deliverables.
 
-## Step 6: Write new issues
+## Step 5: Write new issues
 
 Work types: **`feature`**, **`review`**, **`summarize`**.
 Target roughly 2:1 feature:review during implementation; 1:1 during cleanup.
@@ -171,7 +145,7 @@ gh issue list --label agent-plan --state open --limit 20 \
     --json number,title --jq '.[].title'
 ```
 
-## Step 7: Post and exit
+## Step 6: Post and exit
 
 For each issue, write the plan body to `plans/<UUID-prefix>-N.md`, then post:
 ```

--- a/pod/data/agent-config/codex/commands/replan.md
+++ b/pod/data/agent-config/codex/commands/replan.md
@@ -1,0 +1,72 @@
+# Triage `replan` Issues
+
+You are a **replan** session. Your job is to triage issues labelled
+`replan` — those left behind by PRs closed unsalvageable
+(`coordination close-pr-unsalvageable`), worker skips
+(`coordination skip --replan`), or partial-completion publishes
+(`coordination create-pr --partial`). You do NOT execute any code
+changes and you do NOT create fresh planning work. That is `/plan`'s job.
+
+Replan sits between `repair` and `plan` in dispatch priority and shares
+the planner lock with `/plan`. The lock is managed by `pod` — do NOT
+call `coordination lock-planner` or `coordination unlock-planner`
+yourself.
+
+## Step 1: Orient
+
+1. `git fetch origin master`
+2. Read the last 5 files in `progress/` (sorted by filename) to
+   understand recent work.
+
+## Step 2: Pick up replan candidates
+
+```
+coordination list-replan
+```
+
+Output is one issue per line: `#<number> <title>`. The list goes
+through the same trusted-author gate as `list-unclaimed`. Issues with
+`claimed`, `blocked`, or `has-pr` are filtered out, as are
+`human-oversight` issues (those have an owner-closes-only policy and
+must never be auto-replanned).
+
+If the list is empty, exit cleanly — pod will release the planner lock.
+
+## Step 3: Triage each candidate
+
+For each issue, read the body and any closing comment (from a closed
+PR) to understand why it was abandoned, then apply **exactly one** of
+the following:
+
+- **Work already done** (a subsequent PR merged it):
+  close with a forward link.
+- **Plan stale / approach changed**: create a corrected replacement
+  issue via `coordination plan`, close the original linking forward.
+- **Partial progress**: create an issue for the remaining deliverables,
+  close the original linking forward.
+- **Worker-decomposed**: the worker created sub-issues before releasing
+  the claim. Detect via a comment that starts with `Decomposed into #`
+  and lists the sub-issue numbers. Read the sub-issues and decide:
+  - sub-issues fully cover the parent → close the parent with a
+    forward link (do **not** re-create the sub-issues);
+  - residual scope remains → narrow the body to that residual and
+    remove the `replan` label so workers can claim it again.
+  In the partial-PR variant the parent will also have a merged or open
+  PR reference; treat it the same way and rely on the merged PR to
+  record the partial work.
+- **Still valid, body still accurate**: remove the `replan` label
+  (`gh issue edit N --remove-label replan`) to re-open for workers.
+- **Still valid, body stale**: update the issue body with current
+  state, then remove the `replan` label.
+
+Process **every** candidate from `list-replan` before exiting.
+
+## Step 4: Exit
+
+This session produces no PR — it edits issues directly. After every
+candidate has been disposed of, exit. The harness will release the
+planner lock.
+
+Do **not** create new `agent-plan` issues beyond residual sub-issues
+required to record narrowed scope. Fresh planning is the next
+planner's job, not yours.


### PR DESCRIPTION
This PR ships the agent-facing pieces that pair with the `replan` dispatch tier added in #58:

- New `/replan` slash command (`data/agent-config/{claude,codex}/commands/replan.md`). Walks `coordination list-replan` and applies one of the dispositions previously inlined in `/plan` Step 3: close-as-done, replace, narrow, decompose-aware, remove-label, or update-then-remove-label. Produces no PR; edits issues directly. Shares the planner lock with `/plan` via pod, so it must not call `coordination lock-planner` itself.
- `/plan` template (claude + codex): drop Step 3 (replan triage). That responsibility now belongs to `/replan`. A one-line pointer remains. Subsequent steps renumber.
- `pod/cli.py` `DEFAULT_CONFIG`: add `[worker_types.replan]` with `lock = "planner"` so new `pod init` projects pick up the new tier automatically.

Existing projects opt in by appending the worker-type block to their `.pod/config.toml`; the dispatch short-circuit from #58 is gated on `"replan" in worker_types`, so until they do, this PR is a no-op for them.

Full test suite: 324 passed.

🤖 Prepared with Claude Code