### PR TITLE
fix: pod TUI loses newest items + drops `Blocked on` annotations

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1776,15 +1776,17 @@ class GHItem:
 _TUI_REFRESH_QUERY = """
 query TuiRefresh($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
-    openAgentPlan: issues(first: 100, states: OPEN,
-                           labels: ["agent-plan"]) {
+    openAgentPlan: issues(first: 200, states: OPEN,
+                           labels: ["agent-plan"],
+                           orderBy: {field: CREATED_AT, direction: DESC}) {
       nodes {
         number title createdAt updatedAt
         labels(first: 20) { nodes { name } }
       }
     }
     openHumanOversight: issues(first: 100, states: OPEN,
-                                 labels: ["human-oversight"]) {
+                                 labels: ["human-oversight"],
+                                 orderBy: {field: CREATED_AT, direction: DESC}) {
       nodes {
         number title createdAt updatedAt
         labels(first: 20) { nodes { name } }
@@ -1806,13 +1808,12 @@ query TuiRefresh($owner: String!, $name: String!) {
         labels(first: 20) { nodes { name } }
       }
     }
-    blocked: issues(first: 40, states: OPEN, labels: ["blocked"]) {
+    blocked: issues(first: 100, states: OPEN, labels: ["blocked"],
+                     orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes { number body }
     }
-    openIssueNumbers: issues(first: 100, states: OPEN) {
-      nodes { number }
-    }
-    hasPrIssues: issues(first: 40, states: OPEN, labels: ["has-pr"]) {
+    hasPrIssues: issues(first: 100, states: OPEN, labels: ["has-pr"],
+                         orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes {
         number
         closedByPullRequestsReferences(first: 20) {
@@ -1846,7 +1847,11 @@ _TUI_REFRESH_LOCK = threading.Lock()
 # Bump when `_TUI_REFRESH_QUERY` changes shape so an on-disk snapshot from
 # an older pod version is rejected instead of feeding the new code stale
 # data with missing keys (`openAgentPlan`, `blocked`, etc.).
-_TUI_CACHE_SCHEMA = 1
+# Schema 2 (2026-05-12): removed `openIssueNumbers` (dep resolution moved
+# to `fetch_issue_states`); added `orderBy: CREATED_AT DESC` to
+# `openAgentPlan`/`openHumanOversight` and `orderBy: UPDATED_AT DESC` to
+# `blocked`/`hasPrIssues`; bumped `openAgentPlan` cap to 200.
+_TUI_CACHE_SCHEMA = 2
 # One-shot flag: try the disk fallback exactly once per process, on the
 # first refresh tick after start-up. After that we either have live data
 # or we're already serving the in-memory copy.
@@ -1914,8 +1919,7 @@ def _load_tui_cache(slug: str) -> tuple[float, dict] | None:
     # shape (defence in depth on top of the schema-version check).
     required = ("openAgentPlan", "openHumanOversight",
                 "closedAgentPlan", "closedHumanOversight",
-                "blocked", "openIssueNumbers",
-                "hasPrIssues", "pullRequests")
+                "blocked", "hasPrIssues", "pullRequests")
     if not all(k in body for k in required):
         return None
     return (fetched_at, body)
@@ -2059,18 +2063,26 @@ def fetch_issues_and_prs() -> list[GHItem]:
 
 
 def fetch_blocked_deps() -> dict[int, list[int]]:
-    """Fetch open depends-on dependencies for blocked issues (closed
-    deps filtered out). Reads from the batched TUI GraphQL response."""
+    """For every blocked issue, return its currently-OPEN
+    `depends-on: #N` deps. Closed (or otherwise non-OPEN) deps are
+    filtered out; entries with no remaining open deps are dropped.
+
+    Dep states are resolved via `fetch_issue_states`, which does an
+    aliased-batch GraphQL lookup and TTL-caches the result on disk.
+    This avoids the older `openIssueNumbers` enumeration which capped
+    at 100 oldest open issues and silently dropped annotations on
+    repos with more than 100 open issues.
+
+    Fail-closed: deps whose state lookup fails are treated as not-open
+    (the annotation is hidden, never wrongly shown).
+    """
     import re as _re
     repo_node = _tui_refresh_batch()
     if repo_node is None:
         return {}
     blocked = ((repo_node.get("blocked") or {}).get("nodes")) or []
-    open_nums_nodes = ((repo_node.get("openIssueNumbers") or {})
-                        .get("nodes")) or []
-    open_nums = {n.get("number") for n in open_nums_nodes
-                 if isinstance(n, dict) and isinstance(n.get("number"), int)}
     raw: dict[int, list[int]] = {}
+    all_deps: set[int] = set()
     for iss in blocked:
         num = iss.get("number")
         if not isinstance(num, int):
@@ -2079,8 +2091,12 @@ def fetch_blocked_deps() -> dict[int, list[int]]:
         deps = [int(d) for d in _re.findall(r"depends-on: #(\d+)", body)]
         if deps:
             raw[num] = deps
+            all_deps.update(deps)
+    if not all_deps:
+        return {}
+    states = fetch_issue_states(_get_repo(), sorted(all_deps))
     return {num: filtered for num, deps in raw.items()
-            if (filtered := [d for d in deps if d in open_nums])}
+            if (filtered := [d for d in deps if states.get(d) == "OPEN"])}
 
 
 def fetch_has_pr_links() -> dict[int, list[int]]:
@@ -3556,6 +3572,134 @@ def fetch_issue_provenance(repo: str, issue_num: int) -> _IssueProvenance:
             f"failed to fetch provenance for {repo}#{issue_num}: "
             "GraphQL returned no issue node")
     return got[issue_num]
+
+
+# ---------------------------------------------------------------------------
+# Issue-state batched lookup (used by `fetch_blocked_deps` to resolve
+# `depends-on: #N` references without enumerating every open issue).
+# ---------------------------------------------------------------------------
+
+_ISSUE_STATE_BATCH_SIZE = 25  # aliases per GraphQL POST, matches provenance
+_ISSUE_STATE_TTL_SECONDS = 60.0  # how long a state lookup is reused
+
+
+def _build_issue_state_batch_query(count: int) -> str:
+    """Build a GraphQL query with `count` aliased single-issue lookups
+    returning just `number` and `state`. Each alias `i{k}` uses
+    `$num{k}: Int!`."""
+    aliases = "\n".join(
+        f"    i{k}: issue(number: $num{k}) {{ number state }}"
+        for k in range(count)
+    )
+    var_decls = ", ".join(f"$num{k}: Int!" for k in range(count))
+    return (
+        f"query IssueStateBatch($owner: String!, $name: String!, "
+        f"{var_decls}) {{\n"
+        f"  repository(owner: $owner, name: $name) {{\n"
+        f"{aliases}\n"
+        f"  }}\n"
+        f"}}\n"
+    )
+
+
+_ISSUE_STATE_CACHE_FILE = "issue-state-cache.json"
+
+
+def _issue_state_cache_path() -> Path:
+    return POD_DIR / _ISSUE_STATE_CACHE_FILE
+
+
+def _load_issue_state_cache() -> dict[str, dict]:
+    p = _issue_state_cache_path()
+    try:
+        return json.loads(p.read_text())
+    except (OSError, FileNotFoundError, json.JSONDecodeError, ValueError):
+        return {}
+
+
+def _save_issue_state_cache(cache: dict[str, dict]) -> None:
+    p = _issue_state_cache_path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(".tmp")
+        tmp.write_text(json.dumps(cache, separators=(",", ":"), sort_keys=True))
+        tmp.replace(p)
+    except OSError:
+        pass
+
+
+def _issue_state_cache_key(repo: str, num: int) -> str:
+    return f"{repo}#{num}"
+
+
+def fetch_issue_states(repo: str, nums: list[int]) -> dict[int, str]:
+    """Return `{issue_number: state}` for each number in `nums`.
+
+    State is `"OPEN"`, `"CLOSED"`, or `""` (lookup failed / not found).
+    Cached on disk at `.pod/issue-state-cache.json` with TTL
+    `_ISSUE_STATE_TTL_SECONDS`; only cache misses (or expired entries)
+    trigger a batched GraphQL POST. On transport failure for a chunk,
+    the affected numbers are omitted from the result (callers treat
+    absence as "not open" — fail-closed; the UI hides annotations
+    rather than ever showing wrong ones).
+    """
+    owner, _, name = repo.partition("/")
+    if not (owner and name) or not nums:
+        return {}
+
+    cache = _load_issue_state_cache()
+    now = time.time()
+    out: dict[int, str] = {}
+    misses: list[int] = []
+    # Dedupe while preserving order so test fixtures stay deterministic.
+    deduped = list(dict.fromkeys(int(n) for n in nums))
+    for n in deduped:
+        entry = cache.get(_issue_state_cache_key(repo, n))
+        if (isinstance(entry, dict)
+                and isinstance(entry.get("fetched_at"), (int, float))
+                and now - float(entry["fetched_at"]) < _ISSUE_STATE_TTL_SECONDS
+                and isinstance(entry.get("state"), str)):
+            out[n] = entry["state"]
+        else:
+            misses.append(n)
+
+    if not misses:
+        return out
+
+    client = gh.get_client()
+    cache_dirty = False
+    for start in range(0, len(misses), _ISSUE_STATE_BATCH_SIZE):
+        chunk = misses[start:start + _ISSUE_STATE_BATCH_SIZE]
+        query = _build_issue_state_batch_query(len(chunk))
+        variables: dict = {"owner": owner, "name": name}
+        for k, n in enumerate(chunk):
+            variables[f"num{k}"] = n
+        try:
+            resp = client.graphql(query, variables=variables, cache="none")
+        except Exception:
+            # Transport-level failure: skip this chunk, leave its entries
+            # missing from `out`. Callers fail-closed.
+            continue
+        if not resp.ok():
+            continue
+        body = resp.body() or {}
+        repo_node = (body.get("data") or {}).get("repository") or {}
+        for k, n in enumerate(chunk):
+            node = repo_node.get(f"i{k}")
+            state = ""
+            if isinstance(node, dict):
+                s = node.get("state")
+                if isinstance(s, str):
+                    state = s
+            out[n] = state
+            cache[_issue_state_cache_key(repo, n)] = {
+                "state": state, "fetched_at": now,
+            }
+            cache_dirty = True
+
+    if cache_dirty:
+        _save_issue_state_cache(cache)
+    return out
 
 
 def is_trusted(provenance: _IssueProvenance, config: dict) -> tuple[bool, str]:

--- a/tests/test_dep_state_resolution.py
+++ b/tests/test_dep_state_resolution.py
@@ -1,0 +1,212 @@
+"""Tests for `fetch_issue_states` — the aliased-batch GraphQL helper
+that `fetch_blocked_deps` uses to resolve `depends-on: #N` references.
+
+This replaces the older `openIssueNumbers` enumeration which had a
+silent 100-oldest cap and dropped annotations on repos with more than
+100 open issues. The new code resolves dep states via a per-number
+GraphQL lookup, batched (25 aliases per POST) and TTL-cached on disk.
+"""
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pod import cli
+
+from _gh_helpers import fake_response, patch_client
+
+
+class BuildIssueStateBatchQueryTests(unittest.TestCase):
+    def test_generates_n_aliases_and_variable_decls(self):
+        q = cli._build_issue_state_batch_query(3)
+        # 3 aliases.
+        for k in (0, 1, 2):
+            self.assertIn(f"i{k}: issue(number: $num{k})", q)
+        # Variable decls in the query signature.
+        self.assertIn("$num0: Int!", q)
+        self.assertIn("$num1: Int!", q)
+        self.assertIn("$num2: Int!", q)
+        # No fourth alias.
+        self.assertNotIn("i3:", q)
+
+    def test_only_requests_state_and_number(self):
+        q = cli._build_issue_state_batch_query(1)
+        # Should NOT request body / labels / comments — those are heavy and
+        # unnecessary. State + number is enough for dep-resolution.
+        self.assertNotIn("body", q)
+        self.assertNotIn("labels", q)
+        self.assertNotIn("comments", q)
+        self.assertRegex(q, r"i0: issue\(number: \$num0\) \{\s*number\s+state\s*\}")
+
+
+class FetchIssueStatesTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.cache_path = Path(self._tmp.name) / "issue-state-cache.json"
+        p = mock.patch.object(cli, "_issue_state_cache_path",
+                               return_value=self.cache_path)
+        p.start()
+        self.addCleanup(p.stop)
+
+    def _make_response(self, states_by_num):
+        """Build a GraphQL response body in which `i{k}` aliases map to
+        the supplied states_by_num. Order of nums in the response matches
+        insertion order of states_by_num."""
+        repo = {}
+        for k, (n, s) in enumerate(states_by_num.items()):
+            repo[f"i{k}"] = {"number": n, "state": s} if s is not None else None
+        return {"data": {"repository": repo}}
+
+    def test_empty_input_returns_empty_dict(self):
+        out = cli.fetch_issue_states("o/r", [])
+        self.assertEqual(out, {})
+
+    def test_single_batch_resolves_all_states(self):
+        body = self._make_response({100: "OPEN", 101: "CLOSED", 102: "OPEN"})
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(200, body=body),
+        }):
+            out = cli.fetch_issue_states("o/r", [100, 101, 102])
+        self.assertEqual(out, {100: "OPEN", 101: "CLOSED", 102: "OPEN"})
+
+    def test_multi_batch_when_over_25(self):
+        # 26 nums → two GraphQL POSTs. `patch_client` supports a list of
+        # responses per route, dispensed in call order.
+        nums = list(range(1000, 1026))
+        responses = [
+            fake_response(200, body=self._make_response(
+                {n: "OPEN" for n in nums[:25]})),
+            fake_response(200, body=self._make_response(
+                {nums[25]: "CLOSED"})),
+        ]
+        with patch_client(routes={
+            ("POST", "/graphql"): responses,
+        }) as client:
+            out = cli.fetch_issue_states("o/r", nums)
+        calls = [c for c in client.calls if c.get("path") == "/graphql"]
+        self.assertEqual(len(calls), 2)
+        v1 = calls[0]["json"]["variables"]
+        v2 = calls[1]["json"]["variables"]
+        self.assertEqual({k for k in v1 if k.startswith("num")},
+                         {f"num{k}" for k in range(25)})
+        self.assertEqual({k for k in v2 if k.startswith("num")}, {"num0"})
+        self.assertEqual(out[1000], "OPEN")
+        self.assertEqual(out[1025], "CLOSED")
+
+    def test_cache_hit_skips_graphql(self):
+        # Seed cache directly.
+        import time as _time
+        cli._save_issue_state_cache({
+            cli._issue_state_cache_key("o/r", 7): {
+                "state": "OPEN", "fetched_at": _time.time(),
+            },
+            cli._issue_state_cache_key("o/r", 8): {
+                "state": "CLOSED", "fetched_at": _time.time(),
+            },
+        })
+        # No routes registered — any GraphQL call would return the
+        # default 503 response. We assert that no POST happened at all.
+        with patch_client() as client:
+            out = cli.fetch_issue_states("o/r", [7, 8])
+        self.assertEqual(out, {7: "OPEN", 8: "CLOSED"})
+        gql_calls = [c for c in client.calls
+                     if c.get("path") == "/graphql"]
+        self.assertEqual(gql_calls, [])
+
+    def test_expired_cache_triggers_refetch(self):
+        # Seed with an expired entry.
+        cli._save_issue_state_cache({
+            cli._issue_state_cache_key("o/r", 7): {
+                "state": "OPEN",
+                "fetched_at": 0.0,  # epoch — definitely expired
+            },
+        })
+        body = self._make_response({7: "CLOSED"})
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(200, body=body),
+        }):
+            out = cli.fetch_issue_states("o/r", [7])
+        self.assertEqual(out, {7: "CLOSED"})
+
+    def test_transport_failure_omits_chunk(self):
+        # GraphQL returns 500 → caller must NOT receive any state for
+        # those nums. (Fail-closed: `fetch_blocked_deps` then drops them.)
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(500, body={}),
+        }):
+            out = cli.fetch_issue_states("o/r", [9, 10])
+        self.assertEqual(out, {})
+
+    def test_writes_cache_for_successful_lookups(self):
+        body = self._make_response({100: "OPEN"})
+        with patch_client(routes={
+            ("POST", "/graphql"): fake_response(200, body=body),
+        }):
+            cli.fetch_issue_states("o/r", [100])
+        raw = json.loads(self.cache_path.read_text())
+        key = cli._issue_state_cache_key("o/r", 100)
+        self.assertIn(key, raw)
+        self.assertEqual(raw[key]["state"], "OPEN")
+        self.assertGreater(raw[key]["fetched_at"], 0.0)
+
+
+class TuiRefreshQueryShapeTests(unittest.TestCase):
+    """Defence-in-depth: the GraphQL query string must include the
+    orderBy clauses we added, otherwise a future refactor could quietly
+    revert to oldest-first and the TUI would silently drop newest items
+    again. Also: `openIssueNumbers` must NOT be present (it was removed
+    in favour of `fetch_issue_states`)."""
+
+    def test_open_agent_plan_orders_newest_first(self):
+        q = cli._TUI_REFRESH_QUERY
+        # Pattern matches the openAgentPlan sub-query and its orderBy.
+        self.assertRegex(
+            q,
+            r"openAgentPlan: issues\([^)]*orderBy:\s*\{field:\s*CREATED_AT,"
+            r"\s*direction:\s*DESC\}",
+        )
+
+    def test_open_human_oversight_orders_newest_first(self):
+        self.assertRegex(
+            cli._TUI_REFRESH_QUERY,
+            r"openHumanOversight: issues\([^)]*orderBy:\s*\{field:\s*CREATED_AT,"
+            r"\s*direction:\s*DESC\}",
+        )
+
+    def test_blocked_orders_by_updated_desc(self):
+        self.assertRegex(
+            cli._TUI_REFRESH_QUERY,
+            r"blocked: issues\([^)]*orderBy:\s*\{field:\s*UPDATED_AT,"
+            r"\s*direction:\s*DESC\}",
+        )
+
+    def test_has_pr_issues_orders_by_updated_desc(self):
+        self.assertRegex(
+            cli._TUI_REFRESH_QUERY,
+            r"hasPrIssues: issues\([^)]*orderBy:\s*\{field:\s*UPDATED_AT,"
+            r"\s*direction:\s*DESC\}",
+        )
+
+    def test_open_agent_plan_cap_is_200(self):
+        # On repos at hex's scale the 100-issue cap was insufficient. The
+        # plan agreed bump to 200 gives headroom without paying for full
+        # pagination.
+        self.assertRegex(
+            cli._TUI_REFRESH_QUERY,
+            r"openAgentPlan: issues\(first:\s*200,",
+        )
+
+    def test_open_issue_numbers_removed(self):
+        self.assertNotIn("openIssueNumbers", cli._TUI_REFRESH_QUERY)
+
+    def test_cache_schema_is_2(self):
+        self.assertEqual(cli._TUI_CACHE_SCHEMA, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orphan_label_helpers.py
+++ b/tests/test_orphan_label_helpers.py
@@ -74,12 +74,21 @@ def _patch_batch(repo_node):
                               return_value=repo_node)
 
 
+def _patch_states(states_by_num):
+    """Patch `fetch_issue_states` to return the supplied {num: state} dict."""
+    return mock.patch.object(
+        cli, "fetch_issue_states",
+        side_effect=lambda repo, nums: {n: states_by_num.get(n, "")
+                                         for n in nums})
+
+
+def _patch_repo(slug="o/r"):
+    return mock.patch.object(cli, "_get_repo", return_value=slug)
+
+
 class FetchBlockedDepsTests(unittest.TestCase):
     def test_no_blocked_issues_yields_empty(self):
-        with _patch_batch({
-            "blocked": {"nodes": []},
-            "openIssueNumbers": {"nodes": []},
-        }):
+        with _patch_batch({"blocked": {"nodes": []}}), _patch_repo():
             self.assertEqual(cli.fetch_blocked_deps(), {})
 
     def test_includes_blocked_from_any_family_label(self):
@@ -88,30 +97,59 @@ class FetchBlockedDepsTests(unittest.TestCase):
         body = ("HO-2 work item.\n\n"
                 "depends-on: #2563\n"
                 "depends-on: #2564\n")
-        with _patch_batch({
-            "blocked": {"nodes": [_issue(2565, body=body)]},
-            "openIssueNumbers": {"nodes": [{"number": 2563}, {"number": 2564}]},
-        }):
+        with _patch_batch({"blocked": {"nodes": [_issue(2565, body=body)]}}), \
+             _patch_states({2563: "OPEN", 2564: "OPEN"}), \
+             _patch_repo():
             result = cli.fetch_blocked_deps()
         self.assertEqual(result, {2565: [2563, 2564]})
 
     def test_drops_closed_deps(self):
         body = "depends-on: #100\ndepends-on: #101\n"
-        with _patch_batch({
-            "blocked": {"nodes": [_issue(50, body=body)]},
-            "openIssueNumbers": {"nodes": [{"number": 100}]},  # 101 closed
-        }):
+        with _patch_batch({"blocked": {"nodes": [_issue(50, body=body)]}}), \
+             _patch_states({100: "OPEN", 101: "CLOSED"}), \
+             _patch_repo():
             result = cli.fetch_blocked_deps()
         self.assertEqual(result, {50: [100]})
 
     def test_omits_issue_with_all_deps_closed(self):
         body = "depends-on: #100\n"
-        with _patch_batch({
-            "blocked": {"nodes": [_issue(50, body=body)]},
-            "openIssueNumbers": {"nodes": []},  # all deps closed
-        }):
+        with _patch_batch({"blocked": {"nodes": [_issue(50, body=body)]}}), \
+             _patch_states({100: "CLOSED"}), \
+             _patch_repo():
             result = cli.fetch_blocked_deps()
         self.assertEqual(result, {})
+
+    def test_lookup_failure_fail_closed(self):
+        # A dep whose state lookup returned "" (transport failure) must
+        # NOT be reported as open — that would let a closed-issue
+        # annotation leak through.
+        body = "depends-on: #200\ndepends-on: #201\n"
+        with _patch_batch({"blocked": {"nodes": [_issue(60, body=body)]}}), \
+             _patch_states({200: "OPEN", 201: ""}), \
+             _patch_repo():
+            result = cli.fetch_blocked_deps()
+        self.assertEqual(result, {60: [200]})
+
+    def test_resolves_deps_outside_any_cap(self):
+        # Regression: pre-fix, deps were resolved against `openIssueNumbers`
+        # which capped at 100 oldest open issues. Recent deps were silently
+        # dropped, hiding `Blocked on #N` annotations. The new code passes
+        # whatever dep numbers it parses out of bodies directly to
+        # `fetch_issue_states`, so there is no cap.
+        body = "depends-on: #99999\n"
+        recv: list[int] = []
+
+        def capture(repo, nums):
+            recv.extend(nums)
+            return {n: "OPEN" for n in nums}
+
+        with _patch_batch({"blocked": {"nodes": [_issue(7, body=body)]}}), \
+             mock.patch.object(cli, "fetch_issue_states",
+                               side_effect=capture), \
+             _patch_repo():
+            result = cli.fetch_blocked_deps()
+        self.assertEqual(result, {7: [99999]})
+        self.assertEqual(recv, [99999])
 
 
 class FetchHasPrLinksTests(unittest.TestCase):
@@ -200,7 +238,6 @@ class BatchCacheTests(unittest.TestCase):
             "closedAgentPlan": {"nodes": []},
             "closedHumanOversight": {"nodes": []},
             "blocked": {"nodes": []},
-            "openIssueNumbers": {"nodes": []},
             "hasPrIssues": {"nodes": []},
             "pullRequests": {"nodes": []},
         }}}

--- a/tests/test_tui_cache.py
+++ b/tests/test_tui_cache.py
@@ -29,7 +29,6 @@ _VALID_REPO_NODE = {
     "closedAgentPlan": {"nodes": []},
     "closedHumanOversight": {"nodes": []},
     "blocked": {"nodes": []},
-    "openIssueNumbers": {"nodes": []},
     "hasPrIssues": {"nodes": []},
     "pullRequests": {"nodes": []},
 }


### PR DESCRIPTION
This PR fixes two TUI display bugs that come from one root cause: `_TUI_REFRESH_QUERY` has five GraphQL connection sub-queries with hardcoded `first: 100` and no `orderBy` clause. GitHub's default `issues(...)` ordering is oldest-first, so on any repo with more than ~100 open issues the TUI silently clips off the newest items.

Two observable symptoms on hex (~3640+ open issues):

1. **`queue: 2` but no open items visible.** `coordination queue-depth` correctly counted the two newest unclaimed `agent-plan` issues, but the TUI's `openAgentPlan` query returned the 100 oldest, clipping the newest entirely.
2. **Blocked issues shown without `Blocked on #N` annotations.** The `openIssueNumbers` sub-query (also `first: 100`, no orderBy) was the dep-state filter for `fetch_blocked_deps`. With `min=#1, max=#3628` in cache vs deps like #3637, recent deps were absent from the filter set → entry silently dropped → annotation vanished.

## Fixes

- `openAgentPlan`: `orderBy: CREATED_AT DESC`, bump `first: 100 → 200`.
- `openHumanOversight`: `orderBy: CREATED_AT DESC`.
- `blocked` / `hasPrIssues`: `orderBy: UPDATED_AT DESC`, bump `first: 40 → 100`.
- Remove `openIssueNumbers` entirely.
- New `fetch_issue_states(repo, nums) → {num: state}`: aliased-batch GraphQL lookup mirroring `fetch_issue_provenances` (25 aliases per POST), TTL-cached on disk (`.pod/issue-state-cache.json`, 60 s). Fail-closed on transport failure.
- Rewrite `fetch_blocked_deps` to parse `depends-on:` numbers from blocked-issue bodies, dedupe, resolve via `fetch_issue_states`. Exact regardless of repo size.
- Bump `_TUI_CACHE_SCHEMA` 1 → 2 so older on-disk caches are rejected.

## Cost

Zero extra POSTs on the main TUI refresh tick. One batched POST per ~60 s for dep-state resolution when blocked items exist (TTL-cached). With pod's existing 5000/hr GraphQL budget, the new lookups are < 1.5% utilisation overhead at hex's scale.

## Tests

18 new tests:
- `test_dep_state_resolution.py`: query shape, single + multi-batch, cache hit, cache expiry, transport failure fail-closed, disk write-through, plus structural assertions on `_TUI_REFRESH_QUERY` itself (orderBy presence on the four updated sub-queries, `openIssueNumbers` absence, schema = 2).
- `test_orphan_label_helpers.py`: `fetch_blocked_deps` now mocks `fetch_issue_states` instead of `openIssueNumbers`; adds fail-closed test + a regression test for deps that would have been outside any cap.
- `test_tui_cache.py`: drop `openIssueNumbers` from fixtures.

Full suite: 357 passed (was 339; +18 regression tests).

## Migration

After merge, on each runner: `uv tool upgrade dev-pod`, **restart the pod master** (it `os.fork()`s, so an existing supervisor keeps the old in-memory code indefinitely). The cache-schema bump forces fresh GraphQL on first start.

🤖 Prepared with Claude Code