### PR TITLE
feat: per-agent dynamic Claude account + Codex leasing

### DIFF
--- a/pod/accounts.py
+++ b/pod/accounts.py
@@ -1,0 +1,714 @@
+"""Per-agent Claude account leasing, credential mirroring, and candidate
+enumeration.
+
+Pod runs multiple agents concurrently on one host. Historically every
+agent shared one ``CLAUDE_CONFIG_DIR`` and therefore one active Claude
+account: when that account exhausted its weekly Opus quota, every agent
+hit ``waiting_quota`` even though sibling accounts had headroom. This
+module is the per-agent layer that lets each agent pick — independently
+— the best available ``(backend, account, model)`` triple from the
+union of all ``~/.claude/credentials*.json`` accounts and Codex.
+
+Three guarantees:
+
+1. **Atomic lease + revalidate.** Account selection happens under a
+   host-wide meta-lock (``~/.claude/pod-account-leases/.lock``). The
+   chosen account is leased first, then its quota is re-probed; if the
+   quota dropped between probe and lease, the lease is released and
+   selection continues. Two agents cannot commit to the same account.
+
+2. **Refresh-safe credential mirroring.** Each agent has its own
+   isolated keychain entry (keyed by sha256 of its per-agent config
+   dir). On lease acquire we mirror the canonical
+   ``~/.claude/credentials<N>.json`` *only if* the isolated entry is
+   not already fresher. On release we harvest a fresher isolated token
+   back to canonical. All credential I/O is serialised by a
+   per-account file lock (``~/.claude/.<label>.credentials.lock``) so
+   pod, ``swap-account``, and the periodic launchd job interleave
+   safely.
+
+3. **Resume pinning.** When an agent resumes a JSONL session the
+   account it was originally on is the only valid candidate; mismatch
+   would silently fork the conversation or refresh under the wrong
+   account.
+
+Nothing in this module imports ``pod.cli`` — cli imports from here.
+Logging is injected via ``set_logger`` (no-op by default) so the unit
+tests can run without spinning up cli's filesystem layout.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import unicodedata
+from pathlib import Path
+from typing import Callable, Iterable, Iterator
+
+
+# --- Logging injection ------------------------------------------------------
+
+
+def _default_log(msg: str) -> None:  # pragma: no cover - replaced by cli
+    pass
+
+
+_log: Callable[[str], None] = _default_log
+
+
+def set_logger(fn: Callable[[str], None]) -> None:
+    """Install a process-wide logger. cli.py calls this at import time."""
+    global _log
+    _log = fn
+
+
+# --- Paths ------------------------------------------------------------------
+
+CLAUDE_DIR = Path.home() / ".claude"
+LEASE_DIR = CLAUDE_DIR / "pod-account-leases"
+LEASE_META_LOCK = LEASE_DIR / ".lock"
+
+
+def _credentials_path(account_num: int) -> Path:
+    return CLAUDE_DIR / f"credentials{account_num}.json"
+
+
+def _credential_lock_path(label: str) -> Path:
+    """Per-account credential file lock.
+
+    Lives alongside the canonical credential files. Held during read,
+    write, keychain mirror, and harvest. Shared with ``swap-account``'s
+    harvest path so concurrent invocations interleave safely.
+    """
+    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in label)
+    return CLAUDE_DIR / f".{safe}.credentials.lock"
+
+
+def _lease_path(label: str) -> Path:
+    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in label)
+    return LEASE_DIR / f"{safe}.lock"
+
+
+# --- File locks -------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _flock(path: Path, exclusive: bool = True,
+           blocking: bool = True) -> Iterator[bool]:
+    """Yield True iff the lock was acquired.
+
+    When ``blocking=False`` and contention is detected, yields False
+    without holding the lock — callers should treat that as "skip".
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(exist_ok=True)
+    fd = open(path)
+    op = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    if not blocking:
+        op |= fcntl.LOCK_NB
+    acquired = False
+    try:
+        try:
+            fcntl.flock(fd, op)
+            acquired = True
+        except (BlockingIOError, OSError):
+            yield False
+            return
+        yield True
+    finally:
+        if acquired:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+        fd.close()
+
+
+@contextlib.contextmanager
+def credential_lock(label: str) -> Iterator[None]:
+    """Hold the per-account credential lock for the duration of the block.
+
+    Use around any read/write of ``~/.claude/credentials<N>.json`` or
+    the corresponding macOS keychain entry. Blocking.
+    """
+    with _flock(_credential_lock_path(label), exclusive=True, blocking=True):
+        yield
+
+
+# --- Keychain service name --------------------------------------------------
+
+
+def claude_keychain_service(claude_config_dir: Path | None) -> str:
+    """Return the macOS keychain service name Claude Code uses.
+
+    Default ~/.claude dir → ``"Claude Code-credentials"``. A non-default
+    ``CLAUDE_CONFIG_DIR`` → ``"Claude Code-credentials-<sha256-hex8>"``
+    of the NFC-normalised path. Mirrors @anthropic-ai/claude-code.
+    """
+    if claude_config_dir is None:
+        return "Claude Code-credentials"
+    normalized = unicodedata.normalize("NFC", str(claude_config_dir))
+    suffix = hashlib.sha256(normalized.encode()).hexdigest()[:8]
+    return f"Claude Code-credentials-{suffix}"
+
+
+# --- Credential helpers -----------------------------------------------------
+
+
+def _read_credential_blob(path: Path) -> str | None:
+    try:
+        return path.read_text().strip() or None
+    except OSError:
+        return None
+
+
+def _parse_token_meta(blob: str) -> dict:
+    """Extract {expiresAt, accessTokenPrefix, accountLabel} from a JSON blob.
+
+    All fields are best-effort; missing/unparseable returns ``{}``.
+    """
+    try:
+        d = json.loads(blob)
+    except (TypeError, ValueError):
+        return {}
+    oauth = d.get("claudeAiOauth") or {}
+    out = {}
+    if "accountLabel" in d:
+        out["accountLabel"] = d["accountLabel"]
+    if "accessToken" in oauth:
+        out["accessTokenPrefix"] = oauth["accessToken"][:20]
+    for key in ("expiresAt", "expires_at"):
+        if key in oauth:
+            out["expiresAt"] = oauth[key]
+            break
+    return out
+
+
+def _keychain_read(service: str) -> str | None:
+    """Return the raw credential blob from the macOS keychain, or None."""
+    if sys.platform != "darwin":
+        return None
+    try:
+        r = subprocess.run(
+            ["security", "find-generic-password",
+             "-s", service, "-a", os.getenv("USER", ""), "-w"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    out = (r.stdout or "").strip()
+    return out or None
+
+
+def _keychain_write(service: str, blob: str) -> bool:
+    """Write the credential blob to the macOS keychain. True on success."""
+    if sys.platform != "darwin":
+        return False
+    user = os.getenv("USER", "")
+    hex_data = blob.encode().hex()
+    try:
+        subprocess.run(
+            ["security", "add-generic-password", "-U",
+             "-a", user, "-s", service, "-X", hex_data],
+            capture_output=True, timeout=5, check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            FileNotFoundError, OSError) as e:
+        _log(f"accounts: keychain write to {service} failed: {e}")
+        return False
+
+
+def resolve_claude_credential(claude_config_dir: Path | None) -> dict:
+    """Resolve the credential Claude Code will actually use at launch time.
+
+    Mirrors Claude Code's lookup order: keychain entry keyed by config
+    dir first, then ``.credentials.json`` fallback. Returns
+    ``{accountLabel, tokenPrefix, source}``; never raises.
+    """
+    service = claude_keychain_service(claude_config_dir)
+    blob = _keychain_read(service)
+    if blob:
+        meta = _parse_token_meta(blob)
+        return {
+            "accountLabel": meta.get("accountLabel", "?"),
+            "tokenPrefix": meta.get("accessTokenPrefix", ""),
+            "source": f"keychain[{service}]",
+        }
+    if claude_config_dir is not None:
+        creds_path = claude_config_dir / ".credentials.json"
+    else:
+        creds_path = CLAUDE_DIR / ".credentials.json"
+    blob = _read_credential_blob(creds_path)
+    if blob:
+        meta = _parse_token_meta(blob)
+        return {
+            "accountLabel": meta.get("accountLabel", "?"),
+            "tokenPrefix": meta.get("accessTokenPrefix", ""),
+            "source": f"file[{creds_path}]",
+        }
+    return {"accountLabel": "?", "tokenPrefix": "", "source": "none"}
+
+
+# --- Account enumeration ----------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class Account:
+    label: str
+    number: int
+    path: Path  # ~/.claude/credentials<N>.json
+
+
+def list_claude_accounts() -> list[Account]:
+    """Return all (label, number, path) accounts from ~/.claude/credentialsN.json.
+
+    Sorted by account number. Files that fail to parse or lack an
+    ``accountLabel`` are skipped (logged once).
+    """
+    out: list[Account] = []
+    try:
+        entries = sorted(CLAUDE_DIR.glob("credentials*.json"))
+    except OSError:
+        return out
+    for path in entries:
+        stem = path.stem  # "credentials3"
+        num_str = stem[len("credentials"):]
+        try:
+            num = int(num_str)
+        except ValueError:
+            continue
+        blob = _read_credential_blob(path)
+        if not blob:
+            continue
+        meta = _parse_token_meta(blob)
+        label = meta.get("accountLabel")
+        if not label or label == "?":
+            continue
+        out.append(Account(label=label, number=num, path=path))
+    return out
+
+
+# --- Lease layer ------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class Lease:
+    label: str
+    short_id: str
+    pid: int
+    project_dir: str
+    acquired_at: float
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+class LeaseError(Exception):
+    pass
+
+
+def _read_lease(path: Path) -> Lease | None:
+    try:
+        d = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    try:
+        return Lease(
+            label=d["label"],
+            short_id=d["short_id"],
+            pid=int(d.get("pid", 0)),
+            project_dir=d.get("project_dir", ""),
+            acquired_at=float(d.get("acquired_at", 0.0)),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+@contextlib.contextmanager
+def lease_critical_section() -> Iterator[None]:
+    """Acquire the host-wide lease meta-lock.
+
+    Hold across ``try_acquire_lease`` / ``release_lease`` calls so two
+    agents can't both create-or-skip the same lease atomically. Blocks.
+    """
+    LEASE_DIR.mkdir(parents=True, exist_ok=True)
+    with _flock(LEASE_META_LOCK, exclusive=True, blocking=True):
+        yield
+
+
+def try_acquire_lease(label: str, short_id: str,
+                       project_dir: str = "",
+                       pid: int | None = None) -> bool:
+    """Attempt to acquire ``label``'s lease for ``short_id``.
+
+    Must be called inside ``lease_critical_section()``. Returns True on
+    success, False if another agent holds the lease.
+    """
+    LEASE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _lease_path(label)
+    existing = _read_lease(path)
+    if existing is not None and existing.short_id != short_id:
+        return False
+    lease = Lease(
+        label=label,
+        short_id=short_id,
+        pid=pid if pid is not None else os.getpid(),
+        project_dir=project_dir,
+        acquired_at=time.time(),
+    )
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(lease.to_dict(), indent=2) + "\n")
+    tmp.rename(path)
+    return True
+
+
+def release_lease(label: str, short_id: str) -> bool:
+    """Release ``label``'s lease if held by ``short_id``.
+
+    Safe to call outside the meta-lock. Returns True if a lease was
+    removed, False if no lease existed or the owner did not match.
+    """
+    path = _lease_path(label)
+    existing = _read_lease(path)
+    if existing is None:
+        return False
+    if existing.short_id != short_id:
+        _log(f"accounts: refusing to release {label} lease held by "
+             f"{existing.short_id} (caller={short_id})")
+        return False
+    try:
+        path.unlink()
+        return True
+    except OSError:
+        return False
+
+
+def list_leases() -> list[Lease]:
+    """Return all current leases (label, owner, pid, acquired_at)."""
+    out: list[Lease] = []
+    if not LEASE_DIR.exists():
+        return out
+    for path in LEASE_DIR.iterdir():
+        if path.name == LEASE_META_LOCK.name or path.suffix == ".tmp":
+            continue
+        lease = _read_lease(path)
+        if lease is not None:
+            out.append(lease)
+    return out
+
+
+def evict_orphan_leases(live_short_ids: Iterable[str]) -> list[str]:
+    """Remove leases whose owner short_id is not in ``live_short_ids``.
+
+    Returns the labels of evicted leases. Must be called inside
+    ``lease_critical_section()``.
+    """
+    live = set(live_short_ids)
+    evicted: list[str] = []
+    for lease in list_leases():
+        if lease.short_id in live:
+            continue
+        try:
+            _lease_path(lease.label).unlink()
+            evicted.append(lease.label)
+            _log(f"accounts: evicted orphan lease for {lease.label} "
+                 f"(was owned by {lease.short_id})")
+        except OSError:
+            pass
+    return evicted
+
+
+# --- Credential mirror / harvest --------------------------------------------
+
+
+def _expires_at(blob: str | None) -> float:
+    """Return token expiresAt as a unix timestamp, or 0 if unknown.
+
+    Accepts either an ISO-8601 string or a numeric epoch (ms or s).
+    """
+    if not blob:
+        return 0.0
+    meta = _parse_token_meta(blob)
+    val = meta.get("expiresAt")
+    if val is None:
+        return 0.0
+    if isinstance(val, (int, float)):
+        # Assume ms if it's "too big" to be seconds-since-epoch in 2026
+        return float(val) / 1000.0 if val > 1e11 else float(val)
+    if isinstance(val, str):
+        try:
+            # fromisoformat in 3.11+ handles trailing Z via timespec parser?
+            from datetime import datetime
+            return datetime.fromisoformat(val.replace("Z", "+00:00")).timestamp()
+        except (ValueError, ImportError):
+            return 0.0
+    return 0.0
+
+
+def mirror_canonical_to_isolated(label: str, account_num: int,
+                                   claude_config_dir: Path) -> bool:
+    """Mirror ``~/.claude/credentials<N>.json`` into the agent's keychain
+    entry and ``<config_dir>/.credentials.json``.
+
+    Skips the write if the isolated entry's token already looks fresher
+    (newer ``expiresAt``). Returns True iff we wrote.
+
+    Held under the per-account credential lock for the duration. Safe
+    to call concurrently with ``harvest_isolated_to_canonical`` for
+    other agents on the same account because the lock is exclusive
+    per-account.
+    """
+    with credential_lock(label):
+        canonical = _read_credential_blob(_credentials_path(account_num))
+        if not canonical:
+            return False
+        service = claude_keychain_service(claude_config_dir)
+        isolated = _keychain_read(service)
+        if isolated and _expires_at(isolated) >= _expires_at(canonical):
+            # Isolated already has a token at least as fresh; don't clobber.
+            return False
+        wrote_kc = _keychain_write(service, canonical)
+        # Always write the file fallback so non-Darwin platforms work
+        # and so a session that bypasses the keychain still loads the
+        # right account.
+        claude_config_dir.mkdir(parents=True, exist_ok=True)
+        cred_file = claude_config_dir / ".credentials.json"
+        tmp = cred_file.with_suffix(".tmp")
+        tmp.write_text(canonical + ("\n" if not canonical.endswith("\n") else ""))
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        tmp.rename(cred_file)
+        if wrote_kc:
+            _log(f"accounts: mirrored canonical {label} → keychain {service}")
+        return True
+
+
+def harvest_isolated_to_canonical(label: str, account_num: int,
+                                    claude_config_dir: Path) -> bool:
+    """If the isolated keychain entry's token is fresher than the
+    canonical ``credentials<N>.json``, write it back atomically.
+
+    Returns True iff canonical was updated. Held under the per-account
+    credential lock for the duration.
+    """
+    with credential_lock(label):
+        service = claude_keychain_service(claude_config_dir)
+        isolated = _keychain_read(service)
+        if not isolated:
+            return False
+        canonical_path = _credentials_path(account_num)
+        canonical = _read_credential_blob(canonical_path)
+        if canonical and _expires_at(canonical) >= _expires_at(isolated):
+            return False
+        # Validate JSON before overwriting.
+        try:
+            json.loads(isolated)
+        except ValueError:
+            _log(f"accounts: refusing to harvest non-JSON blob for {label}")
+            return False
+        tmp = canonical_path.with_suffix(".json.tmp")
+        tmp.write_text(isolated + ("\n" if not isolated.endswith("\n") else ""))
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        tmp.rename(canonical_path)
+        _log(f"accounts: harvested refreshed {label} token → {canonical_path.name}")
+        return True
+
+
+# --- Quota probing ----------------------------------------------------------
+
+
+def probe_account(quota_cmd: str, label: str,
+                   force: bool = False) -> str | None:
+    """Run ``claude-available-model --account <label>`` and return its
+    stdout (e.g. ``"opus"``, ``"sonnet"``) or None if no quota / error.
+
+    ``force=True`` adds ``--force`` to bypass the helper's own cache.
+    Network/timeout errors yield None (treated as no quota).
+    """
+    if not quota_cmd:
+        return None
+    cmd = os.path.expanduser(quota_cmd)
+    args = [cmd]
+    if force:
+        args.append("--force")
+    if label:
+        args += ["--account", label]
+    try:
+        r = subprocess.run(args, capture_output=True, text=True, timeout=30)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        _log(f"accounts: probe({label}) failed: {e}")
+        return None
+    if r.returncode != 0:
+        return None
+    out = (r.stdout or "").strip()
+    return out or None
+
+
+def probe_codex(quota_cmd: str) -> bool:
+    """Return True iff Codex's quota helper says quota is available.
+
+    Codex has no per-account dimension on the helper side. Exit 0 with
+    non-empty stdout → available; exit 1 → exhausted; exit 2 →
+    cache-stale (treated as unavailable; the launchd refresher will
+    settle it within a minute).
+    """
+    if not quota_cmd:
+        return True
+    cmd = os.path.expanduser(quota_cmd)
+    try:
+        r = subprocess.run([cmd], capture_output=True, text=True, timeout=30)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    return r.returncode == 0 and bool((r.stdout or "").strip())
+
+
+# --- Candidate enumeration --------------------------------------------------
+
+
+# Local copy of the tier ordering. Imported by cli.py too via
+# `from pod.accounts import MODEL_TIER`. Kept here to avoid pod.cli ↔
+# pod.accounts circular imports.
+MODEL_TIER: dict[str, dict[str, int]] = {
+    "claude": {"sonnet": 1, "opus": 2},
+    "codex": {"gpt-5.4": 1, "gpt-5.5": 2},
+}
+
+
+def model_tier(backend: str, model: str) -> int:
+    return MODEL_TIER.get(backend, {}).get(model, 0)
+
+
+@dataclasses.dataclass(frozen=True)
+class Candidate:
+    backend: str       # "claude" or "codex"
+    label: str         # account label (Claude only; "" for Codex)
+    model: str         # selected model — propagated to launch_agent
+    account_num: int = 0  # for Claude credential mirroring
+
+
+def _claude_candidates_for(label: str, available: str | None,
+                             accepted_models: list[str]) -> Iterator[Candidate]:
+    """Yield the highest-tier Candidate this account can satisfy.
+
+    Iterates ``accepted_models`` in the configured order and yields the
+    first one whose tier the available model meets. (Only one Candidate
+    per account — we don't yield both opus and sonnet for the same
+    account; the agent would only ever launch one of them.)
+    """
+    if not available:
+        return
+    avail_tier = model_tier("claude", available)
+    for want in accepted_models:
+        if avail_tier >= model_tier("claude", want):
+            yield Candidate(backend="claude", label=label, model=want)
+            return
+
+
+def enumerate_candidates(
+    *,
+    claude_accounts: list[Account],
+    available_by_label: dict[str, str | None],
+    accepted_models: list[str],
+    codex_available: bool,
+    codex_model: str,
+    prefer: str,
+    pin_label: str | None = None,
+) -> list[Candidate]:
+    """Build the ordered candidate list for one selection pass.
+
+    Args:
+      claude_accounts: result of ``list_claude_accounts()``
+      available_by_label: ``label -> "opus"|"sonnet"|None`` (probe results)
+      accepted_models: ordered model tiers the agent will accept,
+        e.g. ``["opus", "sonnet"]``. First-satisfiable wins per account.
+      codex_available: result of ``probe_codex(...)``
+      codex_model: model name to launch codex with
+      prefer: ``"claude"`` or ``"codex"`` — backend ordering hint
+      pin_label: if set, restrict Claude candidates to this account
+        (resume-pinning). Codex is excluded when pinned.
+
+    Returns the ordered list; an empty list means "wait".
+    """
+    claude_cands: list[Candidate] = []
+    accounts_by_label = {a.label: a for a in claude_accounts}
+    iter_labels: Iterable[str]
+    if pin_label is not None:
+        iter_labels = [pin_label] if pin_label in accounts_by_label else []
+    else:
+        iter_labels = [a.label for a in claude_accounts]
+    for label in iter_labels:
+        avail = available_by_label.get(label)
+        for cand in _claude_candidates_for(label, avail, accepted_models):
+            account = accounts_by_label[label]
+            claude_cands.append(dataclasses.replace(
+                cand, account_num=account.number))
+    codex_cands: list[Candidate] = []
+    if pin_label is None and codex_available:
+        codex_cands.append(Candidate(
+            backend="codex", label="", model=codex_model))
+    if prefer == "codex":
+        return codex_cands + claude_cands
+    return claude_cands + codex_cands
+
+
+# --- Per-agent CLAUDE_CONFIG_DIR --------------------------------------------
+
+
+def agent_claude_config_dir(pod_dir: Path, short_id: str) -> Path:
+    """Return the per-agent CLAUDE_CONFIG_DIR for ``short_id``.
+
+    Always under ``<pod_dir>/claude-config/<short_id>/``. Materialised
+    on demand by ``ensure_agent_claude_config_dir``.
+    """
+    return pod_dir / "claude-config" / short_id
+
+
+def ensure_agent_claude_config_dir(pod_dir: Path, short_id: str) -> Path:
+    """Create the agent's isolated CLAUDE_CONFIG_DIR with minimal contents.
+
+    Idempotent. Creates ``projects/`` for JSONL transcripts and writes
+    a minimal ``settings.json``. The ``.credentials.json`` file is
+    written by ``mirror_canonical_to_isolated`` once an account is
+    leased — *not* here, since we don't know yet which account this
+    agent will use.
+    """
+    config_dir = agent_claude_config_dir(pod_dir, short_id)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = config_dir / "settings.json"
+    if not settings_path.exists():
+        settings_path.write_text('{"skipDangerousModePermissionPrompt": true}\n')
+    (config_dir / "projects").mkdir(exist_ok=True)
+    return config_dir
+
+
+def cleanup_agent_claude_config_dir(pod_dir: Path, short_id: str) -> None:
+    """Remove the per-agent CLAUDE_CONFIG_DIR (e.g. on agent exit).
+
+    Tolerates missing dirs. The macOS keychain entry keyed by sha256
+    of the path is *not* cleaned up here — keychain entries cost ~nil
+    and removing them would lose any refreshed token that hasn't been
+    harvested back. Stale keychain entries from past short_ids are
+    harmless because new agents get a new short_id and therefore a
+    new keychain key.
+    """
+    config_dir = agent_claude_config_dir(pod_dir, short_id)
+    try:
+        shutil.rmtree(config_dir, ignore_errors=True)
+    except OSError:
+        pass

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -46,6 +46,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from pod import accounts
 from pod import github as gh
 
 
@@ -148,11 +149,19 @@ quota_retry_seconds = 60           # Auto-mode sleep when no backend has quota
 prefer = "codex"                   # Tie-break when both backends have quota
 
 [agent.claude]
-model = "opus"                     # Claude model to use
+model = "opus"                     # Claude model to use (back-compat default)
+# Ordered list of acceptable model tiers; first satisfiable per account
+# wins. Set to ["opus"] to require Opus, ["opus", "sonnet"] to fall
+# through to Sonnet when no account has Opus quota. Absent → [model].
+accepted_models = ["opus"]
 quota_check = "~/.claude/skills/claude-usage/claude-available-model"
 quota_check_required = true        # Hard-fail if quota unavailable
 quota_retry_seconds = 60           # Sleep duration when quota unavailable
-isolated_config = true             # Use pod-managed isolated CLAUDE_CONFIG_DIR for agents
+# When isolated_config = true, each agent gets its own
+# CLAUDE_CONFIG_DIR under .pod/claude-config/<short_id>/ with its own
+# keychain entry, so different agents can simultaneously run on
+# different Claude accounts.
+isolated_config = true             # Use per-agent CLAUDE_CONFIG_DIR for agents
 
 [agent.codex]
 model = "gpt-5.4"                  # Codex model to use
@@ -422,51 +431,50 @@ def ensure_config() -> dict:
     return cfg
 
 
-def get_isolated_config_dir(config: dict) -> Path | None:
-    """Return isolated CLAUDE_CONFIG_DIR path, or None if disabled/Codex-only.
+def _claude_isolation_enabled(config: dict) -> bool:
+    """True iff Claude agents should use a per-agent CLAUDE_CONFIG_DIR.
 
-    Returns the path for `claude` and `auto` backends (auto may pick Claude
-    in any iteration); returns None for `codex`. Codex isolation is handled
-    by `_setup_codex_home()` inside `launch_agent()` via `CODEX_HOME`.
+    Returns False when the configured backend is Codex-only or when
+    ``isolated_config`` is explicitly off for Claude.
     """
     if _backend(config) == "codex":
+        return False
+    return bool(_backend_cfg(
+        config, "isolated_config", backend="claude", default=False))
+
+
+def get_isolated_config_dir(config: dict,
+                              short_id: str | None = None) -> Path | None:
+    """Return the CLAUDE_CONFIG_DIR for ``short_id``, or None if disabled.
+
+    With per-agent isolation enabled, each agent gets its own
+    ``.pod/claude-config/<short_id>/`` directory. Passing
+    ``short_id=None`` returns the root claude-config dir (callers that
+    don't yet know the agent id, e.g. legacy code paths).
+    """
+    if not _claude_isolation_enabled(config):
         return None
-    if not _backend_cfg(config, "isolated_config", backend="claude", default=False):
+    if short_id is None:
+        return ISOLATED_CONFIG_DIR
+    return accounts.agent_claude_config_dir(POD_DIR, short_id)
+
+
+def ensure_isolated_config(config: dict,
+                            short_id: str | None = None) -> Path | None:
+    """Materialise the agent's CLAUDE_CONFIG_DIR. Returns path or None if disabled.
+
+    Creates the per-agent dir with ``settings.json`` and ``projects/``.
+    The ``.credentials.json`` file is *not* written here — it lands
+    when ``accounts.mirror_canonical_to_isolated`` runs at lease
+    acquisition (which selects the specific account to use).
+    """
+    if not _claude_isolation_enabled(config):
         return None
-    return ISOLATED_CONFIG_DIR
-
-
-def ensure_isolated_config(config: dict) -> Path | None:
-    """Set up isolated CLAUDE_CONFIG_DIR for agents. Returns path or None if disabled."""
-    config_dir = get_isolated_config_dir(config)
-    if config_dir is None:
-        return None
-
-    config_dir.mkdir(parents=True, exist_ok=True)
-
-    # Minimal settings — no hooks, no plugins, no global CLAUDE.md
-    settings_path = config_dir / "settings.json"
-    settings_path.write_text('{"skipDangerousModePermissionPrompt": true}\n')
-
-    # Symlink credentials from ~/.claude/ so subscription auth works.
-    # Race-safe: use try/except since multiple agents may run this concurrently.
-    real_claude = Path.home() / ".claude"
-    cred_link = config_dir / ".credentials.json"
-    cred_target = real_claude / ".credentials.json"
-    if cred_target.exists():
-        try:
-            cred_link.unlink(missing_ok=True)
-            cred_link.symlink_to(cred_target)
-        except FileExistsError:
-            pass  # Another process created it first — fine
-    else:
-        # Clean up stale symlink if source credential file is gone
-        cred_link.unlink(missing_ok=True)
-
-    # JSONL session storage
-    (config_dir / "projects").mkdir(exist_ok=True)
-
-    return config_dir
+    if short_id is None:
+        # Legacy callers (very rare): fall back to the shared dir.
+        ISOLATED_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        return ISOLATED_CONFIG_DIR
+    return accounts.ensure_agent_claude_config_dir(POD_DIR, short_id)
 
 
 def _instruction_file_warning(git_root: Path, backend: str) -> str | None:
@@ -635,6 +643,11 @@ def say(msg: str):
     line = f"[{ts}] {msg}"
     print(line, file=sys.stderr)
     log(msg)
+
+
+# Route pod.accounts diagnostics through pod's logger so everything
+# lands in .pod/pod.log under the same timestamp format.
+accounts.set_logger(log)
 
 
 # ---------------------------------------------------------------------------
@@ -850,6 +863,15 @@ class AgentState:
     resume_session_uuid: str = ""  # If set, first iteration uses this UUID (to resume conversation)
     backend: str = "claude"        # "claude" or "codex" (for per-backend pricing lookup)
     model: str = ""                # e.g. "opus", "gpt-5.4" (for per-model pricing lookup)
+    # Per-agent account lease (Claude only). `account_label` is the
+    # currently-held lease; "" when waiting or running Codex.
+    # `lease_acquired_at` is a wall-clock timestamp used for stale-lease
+    # debugging and orphan eviction. `claude_config_dir` is the per-agent
+    # CLAUDE_CONFIG_DIR so the TUI and crash-recovery can locate the
+    # isolated config without recomputing the short_id mapping.
+    account_label: str = ""
+    lease_acquired_at: float = 0.0
+    claude_config_dir: str = ""
     # One-shot mode: agent claims and works on `target_issue` once with the
     # given `target_type` prompt, then exits. Set by `pod once`. Bypasses
     # dispatch_queue_balance, the planner / replan / repair lock dance, and
@@ -1479,133 +1501,24 @@ def _model_tier(backend: str, model: str) -> int:
     return _MODEL_TIER.get(backend, {}).get(model, 0)
 
 
-def _claude_keychain_service(claude_config_dir: Path | None) -> str:
-    """Compute the macOS keychain service name Claude Code uses for credentials.
-
-    Mirrors @anthropic-ai/claude-code's lookup: the service is
-    "Claude Code-credentials" for the default ~/.claude config dir, or
-    "Claude Code-credentials-<sha256(NFC(config_dir))[:8]>" when
-    CLAUDE_CONFIG_DIR is set.
-    """
-    import hashlib
-    import unicodedata
-    if claude_config_dir is None:
-        return "Claude Code-credentials"
-    normalized = unicodedata.normalize("NFC", str(claude_config_dir))
-    suffix = hashlib.sha256(normalized.encode()).hexdigest()[:8]
-    return f"Claude Code-credentials-{suffix}"
-
-
-def resolve_claude_credential(claude_config_dir: Path | None) -> dict:
-    """Resolve the credential Claude Code will actually use at launch time.
-
-    Mirrors Claude Code's lookup order: the macOS keychain entry keyed by
-    sha256(CLAUDE_CONFIG_DIR) first, then the plaintext
-    ``$CLAUDE_CONFIG_DIR/.credentials.json`` fallback.
-
-    Returns {accountLabel, tokenPrefix, source}.
-    """
-    import json as _json
-    service = _claude_keychain_service(claude_config_dir)
-
-    try:
-        r = subprocess.run(
-            ["security", "find-generic-password",
-             "-s", service, "-a", os.getenv("USER", ""), "-w"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if r.returncode == 0 and r.stdout.strip():
-            kc = _json.loads(r.stdout.strip())
-            return {
-                "accountLabel": kc.get("accountLabel", "?"),
-                "tokenPrefix": kc.get("claudeAiOauth", {}).get("accessToken", "")[:20],
-                "source": f"keychain[{service}]",
-            }
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError, ValueError):
-        pass
-
-    if claude_config_dir is not None:
-        creds_path = claude_config_dir / ".credentials.json"
-    else:
-        creds_path = Path.home() / ".claude" / ".credentials.json"
-    try:
-        with open(creds_path) as f:
-            creds = _json.load(f)
-        symlink = ""
-        if creds_path.is_symlink():
-            symlink = f" -> {os.readlink(creds_path)}"
-        return {
-            "accountLabel": creds.get("accountLabel", "?"),
-            "tokenPrefix": creds.get("claudeAiOauth", {}).get("accessToken", "")[:20],
-            "source": f"file[{creds_path}]{symlink}",
-        }
-    except (OSError, ValueError):
-        pass
-
-    return {"accountLabel": "?", "tokenPrefix": "", "source": "none"}
-
-
-def _sync_isolated_credential(claude_config_dir: Path | None) -> None:
-    """Mirror the default Claude credential into the isolated config's keychain entry.
-
-    Claude Code derives a per-config-dir keychain service name (suffix =
-    sha256(config_dir)[:8]). `swap-account` only updates the unsuffixed
-    default entry, so without this sync agents stay pinned to whichever
-    account was active when the isolated entry was first written. Run this
-    before each quota check and each agent launch so swap-account changes
-    propagate transparently.
-    """
-    if claude_config_dir is None or sys.platform != "darwin":
-        return
-    default = resolve_claude_credential(None)
-    isolated = resolve_claude_credential(claude_config_dir)
-    if default.get("source") == "none":
-        return
-    if (default.get("accountLabel") == isolated.get("accountLabel")
-            and default.get("tokenPrefix") == isolated.get("tokenPrefix")):
-        return
-    user = os.getenv("USER", "")
-    blob: str | None = None
-    try:
-        r = subprocess.run(
-            ["security", "find-generic-password",
-             "-s", "Claude Code-credentials", "-a", user, "-w"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if r.returncode == 0 and r.stdout.strip():
-            blob = r.stdout.strip()
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        pass
-    if blob is None:
-        try:
-            with open(Path.home() / ".claude" / ".credentials.json") as f:
-                blob = f.read().strip()
-        except (OSError, ValueError):
-            return
-    service = _claude_keychain_service(claude_config_dir)
-    hex_data = blob.encode().hex()
-    try:
-        subprocess.run(
-            ["security", "add-generic-password", "-U",
-             "-a", user, "-s", service, "-X", hex_data],
-            capture_output=True, timeout=5, check=True,
-        )
-        log(f"Mirrored credential [{default.get('accountLabel')}] → "
-            f"isolated keychain [{service}] (was [{isolated.get('accountLabel')}])")
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
-            FileNotFoundError, OSError) as e:
-        log(f"Failed to mirror credential to {service}: {e}")
+# Keychain service name + credential resolution moved to `pod.accounts`
+# so the lease layer and cli.py share one source of truth. Keep
+# back-compat aliases at module scope for any callers that still expect
+# the cli-level names.
+_claude_keychain_service = accounts.claude_keychain_service
+resolve_claude_credential = accounts.resolve_claude_credential
 
 
 def _backend_available(config: dict, backend: str,
                         claude_config_dir: Path | None = None) -> bool:
-    """Check whether `backend` has available quota right now.
+    """Legacy single-account quota check. True iff ``backend``'s quota
+    helper reports ≥ the configured model tier.
 
-    For Claude, resolves the credential Claude Code will actually use for
-    ``claude_config_dir`` and asks the quota helper about *that* account
-    specifically — otherwise the helper inspects whichever account owns the
-    default keychain entry, which may differ from the one launched sessions
-    actually hit.
+    Kept for back-compat with ``select_available_backend`` (and a couple
+    of tests). The agent loop calls ``acquire_backend`` instead, which
+    enumerates every Claude account and atomically leases the best one.
+    Does *not* mutate the keychain — credential mirroring is now part
+    of lease acquisition in ``acquire_backend``.
     """
     cmd = os.path.expanduser(_backend_cfg(config, "quota_check", backend=backend, default=""))
     if not cmd:
@@ -1613,7 +1526,8 @@ def _backend_available(config: dict, backend: str,
     quota_required = _backend_cfg(config, "quota_check_required", backend=backend, default=True)
     args = [cmd]
     if backend == "claude":
-        _sync_isolated_credential(claude_config_dir)
+        # Use the module-level alias so existing tests can patch
+        # `cli.resolve_claude_credential` and intercept this call.
         resolved = resolve_claude_credential(claude_config_dir)
         label = resolved.get("accountLabel", "")
         if label and label != "?":
@@ -1648,19 +1562,12 @@ def _auto_backend_order(config: dict) -> list[str]:
 
 def select_available_backend(config: dict, force: bool = False,
                               claude_config_dir: Path | None = None) -> str | None:
-    """Pick the backend to run for this iteration.
+    """Legacy single-account backend picker, returning just a backend name.
 
-    Returns the backend name (`"claude"` or `"codex"`), or `None` if no
-    backend has available quota.
-
-    - Fixed mode (`agent.backend = "claude"` or `"codex"`): returns that
-      backend if its quota check passes, else None.
-    - Auto mode (`agent.backend = "auto"`): tries each backend in the
-      preference order from `[agent.auto].prefer` and returns the first
-      one whose quota check passes.
-
-    `force` (or the global `FORCE_QUOTA_FILE` flag) bypasses quota checks
-    entirely; in auto mode this returns the preferred backend.
+    Wraps ``_backend_available`` over the configured backend(s) and
+    returns the first one whose quota check passes. New code should
+    use ``acquire_backend``, which enumerates every Claude account and
+    holds a host-wide lease so two agents can't race onto the same one.
     """
     raw = cfg_get(config, "agent", "backend", default="claude")
     if raw == "auto":
@@ -1683,11 +1590,227 @@ def check_quota(config: dict, force: bool = False,
                 claude_config_dir: Path | None = None) -> bool:
     """Back-compat shim: True iff some backend has available quota now.
 
-    New code should call `select_available_backend()` directly so it knows
-    *which* backend to launch.
+    New code should call ``acquire_backend()`` directly so it knows
+    *which* backend, account, and model to launch.
     """
     return select_available_backend(config, force=force,
                                     claude_config_dir=claude_config_dir) is not None
+
+
+# --- Per-agent acquire / release ------------------------------------------
+
+
+def _claude_accepted_models(config: dict | None = None) -> list[str]:
+    """Return the ordered list of accepted Claude model tiers.
+
+    Reads ``[agent.claude].accepted_models`` from config on disk (so
+    edits take effect without restarting pod). Falls back to
+    ``[agent.claude].model`` for back-compat with older configs.
+    """
+    raw = _reload_config_value("agent", "claude", "accepted_models", default=None)
+    if isinstance(raw, list) and raw:
+        return [str(x) for x in raw]
+    fallback = _reload_config_value("agent", "claude", "model", default="opus")
+    return [fallback]
+
+
+def _release_account_lease(state: AgentState,
+                             claude_config_dir: Path | None) -> None:
+    """Release the agent's Claude account lease and harvest any refreshed
+    OAuth token back to canonical ``~/.claude/credentials<N>.json``.
+
+    Idempotent: a no-op when ``state.account_label`` is empty. Clears
+    the lease bookkeeping on state. Safe to call from cleanup paths
+    (normal iteration end, quota-exhaust, rapid-failure backoff,
+    SIGTERM, exception handlers).
+    """
+    label = state.account_label
+    if not label:
+        return
+    if claude_config_dir is not None:
+        for a in accounts.list_claude_accounts():
+            if a.label == label:
+                try:
+                    accounts.harvest_isolated_to_canonical(
+                        label, a.number, claude_config_dir)
+                except OSError as e:
+                    log(f"lease: harvest failed for {label}: {e}")
+                break
+    try:
+        accounts.release_lease(label, state.short_id)
+    except Exception as e:
+        log(f"lease: release failed for {label}: {e}")
+    state.account_label = ""
+    state.lease_acquired_at = 0.0
+
+
+def acquire_backend(
+    config: dict,
+    *,
+    state: AgentState,
+    claude_config_dir: Path | None,
+    force: bool = False,
+    pin_label: str | None = None,
+    pin_backend: str | None = None,
+) -> accounts.Candidate | None:
+    """Pick and (for Claude) atomically lease the best (backend, account,
+    model) triple for this iteration.
+
+    Resolution order, all of it under the lease meta-lock for the
+    Claude path:
+
+    1. If we already hold a lease that still satisfies (the helper still
+       reports a model tier ≥ one of ``accepted_models``), keep it.
+       Avoids release/re-acquire churn between iterations.
+    2. Otherwise enumerate every Claude account (and Codex if allowed),
+       filter to accepted tiers, order by ``[agent.auto].prefer``, then
+       for each candidate try the lease — on success re-probe with
+       ``--force`` to confirm quota didn't drop between bulk probe and
+       acquisition; if it did, release and continue.
+    3. On commit, mirror the canonical ``credentials<N>.json`` into the
+       agent's isolated keychain entry (skipping the write if the
+       isolated entry is already fresher, e.g. mid-session refresh).
+
+    Returns ``None`` when every candidate is exhausted or leased by
+    other agents — the caller should treat that as ``waiting_quota``.
+
+    ``pin_backend``/``pin_label`` are set during resume to keep the
+    session on the backend (and Claude account) it originally ran on.
+    """
+    short_id = state.short_id
+    raw = pin_backend or cfg_get(config, "agent", "backend", default="claude")
+    force = force or FORCE_QUOTA_FILE.exists()
+
+    accepted_models = _claude_accepted_models(config)
+    codex_model = _reload_config_value("agent", "codex", "model", default="gpt-5.4")
+
+    claude_quota_cmd = _backend_cfg(
+        config, "quota_check", backend="claude", default="")
+    codex_quota_cmd = _backend_cfg(
+        config, "quota_check", backend="codex", default="")
+
+    if raw == "codex":
+        backends_allowed = {"codex"}
+    elif raw == "claude":
+        backends_allowed = {"claude"}
+    else:
+        backends_allowed = {"claude", "codex"}
+    prefer = cfg_get(config, "agent", "auto", "prefer", default="codex")
+    if prefer not in ("claude", "codex"):
+        prefer = "codex"
+
+    # Step 1: existing lease still good?
+    if (state.account_label
+            and not force
+            and "claude" in backends_allowed
+            and (pin_label is None or pin_label == state.account_label)):
+        fresh = accounts.probe_account(
+            claude_quota_cmd, state.account_label, force=False)
+        if fresh:
+            avail_tier = accounts.model_tier("claude", fresh)
+            for tier in accepted_models:
+                if avail_tier >= accounts.model_tier("claude", tier):
+                    acct = next(
+                        (a for a in accounts.list_claude_accounts()
+                         if a.label == state.account_label),
+                        None)
+                    if acct is not None:
+                        return accounts.Candidate(
+                            backend="claude",
+                            label=state.account_label,
+                            model=tier,
+                            account_num=acct.number,
+                        )
+                    break
+        # Stale or no longer good — release before re-picking.
+        _release_account_lease(state, claude_config_dir)
+
+    # Step 2: bulk-probe all accounts + codex once per pass.
+    claude_accts = (
+        accounts.list_claude_accounts() if "claude" in backends_allowed else [])
+    available_by_label: dict[str, str | None] = {}
+    if "claude" in backends_allowed and not force:
+        for a in claude_accts:
+            available_by_label[a.label] = accounts.probe_account(
+                claude_quota_cmd, a.label)
+    elif "claude" in backends_allowed and force:
+        available_by_label = {a.label: accepted_models[0]
+                              for a in claude_accts}
+
+    codex_avail = (
+        "codex" in backends_allowed
+        and (force or accounts.probe_codex(codex_quota_cmd)))
+
+    candidates = accounts.enumerate_candidates(
+        claude_accounts=claude_accts,
+        available_by_label=available_by_label,
+        accepted_models=accepted_models,
+        codex_available=codex_avail,
+        codex_model=codex_model,
+        prefer=prefer,
+        pin_label=pin_label,
+    )
+    if not candidates:
+        # No usable candidate. If we got here we already released any
+        # stale lease in step 1, so just signal the caller to wait.
+        return None
+
+    # Step 3: lease + revalidate under host-wide meta-lock.
+    chosen: accounts.Candidate | None = None
+    with accounts.lease_critical_section():
+        # Best-effort orphan eviction so a dead agent's lease doesn't
+        # block live ones forever. Cheap: walks .pod/agents/ and the
+        # lease dir.
+        try:
+            live = {a.short_id for a in read_all_agents()}
+            live.add(short_id)
+            accounts.evict_orphan_leases(live)
+        except Exception:
+            pass
+        held_by_others = {
+            l.label for l in accounts.list_leases()
+            if l.short_id != short_id
+        }
+        for cand in candidates:
+            if cand.backend == "codex":
+                chosen = cand
+                break
+            if cand.label in held_by_others:
+                continue
+            if not accounts.try_acquire_lease(
+                    cand.label, short_id,
+                    project_dir=str(PROJECT_DIR)):
+                continue
+            if not force:
+                fresh = accounts.probe_account(
+                    claude_quota_cmd, cand.label, force=True)
+                if (not fresh
+                        or accounts.model_tier("claude", fresh)
+                        < accounts.model_tier("claude", cand.model)):
+                    accounts.release_lease(cand.label, short_id)
+                    continue
+            if claude_config_dir is not None:
+                try:
+                    accounts.mirror_canonical_to_isolated(
+                        cand.label, cand.account_num, claude_config_dir)
+                except OSError as e:
+                    log(f"acquire_backend: mirror failed for "
+                        f"{cand.label}: {e}")
+                    accounts.release_lease(cand.label, short_id)
+                    continue
+            chosen = cand
+            break
+
+    if chosen is None:
+        return None
+    if chosen.backend == "claude":
+        state.account_label = chosen.label
+        state.lease_acquired_at = time.time()
+    else:
+        # Picked codex; release any outstanding claude lease.
+        if state.account_label:
+            _release_account_lease(state, claude_config_dir)
+    return chosen
 
 
 def coordination(config: dict, *args, env_extra: dict | None = None,
@@ -5364,31 +5487,29 @@ def _disk_low(config: dict) -> str | None:
     return None
 
 
-def _log_credential_state(session_uuid: str, claude_config_dir: Path | None = None):
+def _log_credential_state(session_uuid: str,
+                            claude_config_dir: Path | None = None,
+                            expected_label: str = ""):
     """Log which credential Claude Code will actually use at agent launch time.
 
-    Reports the resolved credential (the one Claude Code reads from the
-    suffixed keychain entry, or the credentials.json fallback) and warns
-    when the isolated config dir diverges from the default keychain entry
-    — that divergence is the canonical sign of the "wrong account" bug.
+    Pure logging — does *not* mutate the keychain. Account selection
+    happens earlier in the iteration (under the lease meta-lock), and
+    ``accounts.mirror_canonical_to_isolated`` writes the chosen
+    account's blob into the per-agent keychain entry. By the time
+    ``launch_agent`` calls us, the right credential is already there;
+    we just confirm and warn if it doesn't match ``expected_label``.
     """
     parts = [f"session={session_uuid[:8]}"]
-
-    _sync_isolated_credential(claude_config_dir)
-    resolved = resolve_claude_credential(claude_config_dir)
+    resolved = accounts.resolve_claude_credential(claude_config_dir)
     parts.append(
         f"resolved=[{resolved['accountLabel']}] "
         f"token={resolved['tokenPrefix']}... via {resolved['source']}"
     )
-
-    if claude_config_dir is not None:
-        default_resolved = resolve_claude_credential(None)
-        if default_resolved["accountLabel"] != resolved["accountLabel"]:
-            parts.append(
-                f"WARNING default keychain has [{default_resolved['accountLabel']}] "
-                f"-- isolated config diverges"
-            )
-
+    if expected_label and resolved["accountLabel"] != expected_label:
+        parts.append(
+            f"WARNING expected [{expected_label}] but isolated "
+            f"keychain has [{resolved['accountLabel']}]"
+        )
     log(f"Credential state at launch: {' | '.join(parts)}")
 
 
@@ -5561,20 +5682,32 @@ def _codex_probe_launched_suspended(cmd: str) -> bool:
 def launch_agent(config: dict, session_uuid: str, prompt: str,
                    wt_dir: str,
                    claude_config_dir: Path | None = None,
-                   backend: str | None = None) -> subprocess.Popen:
+                   backend: str | None = None,
+                   model: str | None = None,
+                   account_label: str = "") -> subprocess.Popen:
     """Launch agent subprocess (Claude or Codex) in the worktree directory.
 
-    `backend` is required when running in auto mode; for fixed-backend
-    modes it defaults to the configured value (re-read from disk to pick
-    up live config edits).
+    ``backend`` is required when running in auto mode; for fixed-backend
+    modes it defaults to the configured value.
+
+    ``model`` should be passed by callers that have already selected a
+    tier via ``acquire_backend`` (which honours ``accepted_models``).
+    Falls back to re-reading ``[agent.<backend>].model`` from disk only
+    when omitted, preserving the pre-leasing call contract.
+
+    ``account_label`` is used purely for the credential-state log line
+    — it warns when the isolated keychain entry's label doesn't match
+    the selected one.
     """
     if backend is None:
         backend = _reload_config_value("agent", "backend", default="claude")
         if backend == "auto":
             raise ValueError(
                 "launch_agent: explicit backend= required in auto mode")
-    # Re-read model from disk so config.toml edits take effect without restart.
-    model = _reload_config_value("agent", backend, "model", default="opus")
+    if model is None:
+        # Legacy path: no caller-supplied selection. Re-read default.
+        model = _reload_config_value(
+            "agent", backend, "model", default="opus")
     session_dir = PROJECT_DIR / cfg_get(config, "project", "session_dir", default="sessions")
     session_dir.mkdir(parents=True, exist_ok=True)
     stdout_path = session_dir / f"{session_uuid}.stdout"
@@ -5658,7 +5791,8 @@ def launch_agent(config: dict, session_uuid: str, prompt: str,
             env["CLAUDE_CONFIG_DIR"] = str(claude_config_dir)
 
         # Log credential state at launch for debugging account-swap issues
-        _log_credential_state(session_uuid, claude_config_dir)
+        _log_credential_state(session_uuid, claude_config_dir,
+                              expected_label=account_label)
 
         agent_args = claude_args
 
@@ -5925,6 +6059,21 @@ def _release_agent_resources(reason: str, skip_msg: str) -> None:
         except OSError:
             pass
 
+    # Release the Claude account lease + harvest any refreshed token
+    # before tearing down the rest of the agent. Done early so a
+    # blocked downstream cleanup doesn't leave the lease orphaned.
+    if state and state.account_label:
+        try:
+            claude_cfg = (
+                Path(state.claude_config_dir) if state.claude_config_dir else None)
+            _release_account_lease(state, claude_cfg)
+            try:
+                state.write()
+            except OSError:
+                pass
+        except Exception as e:
+            log(f"_release_agent_resources: lease release failed: {e}")
+
     # Kill the child agent subprocess (claude/codex), if still running.
     if _agent_proc and _agent_proc.poll() is None:
         try:
@@ -5996,6 +6145,15 @@ def _release_agent_resources(reason: str, skip_msg: str) -> None:
                 cleanup_worktree(state.worktree, state.branch)
             except Exception as e:
                 log(f"Worktree cleanup failed on {reason}: {e}")
+
+        # Cleanup per-agent CLAUDE_CONFIG_DIR (best-effort; keychain
+        # entries linger but are orphaned and harmless).
+        if state.claude_config_dir:
+            try:
+                accounts.cleanup_agent_claude_config_dir(
+                    POD_DIR, state.short_id)
+            except OSError as e:
+                log(f"claude-config cleanup failed on {reason}: {e}")
 
         try:
             state.remove_file()
@@ -6075,10 +6233,11 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         quota_retry = _backend_cfg(config, "quota_retry_seconds", default=60)
     worker_types = cfg_get(config, "worker_types", default={})
 
-    claude_config_dir = ensure_isolated_config(config)
+    claude_config_dir = ensure_isolated_config(config, short_id)
     if claude_config_dir:
         log(f"Agent {short_id}: claude isolated config at {claude_config_dir}"
             + (" (auto mode — claude iterations only)" if raw_backend == "auto" else ""))
+        state.claude_config_dir = str(claude_config_dir)
     if raw_backend in ("codex", "auto"):
         log(f"Agent {short_id}: codex iterations use CODEX_HOME set per session")
     if raw_backend == "auto":
@@ -6094,29 +6253,32 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         iteration += 1
         state.loop_iteration = iteration
 
-        # --- Backend selection + quota check ---
-        # Resume sessions are pinned to the backend they originally ran
-        # under: only Claude has a real `--resume`, and a Codex "resume"
-        # at minimum reuses its worktree/UUID. Auto-selecting here would
-        # silently drop the original conversation.
-        resume_pin = state.backend if state.resume_session_uuid and state.backend else None
+        # --- Backend / account selection + quota check ---
+        # Resume sessions are pinned to the backend AND Claude account
+        # they originally ran on: only Claude has a real `--resume`,
+        # and a refreshed token on the wrong account would silently
+        # fork the conversation or fail.
+        resume_pin_backend = (
+            state.backend if state.resume_session_uuid and state.backend
+            else None)
+        resume_pin_label = (
+            state.account_label
+            if state.resume_session_uuid and state.account_label
+            else None)
         state.status = "waiting_quota"
         state.write()
-        chosen_backend: str | None = None
+        selection: accounts.Candidate | None = None
         while True:
-            if resume_pin:
-                # Honour force_quota during resume too — some quota helpers
-                # may be stale right after a kill/restart.
-                if state.force_quota or _backend_available(
-                        config, resume_pin, claude_config_dir):
-                    chosen_backend = resume_pin
-                    break
-            else:
-                chosen_backend = select_available_backend(
-                    config, force=state.force_quota,
-                    claude_config_dir=claude_config_dir)
-                if chosen_backend is not None:
-                    break
+            selection = acquire_backend(
+                config,
+                state=state,
+                claude_config_dir=claude_config_dir,
+                force=state.force_quota,
+                pin_backend=resume_pin_backend,
+                pin_label=resume_pin_label,
+            )
+            if selection is not None:
+                break
             if state.finishing:
                 break
             # Re-read state file to pick up force_quota toggled by TUI
@@ -6128,22 +6290,38 @@ def agent_process_main(config: dict, agent_id: str | None = None,
                 pass
             if state.force_quota:
                 log(f"Agent {short_id}: force_quota enabled, skipping wait")
-                if resume_pin:
-                    chosen_backend = resume_pin
-                else:
-                    chosen_backend = (select_available_backend(
-                        config, force=True,
-                        claude_config_dir=claude_config_dir) or "claude")
+                selection = acquire_backend(
+                    config,
+                    state=state,
+                    claude_config_dir=claude_config_dir,
+                    force=True,
+                    pin_backend=resume_pin_backend,
+                    pin_label=resume_pin_label,
+                )
+                if selection is None:
+                    # No accounts at all — fall back to bare "claude"
+                    # for the one-shot path; it will surface a clearer
+                    # error inside launch_agent than waiting forever.
+                    selection = accounts.Candidate(
+                        backend=resume_pin_backend or "claude",
+                        label="", model="opus", account_num=0)
                 break
-            target = resume_pin or "any backend"
+            target = resume_pin_backend or "any backend"
+            if resume_pin_label:
+                target += f"/{resume_pin_label}"
             log(f"Agent {short_id}: no quota for {target}, sleeping {quota_retry}s")
             time.sleep(quota_retry)
-        if state.finishing or chosen_backend is None:
+        if state.finishing or selection is None:
             break
 
+        chosen_backend = selection.backend
+        chosen_model = selection.model
+        chosen_account_label = selection.label
+        chosen_account_num = selection.account_num
         state.backend = chosen_backend
-        state.model = _backend_cfg(config, "model", backend=chosen_backend,
-                                    default="") or ""
+        state.model = chosen_model
+        # state.account_label and state.lease_acquired_at are set inside
+        # acquire_backend on the Claude path; cleared for codex.
         state.write()
 
         # --- Housekeeping (time-based, every 10 minutes to conserve GH API calls) ---
@@ -6191,6 +6369,16 @@ def agent_process_main(config: dict, agent_id: str | None = None,
                     pass
                 try:
                     cleanup_stale_branches(config, verbose=True)
+                except Exception:
+                    pass
+                # Evict orphan account leases — covers agents that
+                # crashed without releasing their lease (the per-agent
+                # short_id is no longer in .pod/agents/).
+                try:
+                    with accounts.lease_critical_section():
+                        live = {a.short_id for a in read_all_agents()}
+                        live.add(short_id)
+                        accounts.evict_orphan_leases(live)
                 except Exception:
                     pass
                 _housekeeping_mark_done()
@@ -6384,7 +6572,10 @@ def agent_process_main(config: dict, agent_id: str | None = None,
 
         try:
             _agent_proc = launch_agent(config, session_uuid, prompt, wt_dir,
-                                        claude_config_dir, backend=chosen_backend)
+                                        claude_config_dir,
+                                        backend=chosen_backend,
+                                        model=chosen_model,
+                                        account_label=chosen_account_label)
         except (OSError, FileNotFoundError) as e:
             log(f"Agent {short_id}: failed to launch {chosen_backend}: {e}")
             stop_monitor.set()
@@ -6589,6 +6780,11 @@ def agent_process_main(config: dict, agent_id: str | None = None,
                 except Exception:
                     pass
                 state.lock_held = ""
+            # Release the Claude account lease (and harvest any refreshed
+            # token) so the next iteration is free to pick a different
+            # account — the exhausted one would just trigger this same
+            # path again until it resets.
+            _release_account_lease(state, claude_config_dir)
             _abort_one_shot_iteration(state, "quota exhaustion")
             state.write()
             if state.finishing:
@@ -6643,6 +6839,10 @@ def agent_process_main(config: dict, agent_id: str | None = None,
                 except Exception:
                     pass
                 state.lock_held = ""
+            # Rapid-failure sessions release the account lease too:
+            # we're about to back off for several minutes and another
+            # agent may want this account in the meantime.
+            _release_account_lease(state, claude_config_dir)
             state.status = "backoff"
             _abort_one_shot_iteration(state, f"rapid failure #{rapid_failures}")
             state.write()
@@ -6680,7 +6880,16 @@ def agent_process_main(config: dict, agent_id: str | None = None,
     # --- Agent loop exited ---
     log(f"Agent {short_id} exiting (finishing={state.finishing})")
     state.status = "stopped"
+    # Release any held Claude account lease + harvest refreshed token
+    # back to canonical before the orphan-eviction sweep notices we're
+    # gone. Skipping this leaves the lease blocking other agents for up
+    # to one housekeeping cycle.
+    _release_account_lease(state, claude_config_dir)
     state.write()
+    # Tear down the per-agent CLAUDE_CONFIG_DIR — keychain entries
+    # survive but are orphaned (cheap on disk; harmless).
+    if claude_config_dir is not None:
+        accounts.cleanup_agent_claude_config_dir(POD_DIR, short_id)
     # Leave state file briefly so TUI can see "stopped", then remove
     time.sleep(2)
     state.remove_file()
@@ -7142,6 +7351,11 @@ def _tui_main(stdscr, config: dict):
                 activity = agent.last_text or agent.status
             else:
                 activity = agent.status
+            # Prefix with which Claude account holds the lease (if any),
+            # so operators can see at a glance which account each agent
+            # is burning quota on.
+            if agent.account_label:
+                activity = f"[{agent.account_label}] {activity}"
             # Thinking detection: if JSONL is stale but process is alive
             if (agent.last_activity > 0 and
                     time.time() - agent.last_activity > 10 and

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,463 @@
+"""Tests for pod.accounts — lease layer, candidate enumeration, and
+credential mirror/harvest freshness logic."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pod import accounts
+
+
+# --- Test helpers -----------------------------------------------------------
+
+
+def _make_creds(label: str, expires_iso: str,
+                 access_token: str = "sk-ant-test-AAAAAAAAAAAAAAAAAAAA") -> str:
+    return json.dumps({
+        "accountLabel": label,
+        "claudeAiOauth": {
+            "accessToken": access_token,
+            "expiresAt": expires_iso,
+            "refreshToken": "refresh-token-test",
+        },
+    })
+
+
+class _IsolatedHome(unittest.TestCase):
+    """Base class that redirects accounts.CLAUDE_DIR / LEASE_DIR to a tmp."""
+
+    def setUp(self) -> None:
+        import tempfile
+        self.tmp = Path(tempfile.mkdtemp(prefix="pod-accounts-test-"))
+        self._orig_claude_dir = accounts.CLAUDE_DIR
+        self._orig_lease_dir = accounts.LEASE_DIR
+        self._orig_lease_meta = accounts.LEASE_META_LOCK
+        accounts.CLAUDE_DIR = self.tmp
+        accounts.LEASE_DIR = self.tmp / "pod-account-leases"
+        accounts.LEASE_META_LOCK = accounts.LEASE_DIR / ".lock"
+
+    def tearDown(self) -> None:
+        import shutil
+        accounts.CLAUDE_DIR = self._orig_claude_dir
+        accounts.LEASE_DIR = self._orig_lease_dir
+        accounts.LEASE_META_LOCK = self._orig_lease_meta
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+# --- list_claude_accounts ---------------------------------------------------
+
+
+class ListClaudeAccountsTests(_IsolatedHome):
+    def test_returns_sorted_accounts_skipping_missing_labels(self):
+        (self.tmp / "credentials2.json").write_text(_make_creds("alpha", "2026-12-31T00:00:00Z"))
+        (self.tmp / "credentials4.json").write_text(_make_creds("gamma", "2026-12-31T00:00:00Z"))
+        # No accountLabel → skipped
+        (self.tmp / "credentials3.json").write_text(json.dumps({
+            "claudeAiOauth": {"accessToken": "x", "expiresAt": "2026-12-31T00:00:00Z"}
+        }))
+        # Garbage JSON → skipped
+        (self.tmp / "credentials5.json").write_text("{ not json")
+        # Non-numeric suffix → skipped
+        (self.tmp / "credentialsZ.json").write_text(_make_creds("ignored", "2026-12-31T00:00:00Z"))
+
+        accts = accounts.list_claude_accounts()
+        labels = [(a.number, a.label) for a in accts]
+        self.assertEqual(labels, [(2, "alpha"), (4, "gamma")])
+
+    def test_empty_directory_returns_empty_list(self):
+        self.assertEqual(accounts.list_claude_accounts(), [])
+
+
+# --- Keychain service name --------------------------------------------------
+
+
+class KeychainServiceTests(unittest.TestCase):
+    def test_default_dir(self):
+        self.assertEqual(
+            accounts.claude_keychain_service(None),
+            "Claude Code-credentials")
+
+    def test_nondefault_dir_hashes(self):
+        s = accounts.claude_keychain_service(Path("/tmp/agent-foo"))
+        self.assertTrue(s.startswith("Claude Code-credentials-"))
+        self.assertEqual(len(s.split("-")[-1]), 8)
+
+    def test_nfc_normalisation_stable(self):
+        # Decomposed vs composed unicode should produce the same hash.
+        nfc = Path("/tmp/café")  # composed
+        nfd = Path("/tmp/café")  # decomposed
+        self.assertEqual(
+            accounts.claude_keychain_service(nfc),
+            accounts.claude_keychain_service(nfd),
+        )
+
+
+# --- Lease layer ------------------------------------------------------------
+
+
+class LeaseTests(_IsolatedHome):
+    def test_acquire_release_roundtrip(self):
+        with accounts.lease_critical_section():
+            self.assertTrue(accounts.try_acquire_lease("lean-fro", "abcd1234"))
+        leases = accounts.list_leases()
+        self.assertEqual(len(leases), 1)
+        self.assertEqual(leases[0].label, "lean-fro")
+        self.assertEqual(leases[0].short_id, "abcd1234")
+        self.assertTrue(accounts.release_lease("lean-fro", "abcd1234"))
+        self.assertEqual(accounts.list_leases(), [])
+
+    def test_second_agent_cannot_acquire_held_lease(self):
+        with accounts.lease_critical_section():
+            self.assertTrue(accounts.try_acquire_lease("qim", "aaaa"))
+            self.assertFalse(accounts.try_acquire_lease("qim", "bbbb"))
+
+    def test_same_agent_reacquire_is_noop_true(self):
+        with accounts.lease_critical_section():
+            self.assertTrue(accounts.try_acquire_lease("qim", "aaaa"))
+            self.assertTrue(accounts.try_acquire_lease("qim", "aaaa"))
+
+    def test_release_wrong_owner_refused(self):
+        with accounts.lease_critical_section():
+            self.assertTrue(accounts.try_acquire_lease("lean-fro", "aaaa"))
+        self.assertFalse(accounts.release_lease("lean-fro", "bbbb"))
+        self.assertEqual(len(accounts.list_leases()), 1)
+
+    def test_release_missing_is_false(self):
+        self.assertFalse(accounts.release_lease("nobody", "ZZZZ"))
+
+    def test_evict_orphans(self):
+        with accounts.lease_critical_section():
+            accounts.try_acquire_lease("alpha", "live1")
+            accounts.try_acquire_lease("beta", "dead1")
+            accounts.try_acquire_lease("gamma", "live2")
+            evicted = accounts.evict_orphan_leases(["live1", "live2"])
+        self.assertEqual(sorted(evicted), ["beta"])
+        remaining = sorted(l.label for l in accounts.list_leases())
+        self.assertEqual(remaining, ["alpha", "gamma"])
+
+    def test_label_with_unsafe_chars_does_not_escape_dir(self):
+        # Account labels shouldn't normally contain /, but the lease
+        # filename builder must defend against it.
+        with accounts.lease_critical_section():
+            self.assertTrue(accounts.try_acquire_lease("a/b/../c", "abcd"))
+        leases = accounts.list_leases()
+        self.assertEqual(len(leases), 1)
+        # The on-disk path must remain inside LEASE_DIR.
+        for entry in accounts.LEASE_DIR.iterdir():
+            self.assertEqual(entry.parent, accounts.LEASE_DIR)
+
+
+# --- expiresAt parsing ------------------------------------------------------
+
+
+class ExpiresAtTests(unittest.TestCase):
+    def test_iso_string(self):
+        blob = _make_creds("x", "2026-12-31T00:00:00Z")
+        self.assertGreater(accounts._expires_at(blob), 1_700_000_000)
+
+    def test_epoch_ms(self):
+        ms = 1_900_000_000_000  # year ~2030 in ms
+        blob = json.dumps({
+            "accountLabel": "x",
+            "claudeAiOauth": {"accessToken": "y", "expiresAt": ms},
+        })
+        secs = accounts._expires_at(blob)
+        self.assertAlmostEqual(secs, ms / 1000.0, places=3)
+
+    def test_epoch_seconds(self):
+        s = 1_900_000_000  # year ~2030 in s
+        blob = json.dumps({
+            "accountLabel": "x",
+            "claudeAiOauth": {"accessToken": "y", "expiresAt": s},
+        })
+        self.assertAlmostEqual(accounts._expires_at(blob), float(s), places=3)
+
+    def test_missing_or_bad(self):
+        self.assertEqual(accounts._expires_at(None), 0.0)
+        self.assertEqual(accounts._expires_at("{}"), 0.0)
+        self.assertEqual(accounts._expires_at("{ bogus"), 0.0)
+
+
+# --- Mirror / harvest -------------------------------------------------------
+
+
+class MirrorHarvestTests(_IsolatedHome):
+    """These tests stub out the keychain so they run on Linux CI too."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._kc: dict[str, str] = {}
+
+        def fake_read(service: str) -> str | None:
+            return self._kc.get(service)
+
+        def fake_write(service: str, blob: str) -> bool:
+            self._kc[service] = blob
+            return True
+
+        self._kc_read = mock.patch.object(accounts, "_keychain_read", side_effect=fake_read)
+        self._kc_write = mock.patch.object(accounts, "_keychain_write", side_effect=fake_write)
+        self._kc_read.start()
+        self._kc_write.start()
+        self.addCleanup(self._kc_read.stop)
+        self.addCleanup(self._kc_write.stop)
+
+    def _write_canonical(self, num: int, label: str, expires: str) -> Path:
+        path = self.tmp / f"credentials{num}.json"
+        path.write_text(_make_creds(label, expires))
+        return path
+
+    def test_mirror_writes_when_isolated_empty(self):
+        self._write_canonical(4, "lean-fro", "2026-12-31T00:00:00Z")
+        config_dir = self.tmp / "claude-config" / "abcd1234"
+        wrote = accounts.mirror_canonical_to_isolated(
+            "lean-fro", 4, config_dir)
+        self.assertTrue(wrote)
+        service = accounts.claude_keychain_service(config_dir)
+        self.assertIn(service, self._kc)
+        self.assertTrue((config_dir / ".credentials.json").exists())
+
+    def test_mirror_skips_when_isolated_is_fresher(self):
+        # Canonical expires 2026; isolated already has 2027 → don't clobber.
+        self._write_canonical(4, "lean-fro", "2026-12-31T00:00:00Z")
+        config_dir = self.tmp / "claude-config" / "abcd1234"
+        service = accounts.claude_keychain_service(config_dir)
+        self._kc[service] = _make_creds("lean-fro", "2027-12-31T00:00:00Z")
+        wrote = accounts.mirror_canonical_to_isolated(
+            "lean-fro", 4, config_dir)
+        self.assertFalse(wrote)
+        # The fresher blob is still there.
+        self.assertIn("2027", self._kc[service])
+
+    def test_harvest_writes_when_isolated_is_fresher(self):
+        path = self._write_canonical(4, "lean-fro", "2026-12-31T00:00:00Z")
+        config_dir = self.tmp / "claude-config" / "abcd1234"
+        service = accounts.claude_keychain_service(config_dir)
+        # Simulate a mid-session refresh: isolated now has a 2027 expiry.
+        self._kc[service] = _make_creds(
+            "lean-fro", "2027-12-31T00:00:00Z",
+            access_token="sk-ant-test-NEWNEWNEWNEWNEWNEWNE")
+        wrote = accounts.harvest_isolated_to_canonical(
+            "lean-fro", 4, config_dir)
+        self.assertTrue(wrote)
+        # Canonical now has 2027.
+        canonical_after = path.read_text()
+        self.assertIn("2027", canonical_after)
+        self.assertIn("NEWNEWNEWNEWNEWNEW", canonical_after)
+
+    def test_harvest_skips_when_canonical_is_fresher_or_equal(self):
+        self._write_canonical(4, "lean-fro", "2027-12-31T00:00:00Z")
+        config_dir = self.tmp / "claude-config" / "abcd1234"
+        service = accounts.claude_keychain_service(config_dir)
+        self._kc[service] = _make_creds("lean-fro", "2026-12-31T00:00:00Z")
+        wrote = accounts.harvest_isolated_to_canonical(
+            "lean-fro", 4, config_dir)
+        self.assertFalse(wrote)
+
+    def test_harvest_refuses_non_json_isolated(self):
+        path = self._write_canonical(4, "lean-fro", "2026-01-01T00:00:00Z")
+        config_dir = self.tmp / "claude-config" / "abcd1234"
+        service = accounts.claude_keychain_service(config_dir)
+        self._kc[service] = "not even json"
+        wrote = accounts.harvest_isolated_to_canonical(
+            "lean-fro", 4, config_dir)
+        self.assertFalse(wrote)
+        # Canonical untouched.
+        self.assertIn("2026", path.read_text())
+
+
+# --- probe_account / probe_codex --------------------------------------------
+
+
+class ProbeTests(unittest.TestCase):
+    def test_probe_account_returns_stdout_on_success(self):
+        cp = subprocess.CompletedProcess(args=[], returncode=0,
+                                          stdout="opus\n", stderr="")
+        with mock.patch("subprocess.run", return_value=cp) as m:
+            out = accounts.probe_account(
+                "/bin/quota-helper", "lean-fro")
+        self.assertEqual(out, "opus")
+        args, _ = m.call_args
+        self.assertEqual(args[0], ["/bin/quota-helper", "--account", "lean-fro"])
+
+    def test_probe_account_force_flag(self):
+        cp = subprocess.CompletedProcess(args=[], returncode=0,
+                                          stdout="sonnet", stderr="")
+        with mock.patch("subprocess.run", return_value=cp) as m:
+            accounts.probe_account("/bin/quota-helper", "qim", force=True)
+        args, _ = m.call_args
+        self.assertIn("--force", args[0])
+
+    def test_probe_account_nonzero_exit_returns_none(self):
+        cp = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+        with mock.patch("subprocess.run", return_value=cp):
+            self.assertIsNone(accounts.probe_account(
+                "/bin/q", "exhausted"))
+
+    def test_probe_account_oserror_returns_none(self):
+        with mock.patch("subprocess.run", side_effect=FileNotFoundError):
+            self.assertIsNone(accounts.probe_account("/bin/missing", "x"))
+
+    def test_probe_codex_success(self):
+        cp = subprocess.CompletedProcess(args=[], returncode=0,
+                                          stdout="gpt-5.5\n", stderr="")
+        with mock.patch("subprocess.run", return_value=cp):
+            self.assertTrue(accounts.probe_codex("/bin/codex-q"))
+
+    def test_probe_codex_cache_stale_exit2(self):
+        cp = subprocess.CompletedProcess(args=[], returncode=2,
+                                          stdout="", stderr="")
+        with mock.patch("subprocess.run", return_value=cp):
+            self.assertFalse(accounts.probe_codex("/bin/codex-q"))
+
+
+# --- Candidate enumeration --------------------------------------------------
+
+
+class EnumerateCandidatesTests(unittest.TestCase):
+    def _accounts(self, *labels: str) -> list[accounts.Account]:
+        return [accounts.Account(label=l, number=i + 1, path=Path(f"/dev/null/{l}"))
+                for i, l in enumerate(labels)]
+
+    def test_opus_account_yields_opus_candidate(self):
+        cands = accounts.enumerate_candidates(
+            claude_accounts=self._accounts("a", "b"),
+            available_by_label={"a": "opus", "b": None},
+            accepted_models=["opus"],
+            codex_available=False,
+            codex_model="gpt-5.5",
+            prefer="claude",
+        )
+        self.assertEqual([(c.backend, c.label, c.model) for c in cands],
+                         [("claude", "a", "opus")])
+
+    def test_sonnet_only_account_skipped_when_opus_required(self):
+        cands = accounts.enumerate_candidates(
+            claude_accounts=self._accounts("only-sonnet"),
+            available_by_label={"only-sonnet": "sonnet"},
+            accepted_models=["opus"],
+            codex_available=False,
+            codex_model="gpt-5.5",
+            prefer="claude",
+        )
+        self.assertEqual(cands, [])
+
+    def test_sonnet_accepted_after_opus(self):
+        cands = accounts.enumerate_candidates(
+            claude_accounts=self._accounts("opus-acct", "sonnet-acct"),
+            available_by_label={"opus-acct": "opus", "sonnet-acct": "sonnet"},
+            accepted_models=["opus", "sonnet"],
+            codex_available=False,
+            codex_model="gpt-5.5",
+            prefer="claude",
+        )
+        # First-satisfiable per account: opus-acct -> opus, sonnet-acct -> sonnet
+        self.assertEqual([(c.label, c.model) for c in cands],
+                         [("opus-acct", "opus"), ("sonnet-acct", "sonnet")])
+
+    def test_one_candidate_per_account_not_one_per_tier(self):
+        cands = accounts.enumerate_candidates(
+            claude_accounts=self._accounts("a"),
+            available_by_label={"a": "opus"},
+            accepted_models=["opus", "sonnet"],
+            codex_available=False,
+            codex_model="gpt-5.5",
+            prefer="claude",
+        )
+        # Opus satisfies both tiers but we only emit one candidate per account.
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(cands[0].model, "opus")
+
+    def test_codex_added_after_claude_when_prefer_claude(self):
+        cands = accounts.enumerate_candidates(
+            claude_accounts=self._accounts("a"),
+            available_by_label={"a": "opus"},
+            accepted_models=["opus"],
+            codex_available=True,
+            codex_model="gpt-5.5",
+            prefer="claude",
+        )
+        self.assertEqual([(c.backend, c.label) for c in cands],
+                         [("claude", "a"), ("codex", "")])
+
+    def test_codex_first_when_prefer_codex(self):
+        cands = accounts.enumerate_candidates(
+            claude_accounts=self._accounts("a"),
+            available_by_label={"a": "opus"},
+            accepted_models=["opus"],
+            codex_available=True,
+            codex_model="gpt-5.5",
+            prefer="codex",
+        )
+        self.assertEqual([(c.backend, c.label) for c in cands],
+                         [("codex", ""), ("claude", "a")])
+
+    def test_no_candidates_when_all_exhausted(self):
+        cands = accounts.enumerate_candidates(
+            claude_accounts=self._accounts("a", "b"),
+            available_by_label={"a": None, "b": None},
+            accepted_models=["opus", "sonnet"],
+            codex_available=False,
+            codex_model="gpt-5.5",
+            prefer="claude",
+        )
+        self.assertEqual(cands, [])
+
+    def test_pin_label_restricts_to_that_account(self):
+        cands = accounts.enumerate_candidates(
+            claude_accounts=self._accounts("a", "b"),
+            available_by_label={"a": "opus", "b": "opus"},
+            accepted_models=["opus"],
+            codex_available=True,
+            codex_model="gpt-5.5",
+            prefer="claude",
+            pin_label="b",
+        )
+        # Only b, no codex (pinning is for resume — must be the same backend too).
+        self.assertEqual([(c.backend, c.label) for c in cands],
+                         [("claude", "b")])
+
+    def test_pin_label_with_missing_account_yields_empty(self):
+        cands = accounts.enumerate_candidates(
+            claude_accounts=self._accounts("a"),
+            available_by_label={"a": "opus"},
+            accepted_models=["opus"],
+            codex_available=True,
+            codex_model="gpt-5.5",
+            prefer="claude",
+            pin_label="nonexistent",
+        )
+        self.assertEqual(cands, [])
+
+
+# --- Per-agent dir helpers --------------------------------------------------
+
+
+class AgentConfigDirTests(unittest.TestCase):
+    def test_returns_per_agent_subdir(self):
+        d = accounts.agent_claude_config_dir(Path("/tmp/.pod"), "abcd1234")
+        self.assertEqual(d, Path("/tmp/.pod/claude-config/abcd1234"))
+
+    def test_ensure_creates_minimal_layout(self):
+        import tempfile
+        tmp = Path(tempfile.mkdtemp(prefix="pod-test-"))
+        try:
+            d = accounts.ensure_agent_claude_config_dir(tmp / ".pod", "zzzzzzzz")
+            self.assertTrue(d.exists())
+            self.assertTrue((d / "settings.json").exists())
+            self.assertTrue((d / "projects").is_dir())
+            # No credentials yet — that's mirror_canonical_to_isolated's job.
+            self.assertFalse((d / ".credentials.json").exists())
+        finally:
+            import shutil
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_acquire_backend.py
+++ b/tests/test_acquire_backend.py
@@ -1,0 +1,472 @@
+"""Tests for cli.acquire_backend — the new lease-aware backend picker.
+
+These tests exercise the integration between cli.acquire_backend and
+pod.accounts: enumeration, atomic lease + revalidation, sticky leases,
+mirror-on-acquire, resume pinning. The accounts module's internals are
+tested separately in test_accounts.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pod import accounts, cli
+
+
+def _quota_cp(stdout: str = "opus", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout + "\n", stderr="")
+
+
+def _config(backend: str = "auto", *,
+             prefer: str = "claude",
+             accepted_models: list[str] | None = None,
+             codex_model: str = "gpt-5.4") -> dict:
+    cfg = {
+        "agent": {
+            "backend": backend,
+            "auto": {"prefer": prefer},
+            "claude": {
+                "model": "opus",
+                "quota_check": "/bin/claude-quota",
+                "quota_check_required": True,
+                "isolated_config": True,
+            },
+            "codex": {
+                "model": codex_model,
+                "quota_check": "/bin/codex-quota",
+                "quota_check_required": True,
+                "isolated_config": True,
+            },
+        }
+    }
+    if accepted_models is not None:
+        cfg["agent"]["claude"]["accepted_models"] = accepted_models
+    return cfg
+
+
+class _Harness(unittest.TestCase):
+    """Sets up a temp ~/.claude tree, mocks the keychain, and reroutes
+    POD_DIR/PROJECT_DIR so the meta-lock and state files land in tmp."""
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="pod-acquire-test-"))
+        # Override accounts module globals
+        self._orig_claude_dir = accounts.CLAUDE_DIR
+        self._orig_lease_dir = accounts.LEASE_DIR
+        self._orig_meta = accounts.LEASE_META_LOCK
+        accounts.CLAUDE_DIR = self.tmp / ".claude"
+        accounts.LEASE_DIR = accounts.CLAUDE_DIR / "pod-account-leases"
+        accounts.LEASE_META_LOCK = accounts.LEASE_DIR / ".lock"
+        accounts.CLAUDE_DIR.mkdir(parents=True)
+        # Override cli paths
+        self._orig_pod_dir = cli.POD_DIR
+        self._orig_project_dir = cli.PROJECT_DIR
+        self._orig_force_quota_file = cli.FORCE_QUOTA_FILE
+        self._orig_agents_dir = cli.AGENTS_DIR
+        cli.POD_DIR = self.tmp / ".pod"
+        cli.PROJECT_DIR = self.tmp
+        cli.FORCE_QUOTA_FILE = cli.POD_DIR / "force-quota"
+        cli.AGENTS_DIR = cli.POD_DIR / "agents"
+        cli.POD_DIR.mkdir(parents=True)
+        cli.AGENTS_DIR.mkdir(parents=True)
+        # Mock keychain — we don't want test pods to touch the real one
+        self._kc: dict[str, str] = {}
+        self._kc_read = mock.patch.object(
+            accounts, "_keychain_read",
+            side_effect=lambda s: self._kc.get(s))
+        self._kc_write = mock.patch.object(
+            accounts, "_keychain_write",
+            side_effect=lambda s, b: (self._kc.__setitem__(s, b) or True))
+        self._kc_read.start()
+        self._kc_write.start()
+        # Stub _reload_config_value to read accepted_models / model from
+        # the in-memory config (not from disk, which isn't a real
+        # config.toml in this harness).
+        self._cfg_for_reload: dict = {}
+        self._reload = mock.patch.object(
+            cli, "_reload_config_value",
+            side_effect=self._fake_reload)
+        self._reload.start()
+        self.addCleanup(self.tearDown_helpers)
+
+    def _fake_reload(self, *keys, default=None):
+        cur: object = self._cfg_for_reload
+        for k in keys:
+            if not isinstance(cur, dict) or k not in cur:
+                return default
+            cur = cur[k]
+        return cur
+
+    def tearDown_helpers(self):
+        self._kc_read.stop()
+        self._kc_write.stop()
+        self._reload.stop()
+
+    def tearDown(self) -> None:
+        accounts.CLAUDE_DIR = self._orig_claude_dir
+        accounts.LEASE_DIR = self._orig_lease_dir
+        accounts.LEASE_META_LOCK = self._orig_meta
+        cli.POD_DIR = self._orig_pod_dir
+        cli.PROJECT_DIR = self._orig_project_dir
+        cli.FORCE_QUOTA_FILE = self._orig_force_quota_file
+        cli.AGENTS_DIR = self._orig_agents_dir
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # --- Helpers -----------------------------------------------------------
+
+    def _write_credentials(self, num: int, label: str,
+                            expires: str = "2026-12-31T00:00:00Z"):
+        p = accounts.CLAUDE_DIR / f"credentials{num}.json"
+        p.write_text(json.dumps({
+            "accountLabel": label,
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-test-AAAAAAAAAAAAAAAAAAAA",
+                "expiresAt": expires,
+            },
+        }))
+        return p
+
+    def _make_state(self, short_id: str = "agent1234") -> cli.AgentState:
+        state = cli.AgentState(short_id=short_id, pid=os.getpid(),
+                                status="starting")
+        # Write to AGENTS_DIR so orphan-lease eviction inside
+        # acquire_backend's meta-lock recognises this short_id as live
+        # and doesn't reap a lease we just acquired for a sibling test
+        # agent.
+        state.write()
+        return state
+
+    def _set_cfg(self, cfg: dict):
+        """Mirror cfg into the reload-stub view so reload() pulls from it."""
+        self._cfg_for_reload = cfg
+
+
+# --- Single-claude-account happy path --------------------------------------
+
+
+class SingleAccountTests(_Harness):
+    def test_opus_account_acquires_and_leases(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(4, "lean-fro")
+        state = self._make_state()
+        config_dir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        with mock.patch.object(accounts, "probe_account",
+                                return_value="opus"):
+            sel = cli.acquire_backend(
+                cfg, state=state, claude_config_dir=config_dir)
+        self.assertIsNotNone(sel)
+        self.assertEqual(sel.backend, "claude")
+        self.assertEqual(sel.label, "lean-fro")
+        self.assertEqual(sel.model, "opus")
+        self.assertEqual(sel.account_num, 4)
+        # State + lease updated
+        self.assertEqual(state.account_label, "lean-fro")
+        self.assertGreater(state.lease_acquired_at, 0)
+        leases = accounts.list_leases()
+        self.assertEqual([l.label for l in leases], ["lean-fro"])
+
+    def test_no_accounts_returns_none(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        state = self._make_state()
+        config_dir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        sel = cli.acquire_backend(
+            cfg, state=state, claude_config_dir=config_dir)
+        self.assertIsNone(sel)
+        self.assertEqual(state.account_label, "")
+
+    def test_sonnet_only_account_rejected_when_opus_required(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(4, "lean-fro")
+        state = self._make_state()
+        config_dir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        with mock.patch.object(accounts, "probe_account",
+                                return_value="sonnet"):
+            sel = cli.acquire_backend(
+                cfg, state=state, claude_config_dir=config_dir)
+        self.assertIsNone(sel)
+
+    def test_sonnet_account_accepted_when_listed(self):
+        cfg = _config("claude", accepted_models=["opus", "sonnet"])
+        self._set_cfg(cfg)
+        self._write_credentials(4, "lean-fro")
+        state = self._make_state()
+        config_dir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        with mock.patch.object(accounts, "probe_account",
+                                return_value="sonnet"):
+            sel = cli.acquire_backend(
+                cfg, state=state, claude_config_dir=config_dir)
+        self.assertIsNotNone(sel)
+        self.assertEqual(sel.label, "lean-fro")
+        self.assertEqual(sel.model, "sonnet")
+
+
+# --- Multi-account contention ------------------------------------------------
+
+
+class MultiAccountTests(_Harness):
+    def test_two_agents_pick_different_accounts(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(2, "alpha")
+        self._write_credentials(3, "beta")
+        state1 = self._make_state("agent1111")
+        state2 = self._make_state("agent2222")
+        cdir1 = accounts.agent_claude_config_dir(cli.POD_DIR, state1.short_id)
+        cdir2 = accounts.agent_claude_config_dir(cli.POD_DIR, state2.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state1.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state2.short_id)
+        with mock.patch.object(accounts, "probe_account",
+                                return_value="opus"):
+            sel1 = cli.acquire_backend(cfg, state=state1, claude_config_dir=cdir1)
+            sel2 = cli.acquire_backend(cfg, state=state2, claude_config_dir=cdir2)
+        self.assertIsNotNone(sel1)
+        self.assertIsNotNone(sel2)
+        self.assertNotEqual(sel1.label, sel2.label)
+        held = sorted(l.label for l in accounts.list_leases())
+        self.assertEqual(held, ["alpha", "beta"])
+
+    def test_third_agent_waits_when_all_leased(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(2, "alpha")
+        state1 = self._make_state("agent1111")
+        state2 = self._make_state("agent2222")
+        cdir1 = accounts.agent_claude_config_dir(cli.POD_DIR, state1.short_id)
+        cdir2 = accounts.agent_claude_config_dir(cli.POD_DIR, state2.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state1.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state2.short_id)
+        with mock.patch.object(accounts, "probe_account",
+                                return_value="opus"):
+            sel1 = cli.acquire_backend(cfg, state=state1, claude_config_dir=cdir1)
+            sel2 = cli.acquire_backend(cfg, state=state2, claude_config_dir=cdir2)
+        self.assertIsNotNone(sel1)
+        self.assertIsNone(sel2)
+
+    def test_codex_picked_when_no_claude_in_auto(self):
+        cfg = _config("auto", prefer="claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(2, "alpha")
+        state = self._make_state()
+        cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        # Claude exhausted, codex available
+        def fake_probe(cmd, label, force=False):
+            return None
+        with mock.patch.object(accounts, "probe_account",
+                                side_effect=fake_probe), \
+             mock.patch.object(accounts, "probe_codex",
+                                return_value=True):
+            sel = cli.acquire_backend(cfg, state=state, claude_config_dir=cdir)
+        self.assertIsNotNone(sel)
+        self.assertEqual(sel.backend, "codex")
+        self.assertEqual(sel.label, "")
+        # Codex doesn't get a lease
+        self.assertEqual(accounts.list_leases(), [])
+
+    def test_release_existing_claude_lease_when_picking_codex(self):
+        cfg = _config("auto", prefer="claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(4, "lean-fro")
+        state = self._make_state()
+        cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        # First call: claude OK, lease lean-fro
+        with mock.patch.object(accounts, "probe_account",
+                                return_value="opus"), \
+             mock.patch.object(accounts, "probe_codex",
+                                return_value=True):
+            cli.acquire_backend(cfg, state=state, claude_config_dir=cdir)
+        self.assertEqual(state.account_label, "lean-fro")
+        # Second call: claude exhausted, codex available — should release.
+        with mock.patch.object(accounts, "probe_account",
+                                return_value=None), \
+             mock.patch.object(accounts, "probe_codex",
+                                return_value=True):
+            sel = cli.acquire_backend(cfg, state=state, claude_config_dir=cdir)
+        self.assertIsNotNone(sel)
+        self.assertEqual(sel.backend, "codex")
+        self.assertEqual(state.account_label, "")
+        self.assertEqual(accounts.list_leases(), [])
+
+
+# --- Atomic revalidation ---------------------------------------------------
+
+
+class RevalidateTests(_Harness):
+    def test_quota_dropped_between_probe_and_acquire_skips(self):
+        """Bulk probe says opus, but post-lease force probe says
+        sonnet — should release and move on (only one account here, so
+        end result is None).
+        """
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(2, "alpha")
+        state = self._make_state()
+        cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        # First probe (non-force) returns "opus", second probe (force=True
+        # for revalidation) returns "sonnet" — quota dropped.
+        calls = {"count": 0}
+        def fake(cmd, label, force=False):
+            calls["count"] += 1
+            return "sonnet" if force else "opus"
+        with mock.patch.object(accounts, "probe_account", side_effect=fake):
+            sel = cli.acquire_backend(cfg, state=state, claude_config_dir=cdir)
+        self.assertIsNone(sel)
+        # And the lease should have been released.
+        self.assertEqual(accounts.list_leases(), [])
+
+
+# --- Sticky leases ---------------------------------------------------------
+
+
+class StickyLeaseTests(_Harness):
+    def test_keeps_existing_lease_when_still_satisfies(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(4, "lean-fro")
+        state = self._make_state()
+        cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        # First acquire
+        with mock.patch.object(accounts, "probe_account", return_value="opus"):
+            cli.acquire_backend(cfg, state=state, claude_config_dir=cdir)
+        # Second acquire — same iteration → keep the lease, don't enter
+        # the meta-lock (we shouldn't see additional lease writes).
+        with mock.patch.object(accounts, "probe_account", return_value="opus") as m:
+            sel = cli.acquire_backend(cfg, state=state, claude_config_dir=cdir)
+        self.assertIsNotNone(sel)
+        self.assertEqual(sel.label, "lean-fro")
+        # Only one probe call: the "is current lease still good?" check.
+        self.assertEqual(m.call_count, 1)
+
+    def test_releases_stale_lease_and_re_picks(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(4, "lean-fro")
+        self._write_credentials(5, "gamma")
+        state = self._make_state()
+        cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        # First acquire on lean-fro
+        with mock.patch.object(accounts, "probe_account", return_value="opus"):
+            cli.acquire_backend(cfg, state=state, claude_config_dir=cdir)
+        self.assertEqual(state.account_label, "lean-fro")
+        # Now lean-fro is exhausted but gamma still has opus.
+        def fake(cmd, label, force=False):
+            if label == "lean-fro":
+                return None
+            return "opus"
+        with mock.patch.object(accounts, "probe_account", side_effect=fake):
+            sel = cli.acquire_backend(cfg, state=state, claude_config_dir=cdir)
+        self.assertIsNotNone(sel)
+        self.assertEqual(sel.label, "gamma")
+        self.assertEqual(state.account_label, "gamma")
+
+
+# --- Resume pinning --------------------------------------------------------
+
+
+class ResumePinTests(_Harness):
+    def test_pin_label_restricts_enumeration(self):
+        cfg = _config("auto", prefer="claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(2, "alpha")
+        self._write_credentials(3, "beta")
+        state = self._make_state()
+        cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        with mock.patch.object(accounts, "probe_account", return_value="opus"):
+            sel = cli.acquire_backend(
+                cfg, state=state, claude_config_dir=cdir,
+                pin_backend="claude", pin_label="beta")
+        self.assertIsNotNone(sel)
+        self.assertEqual(sel.label, "beta")
+
+    def test_pin_label_unavailable_returns_none(self):
+        cfg = _config("auto", prefer="claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(2, "alpha")
+        # Note: 'beta' is the pin target but no credentials file for it.
+        state = self._make_state()
+        cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        with mock.patch.object(accounts, "probe_account", return_value="opus"):
+            sel = cli.acquire_backend(
+                cfg, state=state, claude_config_dir=cdir,
+                pin_backend="claude", pin_label="beta")
+        self.assertIsNone(sel)
+
+
+# --- Force / FORCE_QUOTA_FILE bypass ---------------------------------------
+
+
+class ForceTests(_Harness):
+    def test_force_skips_quota_probe(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(4, "lean-fro")
+        state = self._make_state()
+        cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        # No probe stub: anything that probes would return None and fail.
+        with mock.patch.object(accounts, "probe_account") as m:
+            sel = cli.acquire_backend(
+                cfg, state=state, claude_config_dir=cdir, force=True)
+        self.assertIsNotNone(sel)
+        self.assertEqual(sel.label, "lean-fro")
+        self.assertEqual(m.call_count, 0)
+
+    def test_force_quota_file_acts_as_force(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(4, "lean-fro")
+        cli.FORCE_QUOTA_FILE.write_text("1")
+        try:
+            state = self._make_state()
+            cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+            accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state.short_id)
+            with mock.patch.object(accounts, "probe_account") as m:
+                sel = cli.acquire_backend(
+                    cfg, state=state, claude_config_dir=cdir)
+            self.assertIsNotNone(sel)
+            self.assertEqual(m.call_count, 0)
+        finally:
+            cli.FORCE_QUOTA_FILE.unlink(missing_ok=True)
+
+
+# --- Release helper --------------------------------------------------------
+
+
+class ReleaseTests(_Harness):
+    def test_release_clears_state_and_lease(self):
+        cfg = _config("claude", accepted_models=["opus"])
+        self._set_cfg(cfg)
+        self._write_credentials(4, "lean-fro")
+        state = self._make_state()
+        cdir = accounts.agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        accounts.ensure_agent_claude_config_dir(cli.POD_DIR, state.short_id)
+        with mock.patch.object(accounts, "probe_account", return_value="opus"):
+            cli.acquire_backend(cfg, state=state, claude_config_dir=cdir)
+        cli._release_account_lease(state, cdir)
+        self.assertEqual(state.account_label, "")
+        self.assertEqual(state.lease_acquired_at, 0.0)
+        self.assertEqual(accounts.list_leases(), [])
+
+    def test_release_is_noop_when_no_lease(self):
+        state = self._make_state()
+        cli._release_account_lease(state, None)
+        self.assertEqual(state.account_label, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR replaces the shared CLAUDE_CONFIG_DIR + single-active-Claude-account quota check with per-agent dynamic backend leasing. Each agent now probes every Claude account in `~/.claude/credentials*.json` plus Codex, atomically leases the best satisfied one from a host-wide pool, and only waits when every candidate is exhausted or already held. Different agents on one host can simultaneously run on different accounts.

The original bug was: when the active Claude account had hit its weekly Opus cap, every agent on the host sat at `waiting_quota` even though sibling accounts had plenty of headroom. The single shared keychain entry forced everyone onto whatever account `~/.claude/.credentials.json` happened to point at, and `select_available_backend` only ever asked the helper about that one.

The new architecture:

- `pod/accounts.py` is a self-contained leasing layer: per-account credential lock (`~/.claude/.<label>.credentials.lock`), host-wide lease meta-lock (`~/.claude/pod-account-leases/.lock`), atomic create-or-skip on `<label>.lock`, credential mirror/harvest with token-freshness comparison, candidate enumeration honouring an ordered `accepted_models` list and `[agent.auto].prefer`.
- `cli.acquire_backend` is the new selection entry point. Sticky across iterations when the held account still satisfies; releases + repicks otherwise. Re-probes the helper with `--force` after acquiring the lease to close the bulk-probe → commit race.
- `AgentState` gains `account_label`, `lease_acquired_at`, `claude_config_dir` (each persisted, surfaced in the TUI as `[<label>] <activity>`).
- `agent_process_main` consumes the lease lifecycle. Lease release + harvest-back lands on quota-exhaust, rapid-failure backoff, normal stop, SIGTERM/crash, and the housekeeping orphan-eviction sweep.
- Per-agent `CLAUDE_CONFIG_DIR` at `.pod/claude-config/<short_id>/` materialised on agent start, torn down on stop.
- Resume sessions pin both backend AND `account_label` so JSONL resumes never silently fork onto a different account.
- `launch_agent` accepts the selected `model` (from `accepted_models`-aware acquisition) and `account_label` explicitly; `_log_credential_state` is now pure logging.
- `[agent.claude].accepted_models = ["opus", "sonnet"]` (etc.) controls model-tier degradation; falls back to `[model]` when absent for back-compat.

Legacy `_backend_available` / `select_available_backend` / `check_quota` remain — they're used by `check_quota` (back-compat shim) and a few unit tests, but the hot path goes through `acquire_backend`.

Coordination with `~/.claude/swap-account`: pod doesn't call swap-account; both tools read/write `credentials<N>.json` and trust the freshness comparison to avoid clobbering newer tokens. A companion commit in `~/.claude` (https://github.com/kim-em/.claude/commit/4d0b883) fixes `swap-account best`'s bash-3.2 incompatibility (silent `local -n` failure that was falling through to the blind toggle) and adds a mkdir-based mutex against concurrent invocations.

Tested by 55 new tests (38 in `tests/test_accounts.py`, 17 in `tests/test_acquire_backend.py`) covering single/multi-account selection, atomic revalidation, sticky leases, codex fallback, resume pinning, force-bypass, mirror/harvest freshness, lease eviction, and credential-lock concurrency. Full suite: 430 green.

Not yet installed in production — the existing pod install is still on `main`. Smoke-test plan: `uv tool install --reinstall --editable /Users/kim/projects/lean/pod`, run with `[agent.claude].accepted_models = ["opus", "sonnet"]`, confirm three agents land on three different accounts.

🤖 Prepared with Claude Code