### PR TITLE
feat: add `pod accounts` subcommand

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -8462,6 +8462,98 @@ def _ensure_branch_protection(init_config):
         print("  warning: could not configure branch protection (gh CLI not available)")
 
 
+def cmd_accounts(config: dict, args):
+    """Inspect / manage Claude account leases held by pod agents.
+
+    Subactions:
+      list                       Show all known accounts and current
+                                 leases (`label  owner  pid  age
+                                 project`). Free accounts also shown.
+      release <label> [--force]  Remove the lease for ``label``.
+                                 Refuses if the owning agent is still
+                                 live; ``--force`` overrides. The
+                                 owning agent's next iteration will
+                                 re-acquire (possibly a different
+                                 account) on its own.
+      evict-orphans              Take the meta-lock and reap any
+                                 leases whose owner short_id is no
+                                 longer in .pod/agents/.
+    """
+    action = getattr(args, "accounts_action", None) or "list"
+    if action == "list":
+        accts = accounts.list_claude_accounts()
+        leases = {l.label: l for l in accounts.list_leases()}
+        live_short_ids = {a.short_id for a in read_all_agents()
+                          if a.status not in ("stopped", "dead")}
+        if not accts and not leases:
+            print("(no accounts found in ~/.claude/credentials*.json)")
+            return
+        print(f"{'LABEL':<14} {'OWNER':<10} {'PID':>6} "
+              f"{'AGE':>8}  PROJECT")
+        for acct in accts:
+            lease = leases.get(acct.label)
+            if lease is None:
+                print(f"{acct.label:<14} {'(free)':<10} {'':>6} {'':>8}  -")
+                continue
+            age = human_duration(time.time() - lease.acquired_at)
+            owner = lease.short_id
+            if lease.short_id not in live_short_ids:
+                owner += "*"  # orphan
+            print(f"{acct.label:<14} {owner:<10} {lease.pid:>6} "
+                  f"{age:>8}  {lease.project_dir}")
+        # Surface orphans that survived account enumeration (e.g. account
+        # file deleted but lease lingered) — also worth reaping.
+        unmatched = [l for l in leases.values()
+                      if l.label not in {a.label for a in accts}]
+        for lease in unmatched:
+            age = human_duration(time.time() - lease.acquired_at)
+            owner = lease.short_id
+            if lease.short_id not in live_short_ids:
+                owner += "*"
+            print(f"{lease.label:<14} {owner:<10} {lease.pid:>6} "
+                  f"{age:>8}  {lease.project_dir} (no account file)")
+        if any(owner.endswith("*") for owner in ()):  # never-true; just suppress
+            pass
+        if any(l.short_id not in live_short_ids for l in leases.values()):
+            print("\n* = orphan (owning agent is no longer live). "
+                  "`pod accounts evict-orphans` to reap.")
+    elif action == "release":
+        label = args.label
+        force = bool(getattr(args, "force", False))
+        leases = {l.label: l for l in accounts.list_leases()}
+        lease = leases.get(label)
+        if lease is None:
+            print(f"No lease held on '{label}'.")
+            return
+        live_short_ids = {a.short_id for a in read_all_agents()
+                          if a.status not in ("stopped", "dead")}
+        if lease.short_id in live_short_ids and not force:
+            print(f"Refusing to release '{label}': owning agent "
+                  f"{lease.short_id} is still live. "
+                  f"Use --force to release anyway "
+                  f"(the agent's next iteration will re-acquire).")
+            sys.exit(1)
+        ok = accounts.release_lease(label, lease.short_id)
+        if ok:
+            print(f"Released '{label}' (was owned by {lease.short_id}).")
+        else:
+            print(f"Failed to release '{label}'.")
+            sys.exit(1)
+    elif action == "evict-orphans":
+        with accounts.lease_critical_section():
+            live = {a.short_id for a in read_all_agents()
+                    if a.status not in ("stopped", "dead")}
+            evicted = accounts.evict_orphan_leases(live)
+        if evicted:
+            print(f"Evicted {len(evicted)} orphan lease(s): "
+                  f"{', '.join(evicted)}")
+        else:
+            print("No orphan leases.")
+    else:
+        print(f"Unknown action: {action}")
+        sys.exit(2)
+
+
 def cmd_init(args):
     """Bootstrap .pod/ in the current git repo."""
     # Verify we're in a git repo
@@ -8650,6 +8742,23 @@ def main():
     p_config.add_argument("--edit", action="store_true",
                            help="Open config in $EDITOR")
 
