### PR TITLE
fix: cap `openAgentPlan` first at GitHub's 100-per-connection limit

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1776,7 +1776,7 @@ class GHItem:
 _TUI_REFRESH_QUERY = """
 query TuiRefresh($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
-    openAgentPlan: issues(first: 200, states: OPEN,
+    openAgentPlan: issues(first: 100, states: OPEN,
                            labels: ["agent-plan"],
                            orderBy: {field: CREATED_AT, direction: DESC}) {
       nodes {

--- a/tests/test_dep_state_resolution.py
+++ b/tests/test_dep_state_resolution.py
@@ -192,13 +192,15 @@ class TuiRefreshQueryShapeTests(unittest.TestCase):
             r"\s*direction:\s*DESC\}",
         )
 
-    def test_open_agent_plan_cap_is_200(self):
-        # On repos at hex's scale the 100-issue cap was insufficient. The
-        # plan agreed bump to 200 gives headroom without paying for full
-        # pagination.
+    def test_open_agent_plan_cap_is_at_github_max(self):
+        # GitHub's GraphQL `first` is capped at 100 per connection;
+        # going above silently errors the entire batched query (HTTP
+        # 200 + `{"errors": [...]}` body, hard to debug from the
+        # caller side). Stay at 100 here. Hex-scale repos rely on
+        # `orderBy: CREATED_AT DESC` for newest-first visibility.
         self.assertRegex(
             cli._TUI_REFRESH_QUERY,
-            r"openAgentPlan: issues\(first:\s*200,",
+            r"openAgentPlan: issues\(first:\s*100,",
         )
 
     def test_open_issue_numbers_removed(self):


### PR DESCRIPTION
Follow-up to #62, which set `first: 200` on `openAgentPlan` to give hex-scale repos headroom. **GitHub's GraphQL API caps `first` at 100 per connection** — anything higher silently errors the entire batched query (HTTP 200 + `{"errors": [...]}` body, no exception thrown). `_tui_refresh_batch` then served the empty cached fallback, leaving the TUI items panel permanently blank.

Smoking gun from `.pod/gh-access.log`:
```
caller=cli.py:_tui_refresh_batch:1970  status=200  bytes=249
```
249 bytes is an error payload, not real data.

Revert to `first: 100`. The `orderBy: CREATED_AT DESC` from #62 stays — that's what makes the newest items visible. Anyone with more than 100 active agent-plan issues now sees the 100 most recent, still strictly better than the pre-#62 behaviour of returning the 100 oldest.

Test updated to assert `first: 100` and to document the 100-cap as GitHub-side, not aesthetic.

Full suite: 357 passed.

🤖 Prepared with Claude Code