### PR TITLE
fix: drop 30-min repair-claim cooldown

### DIFF
--- a/pod/coordination.py
+++ b/pod/coordination.py
@@ -1114,23 +1114,19 @@ def cmd_claim_pr_repair(ctx: CoordinationContext, argv: list[str]) -> int:
         print(f"CLAIM FAILED: PR #{pr_num} is already repair-claimed.")
         return 1
 
-    # Cooldown probe (30 min). Failure here must abort claim — we don't
-    # know whether someone else just claimed.
-    try:
-        cooldown_since = _now_epoch() - 1800
-        recent = _count_recent_repair_claims(client, ctx.repo, pr_num,
-                                              cooldown_since)
-    except _RaceCheckFailed as e:
-        print(f"CLAIM FAILED: cooldown check for PR #{pr_num} failed: {e}")
-        return 1
-    if recent > 0:
-        print(f"CLAIM FAILED: PR #{pr_num} was claimed for repair within "
-              "the last 30 minutes.")
-        return 1
-
     # Freeze the race-detect cutoff BEFORE posting so the layer's
     # rate-limit back-pressure (which can sleep up to 60s) can't push
     # our concurrent attempts past the window.
+    # No long-form cooldown: the `repair-claimed` label + race-detect
+    # window (RACE_SLEEP_SHORT, ~2 s) are sufficient to serialise
+    # concurrent claims. An older 30-minute comment-history cooldown
+    # was removed because crashed-session re-attempts were dominating
+    # legitimate parallel use, causing every fresh agent to walk the
+    # candidate list hitting `CLAIM FAILED: ... within the last 30
+    # minutes` on every PR. Dead-session cleanup is the housekeeping
+    # sweep's job; truly-unsalvageable PRs should be closed with
+    # `coordination close-pr-unsalvageable` so they exit the candidate
+    # list entirely.
     race_since = _now_epoch()
 
     client.gh_cli("pr", "edit", pr_num, "--repo", ctx.repo,

--- a/pod/data/agent-config/claude/commands/repair.md
+++ b/pod/data/agent-config/claude/commands/repair.md
@@ -21,8 +21,8 @@ Claim the top one:
 coordination claim-pr-repair <pr-number>
 ```
 
-If the claim output says the PR was claimed by another session in the last
-30 minutes, skip it and try the next one. If every candidate is claimed,
+If the claim output says the PR is already `repair-claimed` or you lost
+the race, skip it and try the next one. If every candidate is claimed,
 exit — a fresh dispatch will handle the work later.
 
 ## Two Outcomes, No Escalation

--- a/pod/data/agent-config/claude/skills/pr-repair-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/pr-repair-flow/SKILL.md
@@ -29,7 +29,7 @@ failing, abandon.
 | Command | Purpose |
 |---|---|
 | `coordination list-pr-repair` | Read-only list of PRs needing repair, priority-ordered (`conflict` > `failed` > `stuck`). No label writes. |
-| `coordination claim-pr-repair N` | Adds `repair-claimed` label + comment; 30 min cooldown. Fails if already claimed. |
+| `coordination claim-pr-repair N` | Adds `repair-claimed` label + comment, races detected via a short re-read. Fails if already claimed or another session won the race. |
 | `coordination mark-pr-salvaged N` | Clears `repair-claimed`, comments salvage summary. Call after a successful push. |
 | `coordination close-pr-unsalvageable N "reason"` | Closes PR, adds `unsalvageable`, removes `has-pr` on linked issue, adds `replan`. |
 
@@ -50,8 +50,8 @@ PR number out of `#<num> [<reason>] <title>` and claim it:
 coordination claim-pr-repair <pr-number>
 ```
 
-If the claim output says the PR was claimed by another session in the last
-30 minutes, move to the next candidate. If all candidates are claimed,
+If the claim output says the PR is already `repair-claimed` or you lost
+the race, move to the next candidate. If all candidates are claimed,
 exit — another dispatch will handle the work later.
 
 ## Step 2: Check Out the PR Branch

--- a/pod/data/agent-config/codex/commands/repair.md
+++ b/pod/data/agent-config/codex/commands/repair.md
@@ -10,8 +10,8 @@ Run `coordination list-pr-repair`. Output is one PR per line in priority
 order: `conflict` > `failed` > `stuck`. Claim the top one with
 `coordination claim-pr-repair <pr-number>`.
 
-If every candidate is already claimed by another session in the last
-30 minutes, exit — a fresh dispatch will handle the work later.
+If every candidate is already `repair-claimed` (or you lose the race on
+each), exit — a fresh dispatch will handle the work later.
 
 ## Diagnose and Fix
 

--- a/pod/data/agent-config/codex/skills/pr-repair-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/pr-repair-flow/SKILL.md
@@ -29,7 +29,7 @@ failing, abandon.
 | Command | Purpose |
 |---|---|
 | `coordination list-pr-repair` | Read-only list of PRs needing repair, priority-ordered (`conflict` > `failed` > `stuck`). No label writes. |
-| `coordination claim-pr-repair N` | Adds `repair-claimed` label + comment; 30 min cooldown. Fails if already claimed. |
+| `coordination claim-pr-repair N` | Adds `repair-claimed` label + comment, races detected via a short re-read. Fails if already claimed or another session won the race. |
 | `coordination mark-pr-salvaged N` | Clears `repair-claimed`, comments salvage summary. Call after a successful push. |
 | `coordination close-pr-unsalvageable N "reason"` | Closes PR, adds `unsalvageable`, removes `has-pr` on linked issue, adds `replan`. |
 
@@ -50,8 +50,8 @@ PR number out of `#<num> [<reason>] <title>` and claim it:
 coordination claim-pr-repair <pr-number>
 ```
 
-If the claim output says the PR was claimed by another session in the last
-30 minutes, move to the next candidate. If all candidates are claimed,
+If the claim output says the PR is already `repair-claimed` or you lost
+the race, move to the next candidate. If all candidates are claimed,
 exit — another dispatch will handle the work later.
 
 ## Step 2: Check Out the PR Branch

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -254,6 +254,120 @@ class ClaimTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Subcommand: claim-pr-repair
+# ---------------------------------------------------------------------------
+
+class ClaimPRRepairTests(unittest.TestCase):
+    """Repair-claim path: serialisation must come from the
+    `repair-claimed` label + the in-window race-detect (RACE_SLEEP_SHORT
+    re-read) only. There is no long-form comment-history cooldown — an
+    earlier 30-minute cooldown was removed because crashed-session
+    re-attempts dominated legitimate parallel use, sending every fresh
+    agent into a guaranteed-fail walk of the candidate list.
+    """
+
+    def test_already_repair_claimed_returns_1(self):
+        def handler(*argv):
+            if argv[:2] == ("pr", "view"):
+                return _gh_result(stdout="repair-claimed,has-pr")
+            return _gh_result()
+
+        with _capture_stdout() as buf, patch_client(gh_cli_handler=handler):
+            rc = coordination.cmd_claim_pr_repair(_make_ctx(), ["42"])
+        self.assertEqual(rc, 1)
+        self.assertIn("already repair-claimed", buf.getvalue())
+
+    def test_stale_old_repair_claim_comment_does_not_block(self):
+        """A `Claimed PR repair by session` comment older than the
+        race-detect cutoff (race_since = now-at-call) must NOT block the
+        claim. Pre-fix this would have failed with `... within the last
+        30 minutes`. Post-fix the only relevant signal is the label
+        plus the in-window re-read."""
+        def handler(*argv):
+            if argv[:2] == ("pr", "view"):
+                return _gh_result(stdout="has-pr")  # no repair-claimed
+            return _gh_result()
+
+        # One historical claim comment (old) plus our own (just posted).
+        # After race-detect (cache="none" re-read), only our own is in
+        # the post-cutoff window.
+        page = fake_response(200, body=[
+            {"body": "Claimed PR repair by session `old-dead` on branch `y`",
+             "created_at": "2020-01-01T00:00:00Z"},
+            {"body": "Claimed PR repair by session `sess-A` on branch `x`",
+             "created_at": "2026-05-12T00:00:00Z"},
+        ])
+
+        # Two _iso_to_epoch return values matter: the old comment must
+        # fall before race_since, and ours must fall after. Patch to a
+        # function that distinguishes by content.
+        def fake_iso(s):
+            if s.startswith("2020"):
+                return 1  # very old
+            return int(time.time()) + 10  # after race_since
+        with _capture_stdout() as buf, \
+             mock.patch("pod.coordination._iso_to_epoch",
+                        side_effect=fake_iso), \
+             patch_client(routes={
+                 ("GET", "/repos/owner/repo/issues/42/comments"): page,
+             }, gh_cli_handler=handler), \
+             mock.patch("time.sleep"):
+            rc = coordination.cmd_claim_pr_repair(
+                _make_ctx(session_id="sess-A"), ["42"])
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertNotIn("within the last 30 minutes", out)
+        self.assertIn("Claimed PR #42 for repair", out)
+
+    def test_clean_repair_claim_succeeds(self):
+        def handler(*argv):
+            if argv[:2] == ("pr", "view"):
+                return _gh_result(stdout="has-pr")
+            return _gh_result()
+        # Only our own claim comment present.
+        page = fake_response(200, body=[
+            {"body": "Claimed PR repair by session `sess-A` on branch `x`",
+             "created_at": "2026-05-12T00:00:00Z"},
+        ])
+        with _capture_stdout() as buf, \
+             mock.patch("pod.coordination._iso_to_epoch",
+                        return_value=int(time.time()) + 10), \
+             patch_client(routes={
+                 ("GET", "/repos/owner/repo/issues/42/comments"): page,
+             }, gh_cli_handler=handler), \
+             mock.patch("time.sleep"):
+            rc = coordination.cmd_claim_pr_repair(
+                _make_ctx(session_id="sess-A"), ["42"])
+        self.assertEqual(rc, 0)
+        self.assertIn("Claimed PR #42 for repair", buf.getvalue())
+
+    def test_race_lost_returns_1(self):
+        def handler(*argv):
+            if argv[:2] == ("pr", "view"):
+                return _gh_result(stdout="has-pr")
+            return _gh_result()
+        # Two in-window claim comments; alphabetically lower belongs to
+        # a different session — we lose the race.
+        page = fake_response(200, body=[
+            {"body": "Claimed PR repair by session `aaa-other` on branch `y`",
+             "created_at": "2026-05-12T00:00:00Z"},
+            {"body": "Claimed PR repair by session `sess-A` on branch `x`",
+             "created_at": "2026-05-12T00:00:00Z"},
+        ])
+        with _capture_stdout() as buf, \
+             mock.patch("pod.coordination._iso_to_epoch",
+                        return_value=int(time.time()) + 10), \
+             patch_client(routes={
+                 ("GET", "/repos/owner/repo/issues/42/comments"): page,
+             }, gh_cli_handler=handler), \
+             mock.patch("time.sleep"):
+            rc = coordination.cmd_claim_pr_repair(
+                _make_ctx(session_id="sess-A"), ["42"])
+        self.assertEqual(rc, 1)
+        self.assertIn("Race lost on PR #42", buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
 # Subcommand: skip
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR removes the 30-minute comment-history cooldown from `coordination claim-pr-repair`. The remaining serialisation — the `repair-claimed` label plus the `RACE_SLEEP_SHORT` (~2 s) race-detect re-read — is sufficient to prevent two agents repairing the same PR concurrently. The long cooldown was a heuristic backoff for crashed sessions that turned out to dominate legitimate parallel use: every label-removal (salvage / unsalvage / housekeeping sweep) leaves a stale `Claimed PR repair by session` comment visible for another 30 minutes, during which any fresh agent's claim was rejected with `CLAIM FAILED: ... within the last 30 minutes`.

`coordination list-pr-repair` did not honour this cooldown (it filters only on the label), so `_list_pr_repair_count` over-reported actionable candidates. Pod kept dispatching repair agents, every fresh agent walked the entire candidate list hitting cascading `CLAIM FAILED` rejections, sessions exited fast, pod re-dispatched. Observed in production: ~$0.40 per spin × 4 concurrent supervisors × continuous re-spawning until paused manually.

Without the cooldown:
- Two agents racing both add the label + comment within ~2 s; the loser's race-detect re-read finds the lower-sorted session UUID and exits.
- Dead-session cleanup is the housekeeping sweep's job (`check_dead_pr_claimed_prs`, ~10 min).
- Truly-unsalvageable PRs should use `coordination close-pr-unsalvageable` so they exit the candidate list entirely.

Template updates (claude + codex variants of `repair.md` and `pr-repair-flow/SKILL.md`) drop the "within the last 30 minutes" wording.

4 new regression tests (`ClaimPRRepairTests`):
- `test_already_repair_claimed_returns_1` — label still blocks
- `test_stale_old_repair_claim_comment_does_not_block` — the bug (old comment no longer rejects)
- `test_clean_repair_claim_succeeds` — green path
- `test_race_lost_returns_1` — race detection still works

Full suite: 339 passed (was 335; +4).

🤖 Prepared with Claude Code