+    p_accounts = sub.add_parser(
+        "accounts",
+        help="Inspect / manage Claude account leases (list, release, evict-orphans)",
+    )
+    p_accounts_sub = p_accounts.add_subparsers(dest="accounts_action")
+    p_accounts_sub.add_parser("list",
+        help="Show current leases (default action)")
+    p_accounts_release = p_accounts_sub.add_parser(
+        "release",
+        help="Release a lease by label")
+    p_accounts_release.add_argument("label",
+        help="Account label (e.g. lean-fro)")
+    p_accounts_release.add_argument("--force", "-f", action="store_true",
+        help="Release even if the owning agent is still live")
+    p_accounts_sub.add_parser("evict-orphans",
+        help="Reap leases whose owning agent is no longer live")
+
     p_ghstats = sub.add_parser(
         "gh-stats",
         help="Aggregate .pod/gh-access.log to find which callers burn quota",
@@ -8739,6 +8848,8 @@ def main():
         cmd_log(config, args)
     elif args.command == "config":
         cmd_config(config, args)
+    elif args.command == "accounts":
+        cmd_accounts(config, args)
     elif args.command == "gh-stats":
         cmd_gh_stats(config, args)
     elif args.command == "_check-provenance":

--- a/tests/test_accounts_cmd.py
+++ b/tests/test_accounts_cmd.py
@@ -1,0 +1,181 @@
+"""Tests for `pod accounts` subcommand (list / release / evict-orphans)."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from pod import accounts, cli
+
+
+class _Harness(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="pod-accountscmd-test-"))
+        self._orig_claude_dir = accounts.CLAUDE_DIR
+        self._orig_lease_dir = accounts.LEASE_DIR
+        self._orig_meta = accounts.LEASE_META_LOCK
+        accounts.CLAUDE_DIR = self.tmp / ".claude"
+        accounts.LEASE_DIR = accounts.CLAUDE_DIR / "pod-account-leases"
+        accounts.LEASE_META_LOCK = accounts.LEASE_DIR / ".lock"
+        accounts.CLAUDE_DIR.mkdir(parents=True)
+        self._orig_pod_dir = cli.POD_DIR
+        self._orig_project_dir = cli.PROJECT_DIR
+        self._orig_agents_dir = cli.AGENTS_DIR
+        cli.POD_DIR = self.tmp / ".pod"
+        cli.PROJECT_DIR = self.tmp
+        cli.AGENTS_DIR = cli.POD_DIR / "agents"
+        cli.POD_DIR.mkdir(parents=True)
+        cli.AGENTS_DIR.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        accounts.CLAUDE_DIR = self._orig_claude_dir
+        accounts.LEASE_DIR = self._orig_lease_dir
+        accounts.LEASE_META_LOCK = self._orig_meta
+        cli.POD_DIR = self._orig_pod_dir
+        cli.PROJECT_DIR = self._orig_project_dir
+        cli.AGENTS_DIR = self._orig_agents_dir
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_credentials(self, num: int, label: str):
+        p = accounts.CLAUDE_DIR / f"credentials{num}.json"
+        p.write_text(json.dumps({
+            "accountLabel": label,
+            "claudeAiOauth": {
+                "accessToken": "tok",
+                "expiresAt": "2026-12-31T00:00:00Z",
+            },
+        }))
+
+    def _write_agent(self, short_id: str, status: str = "running"):
+        s = cli.AgentState(short_id=short_id, pid=os.getpid(), status=status)
+        s.write()
+
+    def _make_lease(self, label: str, short_id: str,
+                     project_dir: str = "/tmp/proj"):
+        with accounts.lease_critical_section():
+            accounts.try_acquire_lease(label, short_id, project_dir=project_dir)
+
+    def _run(self, action: str, **kwargs) -> str:
+        args = SimpleNamespace(accounts_action=action, **kwargs)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            try:
+                cli.cmd_accounts({}, args)
+            except SystemExit as e:
+                buf.write(f"\n<exit {e.code}>")
+        return buf.getvalue()
+
+
+class ListTests(_Harness):
+    def test_empty(self):
+        out = self._run("list")
+        self.assertIn("no accounts found", out)
+
+    def test_all_free(self):
+        self._write_credentials(2, "alpha")
+        self._write_credentials(3, "beta")
+        out = self._run("list")
+        self.assertIn("alpha", out)
+        self.assertIn("beta", out)
+        self.assertIn("(free)", out)
+
+    def test_held_lease_shows_owner_and_pid(self):
+        self._write_credentials(4, "lean-fro")
+        self._write_agent("agent1234", status="running")
+        self._make_lease("lean-fro", "agent1234", "/Users/kim/projects/x")
+        out = self._run("list")
+        self.assertIn("lean-fro", out)
+        self.assertIn("agent1234", out)
+        self.assertIn("/Users/kim/projects/x", out)
+        # No orphan marker
+        self.assertNotIn("*", out.replace("\n", " "))
+
+    def test_orphan_lease_is_marked(self):
+        self._write_credentials(4, "lean-fro")
+        # No matching agent state.
+        self._make_lease("lean-fro", "deadbeef")
+        out = self._run("list")
+        self.assertIn("deadbeef*", out)
+        self.assertIn("orphan", out)
+
+    def test_lease_with_no_account_file_surfaces(self):
+        self._write_agent("agent1234", status="running")
+        self._make_lease("ghost-account", "agent1234")
+        out = self._run("list")
+        self.assertIn("ghost-account", out)
+        self.assertIn("no account file", out)
+
+
+class ReleaseTests(_Harness):
+    def test_release_held_by_dead_agent(self):
+        self._write_credentials(4, "lean-fro")
+        self._make_lease("lean-fro", "deadbeef")
+        out = self._run("release", label="lean-fro", force=False)
+        self.assertIn("Released 'lean-fro'", out)
+        self.assertEqual(accounts.list_leases(), [])
+
+    def test_release_refuses_live_agent_without_force(self):
+        self._write_credentials(4, "lean-fro")
+        self._write_agent("agent1234", status="running")
+        self._make_lease("lean-fro", "agent1234")
+        out = self._run("release", label="lean-fro", force=False)
+        self.assertIn("Refusing to release", out)
+        self.assertIn("exit 1", out)
+        # Lease still there
+        self.assertEqual(len(accounts.list_leases()), 1)
+
+    def test_release_force_overrides_live_check(self):
+        self._write_credentials(4, "lean-fro")
+        self._write_agent("agent1234", status="running")
+        self._make_lease("lean-fro", "agent1234")
+        out = self._run("release", label="lean-fro", force=True)
+        self.assertIn("Released 'lean-fro'", out)
+        self.assertEqual(accounts.list_leases(), [])
+
+    def test_release_missing_label(self):
+        out = self._run("release", label="nonexistent", force=False)
+        self.assertIn("No lease held", out)
+
+
+class EvictOrphansTests(_Harness):
+    def test_evict_when_no_live_agents(self):
+        self._make_lease("alpha", "dead1")
+        self._make_lease("beta", "dead2")
+        out = self._run("evict-orphans")
+        self.assertIn("Evicted 2", out)
+        self.assertEqual(accounts.list_leases(), [])
+
+    def test_evict_keeps_live(self):
+        self._write_agent("alive1", status="running")
+        self._make_lease("alpha", "alive1")
+        self._make_lease("beta", "dead1")
+        out = self._run("evict-orphans")
+        self.assertIn("Evicted 1", out)
+        labels = [l.label for l in accounts.list_leases()]
+        self.assertEqual(labels, ["alpha"])
+
+    def test_no_orphans(self):
+        self._write_agent("alive1", status="running")
+        self._make_lease("alpha", "alive1")
+        out = self._run("evict-orphans")
+        self.assertIn("No orphan leases", out)
+
+
+class UnknownActionTests(_Harness):
+    def test_unknown_action_exits_2(self):
+        out = self._run("bogus-action")
+        self.assertIn("Unknown action", out)
+        self.assertIn("exit 2", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the first debugging tool for the per-agent leasing infrastructure that landed in #67. Without this, operators inspecting lease state fall back to `ls ~/.claude/pod-account-leases/` and `cat`'ing individual files.

Three actions over `~/.claude/pod-account-leases/`:

- `pod accounts list` (default) — tabulates every Claude account from `~/.claude/credentials*.json` with its current lease owner, pid, acquired-at age, and project_dir. Free accounts and orphans (owner short_id no longer in `.pod/agents/`) are surfaced; orphans get a `*` suffix.
- `pod accounts release <label> [--force]` — removes a lease. Refuses when the owning agent is still live unless `--force`; on release the owning agent's next iteration re-acquires (possibly a different account) without restart.
- `pod accounts evict-orphans` — takes the lease meta-lock and reaps every lease whose owner short_id is no longer in `read_all_agents()`. Same code path the periodic housekeeping sweep runs, exposed as a one-shot.

Covered by 13 tests in `tests/test_accounts_cmd.py`. Full suite: 443 green.

🤖 Prepared with Claude Code