### PR TITLE
fix: stop repair agents spinning on stale `claimed_issue`

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -2194,14 +2194,22 @@ def _parse_codex_jsonl_line(line: bytes, state: AgentState):
             cmd = item.get("command", "")[:120]
             state.last_text = f"[exec] {cmd}"
             state.last_activity = time.time()
-            # Detect issue claim from coordination script output
+            # Detect issue claim from coordination script output.
+            # Anchor the regex to start-of-line so historical mentions in
+            # `git log`, `coordination orient`, `gh issue view`, etc. do not
+            # match. Skip for `repair`/`replan` workers, which do not claim
+            # issues — they claim PRs (repair) or edit issues directly
+            # (replan); a stray match would leave stale state for cleanup.
             output = item.get("aggregated_output", "")
-            m = re.search(r"Claimed issue #(\d+)", output)
-            if m:
-                state.claimed_issue = int(m.group(1))
+            if state.worker_type not in ("repair", "replan"):
+                m = re.search(r"^Claimed issue #(\d+)\s*$",
+                              output, re.MULTILINE)
+                if m:
+                    state.claimed_issue = int(m.group(1))
             # Detect PR repair claim from output (only on success — the command
             # emits "Claimed PR #N for repair" only after race-detect passes)
-            m_pr_claim = re.search(r"Claimed PR #(\d+) for repair", output)
+            m_pr_claim = re.search(r"^Claimed PR #(\d+) for repair\s*$",
+                                   output, re.MULTILINE)
             if m_pr_claim:
                 state.repair_pr = int(m_pr_claim.group(1))
             # Detect PR creation from coordination create-pr
@@ -2234,10 +2242,15 @@ def _parse_claude_jsonl_line(line: bytes, state: AgentState):
                 if isinstance(block, dict) and block.get("type") == "tool_result":
                     result_text = block.get("content", "")
                     if isinstance(result_text, str):
-                        m = re.search(r"Claimed issue #(\d+)", result_text)
-                        if m:
-                            state.claimed_issue = int(m.group(1))
-                        m_pr = re.search(r"Claimed PR #(\d+) for repair", result_text)
+                        # Same anchoring + worker_type guard as the codex
+                        # parser. See the codex path for the rationale.
+                        if state.worker_type not in ("repair", "replan"):
+                            m = re.search(r"^Claimed issue #(\d+)\s*$",
+                                          result_text, re.MULTILINE)
+                            if m:
+                                state.claimed_issue = int(m.group(1))
+                        m_pr = re.search(r"^Claimed PR #(\d+) for repair\s*$",
+                                         result_text, re.MULTILINE)
                         if m_pr:
                             state.repair_pr = int(m_pr.group(1))
         return
@@ -5732,7 +5745,12 @@ def _release_agent_resources(reason: str, skip_msg: str) -> None:
         # Unclaim issue if claimed and no PR yet — but only if no other
         # live agent is also working on this issue (prevents unclaiming
         # when killing duplicate claimants).
-        if state.claimed_issue > 0 and state.pr_number == 0:
+        # Skip for `repair`/`replan` workers: they do not own a claimed
+        # issue, so `claimed_issue` is meaningless for them (if it
+        # somehow holds a stale number, calling `coordination skip` on
+        # it just thrashes on closed issues).
+        if (state.claimed_issue > 0 and state.pr_number == 0
+                and state.worker_type not in ("repair", "replan")):
             try:
                 other_agents = read_all_agents()
             except Exception:
