### PR TITLE
fix(pod once): default to `work` when no label matches a worker type

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -7786,15 +7786,21 @@ def cmd_once(config: dict, args):
             if label in worker_types:
                 work_type = label
                 break
-        if not work_type:
+        if not work_type and "work" in worker_types:
+            work_type = "work"
+            print(f"Defaulting --type work for issue #{issue} "
+                  f"(labels={label_names!r} matched no worker type).")
+        elif not work_type:
             print(
                 f"Could not infer worker type for issue #{issue} from "
-                f"labels {label_names!r}. Pass --type explicitly "
+                f"labels {label_names!r}, and no `work` worker type is "
+                f"configured. Pass --type explicitly "
                 f"(one of: {', '.join(sorted(worker_types)) or 'feature'}).",
                 file=sys.stderr,
             )
             sys.exit(2)
-        print(f"Inferred --type {work_type} from labels {label_names!r}.")
+        else:
+            print(f"Inferred --type {work_type} from labels {label_names!r}.")
 
     pid = spawn_agent(config, target_issue=issue, target_type=work_type)
     print(

--- a/tests/test_once_mode.py
+++ b/tests/test_once_mode.py
@@ -175,6 +175,28 @@ class CmdOnceTests(unittest.TestCase):
                 cli.cmd_once(self._config(), args)
             self.assertEqual(ctx.exception.code, 2)
 
+    def test_falls_back_to_work_when_configured(self):
+        """When no label matches a worker_type but `work` is configured,
+        `pod once` defaults to `work` — `human-oversight`-only issues
+        (the common case for hand-written work items) shouldn't require
+        `--type work` explicitly."""
+        config = {
+            "worker_types": {
+                "work": {"prompt": "/work"},
+                "plan": {"prompt": "/plan"},
+                "repair": {"prompt": "/repair"},
+            }
+        }
+        args = types.SimpleNamespace(issue=3698, work_type=None)
+        with mock.patch.object(cli.subprocess, "check_output",
+                               return_value=self._gh_view(
+                                   ["human-oversight"])), \
+             mock.patch.object(cli, "spawn_agent",
+                               return_value=12345) as spawn:
+            cli.cmd_once(config, args)
+        spawn.assert_called_once()
+        self.assertEqual(spawn.call_args.kwargs["target_type"], "work")
+
     def test_closed_issue_rejected(self):
         args = types.SimpleNamespace(issue=3693, work_type=None)
         with mock.patch.object(cli.subprocess, "check_output",


### PR DESCRIPTION
This PR makes `pod once <issue>` fall back to the `work` worker type when an issue's labels match no configured worker type and `work` is configured.

Before this change, `pod once 3698` on an issue labelled only `human-oversight` exited with:

```
Could not infer worker type for issue #3698 from labels ['human-oversight']. Pass --type explicitly (one of: plan, repair, replan, work).
```

But `human-oversight` (and `agent-plan`) are queue/visibility markers — they describe where the issue came from, not which worker should handle it. The natural worker for both is `work`, and forcing `--type work` on every invocation is friction.

The fallback is announced on stdout (`Defaulting --type work for issue #N (labels=… matched no worker type).`) so the inference stays visible. Issues with no labels and no `work` worker type configured still exit cleanly with the original message.

🤖 Prepared with Claude Code