### PR TITLE
fix(pod once): clear `waiting_quota` status before one-shot setup

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -6221,6 +6221,10 @@ def agent_process_main(config: dict, agent_id: str | None = None,
             chosen_type = state.target_type or "feature"
             wt_config = worker_types.get(chosen_type, {})
             lock_name = ""
+            # Clear the `waiting_quota` status set before the (force_quota-
+            # short-circuited) quota loop, so the TUI shows worktree-setup
+            # / build-cache-copy progress rather than a stale wait label.
+            state.status = "dispatching"
             state.worker_type = chosen_type
             state.write()
             log(f"Agent {short_id}: one-shot mode, target issue #{state.target_issue} "
@@ -6231,6 +6235,7 @@ def agent_process_main(config: dict, agent_id: str | None = None,
             prompt = "You were interrupted mid-task. Review your conversation history and continue where you left off."
             lock_name = ""
             wt_config = {}
+            state.status = "dispatching"
             state.worker_type = chosen_type
             state.write()
             log(f"Agent {short_id}: resuming session {_resume_uuid}")


### PR DESCRIPTION
This PR fixes a status-display bug in one-shot (`pod once`) agents.

`spawn_agent` sets `state.status = "waiting_quota"` before its quota-wait loop. The normal dispatch branch then clears it to `"dispatching"`, but the one-shot branch (`state.target_issue`) and the resume branch fall through without updating status. For the `work` worker type — which sets `copy_build_cache = true` — the rsync of the build cache into the worktree takes minutes, during which the TUI keeps reporting `waiting_quota` even though `force_quota` short-circuited the wait and the agent is actively making progress.

Mirror the dispatch branch and set `status = "dispatching"` at the top of both fall-through paths.

🤖 Prepared with Claude Code