@@ -6134,8 +6152,14 @@ def agent_process_main(config: dict, agent_id: str | None = None,
 
         while _agent_proc.poll() is None:
             state.write()
-            # Track claim changes: write to history when claimed, clear when PR created
-            if state.claimed_issue > 0 and state.pr_number == 0:
+            # Track claim changes: write to history when claimed, clear
+            # when PR created. `repair`/`replan` workers do not own a
+            # claimed issue (repair tracks via `repair_pr`, replan edits
+            # directly), so skip the issue-claim bookkeeping for them —
+            # otherwise a stray `claimed_issue` from a buggy parser
+            # would pollute claim-history.json.
+            if (state.claimed_issue > 0 and state.pr_number == 0
+                    and state.worker_type not in ("repair", "replan")):
                 if state.claimed_issue != _last_tracked_issue:
                     record_claim(state.claimed_issue, state.uuid, state.short_id)
                     _last_tracked_issue = state.claimed_issue
@@ -6260,7 +6284,10 @@ def agent_process_main(config: dict, agent_id: str | None = None,
             # `released:True` entries). On transient GitHub failure (likely
             # under quota pressure), leave the history entry untouched so the
             # next housekeeping reconcile picks it up.
-            if state.claimed_issue > 0 and state.pr_number == 0:
+            # `repair`/`replan` workers do not legitimately own a claimed
+            # issue (see the symmetric cleanup-skip path below).
+            if (state.claimed_issue > 0 and state.pr_number == 0
+                    and state.worker_type not in ("repair", "replan")):
                 released_ok = False
                 try:
                     released_ok = _release_claim(
@@ -6296,7 +6323,13 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         #     claim entry pointing to our old session UUID; the next housekeeping
         #     cycle from any agent sees that UUID as dead and forks a new agent,
         #     causing unbounded agent proliferation.
-        if state.claimed_issue > 0 and state.pr_number == 0:
+        # Only runs for workers that actually claim issues (e.g. `work`,
+        # `plan`). `repair` claims PRs (tracked in `repair_pr`) and `replan`
+        # edits issues directly without claiming, so calling `coordination
+        # skip` on whatever happens to be in `claimed_issue` for those
+        # types just churns on closed-issue errors.
+        if (state.claimed_issue > 0 and state.pr_number == 0
+                and state.worker_type not in ("repair", "replan")):
             skip_ok = False
             try:
                 coordination(

--- a/tests/test_repair_state_bookkeeping.py
+++ b/tests/test_repair_state_bookkeeping.py
@@ -1,0 +1,198 @@
+"""Regression tests for the repair-agent bookkeeping bugs that caused
+unbounded dispatch loops on closed issues.
+
+Bug 1: Both Codex and Claude session parsers scanned ALL command output
+for the substring `Claimed issue #(\\d+)` and set `state.claimed_issue`
+to the matched number. The pattern matched historical mentions in
+unrelated output (`git log`, `coordination orient`, `gh issue view`,
+etc.), and applied even when the agent's `worker_type` was `repair` —
+which doesn't claim issues at all. Result: a stale `claimed_issue`
+pointing to some long-closed issue would be re-asserted on every
+command execution.
+
+Bug 2: The end-of-session cleanup path called `coordination skip
+<claimed_issue>` whenever `claimed_issue > 0 and pr_number == 0`, with
+no `worker_type` guard. For repair/replan agents (which never own a
+claimed issue), this called `skip` on whatever stale number the
+parser had written, repeatedly failed (closed issue), and pod
+re-dispatched the agent — a tight burn loop.
+
+Fixes:
+- Anchor the claim regex to start-of-line with MULTILINE, AND skip the
+  detection entirely for `repair`/`replan` workers.
+- Guard the cleanup-skip and quota-release paths with the same
+  worker_type check.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from unittest import mock
+
+from pod import cli
+
+
+def _agent_state(worker_type: str, **kw) -> cli.AgentState:
+    s = cli.AgentState()
+    s.short_id = "test"
+    s.uuid = "00000000-0000-0000-0000-000000000000"
+    s.worker_type = worker_type
+    for k, v in kw.items():
+        setattr(s, k, v)
+    return s
+
+
+def _codex_command_event(cmd: str, output: str) -> bytes:
+    return json.dumps({
+        "type": "item.completed",
+        "item": {
+            "type": "command_execution",
+            "command": cmd,
+            "aggregated_output": output,
+        },
+    }).encode()
+
+
+def _claude_tool_result(text: str) -> bytes:
+    return json.dumps({
+        "type": "user",
+        "message": {
+            "content": [
+                {"type": "tool_result", "content": text},
+            ],
+        },
+    }).encode()
+
+
+class CodexParserClaimedIssueTests(unittest.TestCase):
+    """The codex parser's claimed-issue regex must:
+      (a) only set state.claimed_issue from a canonical, line-anchored
+          `Claimed issue #N` line (the output of `coordination claim`);
+      (b) never set it for `repair` or `replan` workers.
+    """
+
+    def test_work_agent_canonical_claim_sets_claimed_issue(self):
+        state = _agent_state("work")
+        cli._parse_codex_jsonl_line(
+            _codex_command_event("coordination claim 42",
+                                 "Claimed issue #42\n"),
+            state)
+        self.assertEqual(state.claimed_issue, 42)
+
+    def test_work_agent_ignores_mid_line_historical_mention(self):
+        # `git log` or `coordination orient` may surface old claim
+        # comments. The anchored regex must not match them.
+        state = _agent_state("work")
+        cli._parse_codex_jsonl_line(
+            _codex_command_event(
+                "git log --oneline -20",
+                "abc123 chore: note that we Claimed issue #3399 last week\n"),
+            state)
+        self.assertEqual(state.claimed_issue, 0)
+
+    def test_repair_agent_never_sets_claimed_issue(self):
+        state = _agent_state("repair")
+        # Even a perfectly-formed line is ignored.
+        cli._parse_codex_jsonl_line(
+            _codex_command_event("coordination orient",
+                                 "Claimed issue #3399\n"),
+            state)
+        self.assertEqual(state.claimed_issue, 0)
+
+    def test_replan_agent_never_sets_claimed_issue(self):
+        state = _agent_state("replan")
+        cli._parse_codex_jsonl_line(
+            _codex_command_event("coordination list-replan",
+                                 "Claimed issue #3399\n"),
+            state)
+        self.assertEqual(state.claimed_issue, 0)
+
+    def test_repair_agent_still_records_repair_pr(self):
+        # The repair_pr regex must continue to fire for repair workers.
+        state = _agent_state("repair")
+        cli._parse_codex_jsonl_line(
+            _codex_command_event("coordination claim-pr-repair 3453",
+                                 "Claimed PR #3453 for repair\n"),
+            state)
+        self.assertEqual(state.repair_pr, 3453)
+        self.assertEqual(state.claimed_issue, 0)
+
+
+class ClaudeParserClaimedIssueTests(unittest.TestCase):
+    """Same invariants for the Claude JSONL parser."""
+
+    def test_work_agent_canonical_claim_sets_claimed_issue(self):
+        state = _agent_state("work")
+        cli._parse_claude_jsonl_line(
+            _claude_tool_result("Claimed issue #42\n"), state)
+        self.assertEqual(state.claimed_issue, 42)
+
+    def test_work_agent_ignores_mid_line_historical_mention(self):
+        state = _agent_state("work")
+        cli._parse_claude_jsonl_line(
+            _claude_tool_result(
+                "Earlier we Claimed issue #3399 but moved on.\n"),
+            state)
+        self.assertEqual(state.claimed_issue, 0)
+
+    def test_repair_agent_never_sets_claimed_issue(self):
+        state = _agent_state("repair")
+        cli._parse_claude_jsonl_line(
+            _claude_tool_result("Claimed issue #3399\n"), state)
+        self.assertEqual(state.claimed_issue, 0)
+
+    def test_replan_agent_never_sets_claimed_issue(self):
+        state = _agent_state("replan")
+        cli._parse_claude_jsonl_line(
+            _claude_tool_result("Claimed issue #3399\n"), state)
+        self.assertEqual(state.claimed_issue, 0)
+
+    def test_repair_agent_still_records_repair_pr(self):
+        state = _agent_state("repair")
+        cli._parse_claude_jsonl_line(
+            _claude_tool_result("Claimed PR #3453 for repair\n"), state)
+        self.assertEqual(state.repair_pr, 3453)
+        self.assertEqual(state.claimed_issue, 0)
+
+
+class CleanupSkipPathGuardTests(unittest.TestCase):
+    """The end-of-session cleanup-skip path (cli.py around L6312)
+    must not call `coordination skip` for `repair` or `replan`
+    workers, regardless of what `claimed_issue` happens to hold.
+
+    Rather than spin up the whole session-loop, we test the structural
+    invariant via a string-level inspection: every `coordination skip`
+    of `state.claimed_issue` is guarded by a worker-type check.
+    """
+
+    def test_cleanup_skip_callsite_is_worker_type_guarded(self):
+        import inspect
+        src = inspect.getsource(cli)
+        # Find all guards on `state.claimed_issue > 0 and state.pr_number == 0`
+        # — there are two: the quota-exhaustion release path and the
+        # general cleanup-skip path. Both must exclude repair/replan.
+        # Crude but stable check: the line containing the conjunction
+        # must also reference `worker_type` within the same `if`.
+        import re
+        # Find every occurrence of the conjunction
+        pattern = re.compile(
+            r"state\.claimed_issue\s*>\s*0\s+and\s+state\.pr_number\s*==\s*0"
+            r"(?:[\s\S]{0,200}?)(?:repair|replan|worker_type)",
+        )
+        matches = pattern.findall(src)
+        # Every callsite must be near a worker_type/repair/replan reference.
+        # If a new unguarded callsite is added, this fails.
+        callsite_count = len(re.findall(
+            r"state\.claimed_issue\s*>\s*0\s+and\s+state\.pr_number\s*==\s*0",
+            src))
+        self.assertEqual(
+            len(matches), callsite_count,
+            f"Found {callsite_count} `claimed_issue > 0 and pr_number == 0` "
+            f"call-sites but only {len(matches)} guarded by repair/replan/"
+            f"worker_type — every such call-site must skip repair/replan "
+            f"workers, otherwise pod will spin on closed issues.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR fixes a structural burn-loop in which `repair` (and now `replan`) agents would spin forever on stale `claimed_issue` values pointing to long-closed issues. Observed in production: four agents all reporting `repair #3399` despite #3399 having been merged hours earlier; each session exited in under 90 s without doing useful work, and pod re-dispatched them every tick (~$0.40 per spin under Codex).

Two intertwined bugs:

**Bug 1 — over-broad claim regex.** Both `_parse_codex_jsonl_line` and `_parse_claude_jsonl_line` scanned every command's stdout (or every tool_result for Claude) with `re.search(r"Claimed issue #(\d+)", …)`. The pattern matched historical mentions in `git log`, `coordination orient`, `gh issue view`, agent prose — and it applied regardless of `worker_type`. Repair agents, which never own a claimed issue, would have `state.claimed_issue` overwritten on every command execution to whatever stale number appeared.

Fix: anchor the regex to a complete line via `^Claimed issue #(\d+)\s*$` with `re.MULTILINE`, and skip the detection entirely for `worker_type in ("repair", "replan")`. Apply the same anchoring to the `Claimed PR #N for repair` regex for symmetry.

**Bug 2 — unguarded cleanup-skip.** Four call-sites check `state.claimed_issue > 0 and state.pr_number == 0` and then either call `coordination skip <claimed_issue>` or `record_claim`:

- end-of-session cleanup
- quota-exhaustion release path
- agent-teardown unclaim
- monitor-loop claim-history tracker

None had a `worker_type` guard. Any stale `claimed_issue` from Bug 1 produced a tight burn loop on a closed issue (`coordination skip` fails → claim retained → re-dispatch → repeat).

Fix: add `state.worker_type not in ("repair", "replan")` to all four call-sites. Per the existing comment at the monitor-loop tracker ("A repair agent never has a claimed_issue"), this invariant was already assumed but never enforced.

11 new regression tests cover both parsers, both edge cases (mid-line mention rejected, canonical-claim still accepted, repair PR claim still recorded), and a structural assertion that every `claimed_issue > 0 and pr_number == 0` call-site has a `worker_type`/`repair`/`replan` guard nearby (so new unguarded sites added later fail the test).

Full suite: 335 passed (was 324; +11 regression tests).

🤖 Prepared with Claude Code