### PR TITLE
rename: `human-oversight` label to `directive` and rewrite closure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ exposes `enforce_interaction_limits`, `minimum_interaction_limit`, and
 forward-only. They block who can post *new* issues and comments, but
 they don't reach back through history. An issue body authored before
 the limit was enabled, or comments left on an issue *before* a
-collaborator applied the `agent-plan` / `human-oversight` label, are
+collaborator applied the `agent-plan` / `directive` label, are
 still ingested verbatim by the interaction-limit check alone. The
 per-message provenance gate below covers that residual gap.
 

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1947,9 +1947,9 @@ query TuiRefresh($owner: String!, $name: String!) {
         labels(first: 20) { nodes { name } }
       }
     }
-    openHumanOversight: issues(first: 100, states: OPEN,
-                                 labels: ["human-oversight"],
-                                 orderBy: {field: CREATED_AT, direction: DESC}) {
+    openDirective: issues(first: 100, states: OPEN,
+                           labels: ["directive"],
+                           orderBy: {field: CREATED_AT, direction: DESC}) {
       nodes {
         number title createdAt updatedAt
         labels(first: 20) { nodes { name } }
@@ -1963,9 +1963,9 @@ query TuiRefresh($owner: String!, $name: String!) {
         labels(first: 20) { nodes { name } }
       }
     }
-    closedHumanOversight: issues(first: 30, states: CLOSED,
-                                   labels: ["human-oversight"],
-                                   orderBy: {field: UPDATED_AT, direction: DESC}) {
+    closedDirective: issues(first: 30, states: CLOSED,
+                              labels: ["directive"],
+                              orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes {
         number title createdAt updatedAt closedAt
         labels(first: 20) { nodes { name } }
@@ -2014,7 +2014,10 @@ _TUI_REFRESH_LOCK = threading.Lock()
 # to `fetch_issue_states`); added `orderBy: CREATED_AT DESC` to
 # `openAgentPlan`/`openHumanOversight` and `orderBy: UPDATED_AT DESC` to
 # `blocked`/`hasPrIssues`; bumped `openAgentPlan` cap to 200.
-_TUI_CACHE_SCHEMA = 2
+# Schema 3 (2026-05-15): renamed GraphQL aliases `openHumanOversight` /
+# `closedHumanOversight` to `openDirective` / `closedDirective` to match
+# the renamed `directive` label (was `human-oversight`).
+_TUI_CACHE_SCHEMA = 3
 # One-shot flag: try the disk fallback exactly once per process, on the
 # first refresh tick after start-up. After that we either have live data
 # or we're already serving the in-memory copy.
@@ -2080,8 +2083,8 @@ def _load_tui_cache(slug: str) -> tuple[float, dict] | None:
         return None
     # Reject snapshots whose top-level keys don't match the current query
     # shape (defence in depth on top of the schema-version check).
-    required = ("openAgentPlan", "openHumanOversight",
-                "closedAgentPlan", "closedHumanOversight",
+    required = ("openAgentPlan", "openDirective",
+                "closedAgentPlan", "closedDirective",
                 "blocked", "hasPrIssues", "pullRequests")
     if not all(k in body for k in required):
         return None
@@ -2164,15 +2167,15 @@ def _gql_rollup_to_ci(commits_node: dict) -> str:
 
 
 def fetch_issues_and_prs() -> list[GHItem]:
-    """Fetch issues (agent-plan or human-oversight label, all states)
-    and recent PRs from GitHub. Powered by the batched TUI GraphQL
-    query so it costs one round-trip (or a 304) per refresh tick."""
+    """Fetch issues (agent-plan or directive label, all states) and
+    recent PRs from GitHub. Powered by the batched TUI GraphQL query
+    so it costs one round-trip (or a 304) per refresh tick."""
     repo_node = _tui_refresh_batch()
     if repo_node is None:
         return []
     items: list[GHItem] = []
     seen_open: set[int] = set()
-    for key in ("openAgentPlan", "openHumanOversight"):
+    for key in ("openAgentPlan", "openDirective"):
         nodes = ((repo_node.get(key) or {}).get("nodes")) or []
         for iss in nodes:
             num = iss.get("number")
@@ -2187,7 +2190,7 @@ def fetch_issues_and_prs() -> list[GHItem]:
                 labels=labels, ci_status="", state="open", timestamp=ts,
             ))
     seen_closed: set[int] = set()
-    for key in ("closedAgentPlan", "closedHumanOversight"):
+    for key in ("closedAgentPlan", "closedDirective"):
         nodes = ((repo_node.get(key) or {}).get("nodes")) or []
         for iss in nodes:
             num = iss.get("number")

--- a/pod/coordination.py
+++ b/pod/coordination.py
@@ -43,7 +43,7 @@ REQUIRED_LABELS = {
     "has-pr": "5319E7",
     "replan": "D93F0B",
     "coordination": "0E8A16",
-    "human-oversight": "CC317C",
+    "directive": "CC317C",
     "return-to-human": "E4A400",
     "critical-path": "FF6600",
     "repair-claimed": "7057FF",
@@ -427,13 +427,13 @@ def _unclaimed_issues(ctx: CoordinationContext,
             items = []
         return _unclaimed_filter(items)
 
-    # No extra label: union of agent-plan + human-oversight, dedup by number.
+    # No extra label: union of agent-plan + directive, dedup by number.
     items_a = _safe_json(_filter_trusted_issues([
         "--label", "agent-plan", "--state", "open", "--limit", "50",
         "--json", "number,title,labels,createdAt", *include,
     ]), default=[])
     items_h = _safe_json(_filter_trusted_issues([
-        "--label", "human-oversight", "--state", "open", "--limit", "50",
+        "--label", "directive", "--state", "open", "--limit", "50",
         "--json", "number,title,labels,createdAt", *include,
     ]), default=[])
     seen: dict[int, dict] = {}
@@ -446,8 +446,9 @@ def _unclaimed_issues(ctx: CoordinationContext,
 
 def _replan_issues(ctx: CoordinationContext) -> list[dict]:
     """Return `agent-plan + replan` issues filtered through the trusted-
-    author gate. `human-oversight` is intentionally excluded — those
-    issues have an owner-closes-only policy and must not be auto-replanned.
+    author gate. `directive` issues are intentionally excluded — their
+    satisfaction is judgment-laden, so the worker who completes the
+    deliverables closes them; they are not bounced through replan triage.
     """
     include = ["--include-untrusted"] if ctx.include_untrusted else []
     args = ["--label", "agent-plan", "--label", "replan",
@@ -479,9 +480,9 @@ def _safe_json(s: str, default=None):
 def cmd_orient(ctx: CoordinationContext, argv: list[str]) -> int:
     client = gh.get_client()
 
-    print("=== HUMAN OVERSIGHT DIRECTIVES (highest priority) ===")
+    print("=== DIRECTIVES (highest priority) ===")
     r = client.gh_cli(
-        "issue", "list", "--repo", ctx.repo, "--label", "human-oversight",
+        "issue", "list", "--repo", ctx.repo, "--label", "directive",
         "--state", "open", "--limit", "50",
         "--json", "number,title,labels,createdAt",
         "--jq", '.[] | select(.labels | all(.name != "has-pr")) '
@@ -1029,8 +1030,8 @@ def cmd_list_replan(ctx: CoordinationContext, argv: list[str]) -> int:
     """List `agent-plan + replan` issues ready for /replan triage.
 
     Goes through the same trusted-author gate as `list-unclaimed`.
-    Excludes `claimed`, `blocked`, `has-pr`. `human-oversight` is
-    excluded by construction (we only ask for `agent-plan`).
+    Excludes `claimed`, `blocked`, `has-pr`. `directive` is excluded
+    by construction (we only ask for `agent-plan`).
     """
     for it in _replan_issues(ctx):
         print(f"#{it.get('number')} {it.get('title','')}")

--- a/pod/data/agent-config/claude/commands/plan.md
+++ b/pod/data/agent-config/claude/commands/plan.md
@@ -11,30 +11,38 @@ items as GitHub issues, then exit. You do NOT execute any code changes.
 4. Read the project's roadmap document to understand current phase
 5. Record quality metrics as described in the project's CLAUDE.md
 
-## Step 1b: Check for human oversight directives
+## Step 1b: Check for directives
 
-Before creating any new work, check for open `human-oversight` issues:
+Before creating any new work, check for open `directive` issues:
 ```
-gh issue list --label human-oversight --state open --json number,title,labels \
+gh issue list --label directive --state open --json number,title,labels \
     --jq '.[] | select(.labels | all(.name != "has-pr")) | "#\(.number) \(.title)"'
 ```
 
-These are direct instructions from the project owner. Treat them as highest priority:
-- **Do not create issues that overlap with or supersede a `human-oversight` issue**
-- **Do not close `human-oversight` issues** — only the owner closes them
-- **Do not add `replan` to `human-oversight` issues** — they stay open until done
-- **Do not hand-apply `has-pr` to a `human-oversight` issue** to "park" it
-  while sub-issues do the work. `has-pr` is owned by `coordination create-pr`
-  alone — applied automatically when a PR with `Closes #N` is opened, removed
-  automatically when GitHub auto-closes the issue on merge. Manual
-  application desynchronises the label from any real PR; when the partial
-  PR merges (without `Closes #N`) the issue stays `has-pr` forever and is
-  silently excluded from the work queue. To park a decomposed directive
-  cleanly, run `coordination add-dep <directive> <sub-issue>` for each open
+These are direct instructions from the project owner — work flowing
+*down* from the human, not work awaiting human attention. Treat them as
+highest priority:
+- **Do not create issues that overlap with or supersede a `directive`**
+- **Close a `directive` when its deliverables are merged.** If you
+  decompose it into sub-issues, the parent stays open until every
+  sub-issue closes; close the parent yourself once the chain is done.
+  Do **not** leave a directive open with a "for owner closure" note.
+- **Do not add `replan` to a `directive`** — if it is genuinely blocked,
+  say so in a comment and leave the claim. The replan triage loop
+  intentionally skips directives.
+- **Do not hand-apply `has-pr` to a `directive`** to "park" it while
+  sub-issues do the work. `has-pr` is owned by `coordination create-pr`
+  alone — applied automatically when a PR with `Closes #N` is opened,
+  removed automatically when GitHub auto-closes the issue on merge.
+  Manual application desynchronises the label from any real PR; when
+  the partial PR merges (without `Closes #N`) the issue stays `has-pr`
+  forever and is silently excluded from the work queue. To park a
+  decomposed directive cleanly, run
+  `coordination add-dep <directive> <sub-issue>` for each open
   sub-issue: the directive becomes `blocked` and auto-unblocks when all
-  subs close. The housekeeping cycle (`check-has-pr`, `check-blocked`) will
-  remove orphan labels and post an audit comment.
-- If a `human-oversight` issue is already claimed, continue to Step 2 (workers are on it)
+  subs close. The housekeeping cycle (`check-has-pr`, `check-blocked`)
+  will remove orphan labels and post an audit comment.
+- If a `directive` is already claimed, continue to Step 2 (workers are on it)
 - If unclaimed, prioritise creating any supporting infrastructure issues first, then exit
   — the next worker will claim the directive itself
 

--- a/pod/data/agent-config/claude/commands/repair.md
+++ b/pod/data/agent-config/claude/commands/repair.md
@@ -41,9 +41,10 @@ Repair has exactly two terminal states:
    This closes the PR, removes `has-pr` from the linked issue, and adds
    `replan` so the planner will produce a fresh approach.
 
-**Do not escalate to `human-oversight`.** The fix-or-abandon rule is
-non-negotiable: complex conflicts become re-implementations via `replan`,
-not human tickets.
+**Do not escalate by inventing a `directive`.** The `directive` label
+flows top-down from the project owner; agents do not author directives.
+The fix-or-abandon rule is non-negotiable: complex conflicts become
+re-implementations via `replan`, not human tickets.
 
 See the `pr-repair-flow` skill for retry budget, verification rules, and
 examples.

--- a/pod/data/agent-config/claude/commands/replan.md
+++ b/pod/data/agent-config/claude/commands/replan.md
@@ -26,9 +26,11 @@ coordination list-replan
 
 Output is one issue per line: `#<number> <title>`. The list goes
 through the same trusted-author gate as `list-unclaimed`. Issues with
-`claimed`, `blocked`, or `has-pr` are filtered out, as are
-`human-oversight` issues (those have an owner-closes-only policy and
-must never be auto-replanned).
+`claimed`, `blocked`, or `has-pr` are filtered out, as are `directive`
+issues — their satisfaction is judgment-laden, so they are closed by
+the worker who completes the deliverables (not by replan triage). If
+a directive's worker chain has stalled, the next planner reading the
+issue retriages manually.
 
 If the list is empty, exit cleanly — pod will release the planner lock.
 

--- a/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/agent-worker-flow/SKILL.md
@@ -82,18 +82,23 @@ coordination orient
 ```
 
 **Priority order:**
-0. **Human oversight directives first**: Check for open `human-oversight` issues before
-   anything else. These are direct instructions from the project owner and take absolute
-   precedence over all other work:
+0. **Directives first**: Check for open `directive` issues before anything else.
+   These are direct instructions from the project owner — work flowing *down* from
+   the human, not work awaiting human attention — and take absolute precedence over
+   all other work:
    ```
-   coordination list-unclaimed --label human-oversight
+   coordination list-unclaimed --label directive
    ```
    If any are open and unclaimed, claim the oldest one immediately.
-   **These issues cannot be skipped or refused because you disagree with the approach.**
-   The only valid exit from a `human-oversight` issue is completing it, or posting a
-   comment explaining a genuine technical blocker (e.g. a missing dependency), then
-   using `coordination skip` with that reason. Do not `skip` because you think a
-   different approach is better — that is the owner's call, not yours.
+   **Directives cannot be skipped or refused because you disagree with the approach.**
+   The valid exits from a `directive` are (a) completing the deliverables and
+   **closing the issue yourself**, (b) opening a partial PR and noting the
+   remaining scope so a successor can pick it up, or (c) posting a comment
+   explaining a genuine technical blocker (e.g. a missing dependency) and
+   `coordination skip` with that reason. Do **not** leave a directive open
+   with a "for owner closure" note — if the deliverables are in, close it.
+   Do not `skip` because you think a different approach is better — that is
+   the owner's call, not yours.
 1. **Oldest unclaimed issue** of your type:
    ```
    coordination list-unclaimed --label <your-label>

--- a/pod/data/agent-config/claude/skills/pr-repair-flow/SKILL.md
+++ b/pod/data/agent-config/claude/skills/pr-repair-flow/SKILL.md
@@ -20,9 +20,10 @@ Repair sessions have exactly two terminal outcomes:
    bounded number of failed attempts. This removes `has-pr` from the linked
    issue and adds `replan`, so a fresh plan can be produced.
 
-**There is no escalation to `human-oversight`.** Complex conflicts become
-re-implementations via `replan`, not human tickets. If verification keeps
-failing, abandon.
+**Repair sessions do not author `directive` issues.** The `directive`
+label flows top-down from the project owner; it is not a place agents
+escalate to. Complex conflicts become re-implementations via `replan`,
+not human tickets. If verification keeps failing, abandon.
 
 ## Coordination Commands
 
@@ -139,7 +140,7 @@ computed on demand by `list-pr-repair`; a label would drift out of sync.
 
 - Open new issues (except as part of a `replan` comment if genuinely
   helpful context).
-- Escalate to `human-oversight`.
+- Author a `directive` to escalate (directives are owner-issued only).
 - Keep trying the same fix with minor variations past the 3-cycle budget.
 - Fight healthy in-progress CI (the stuck threshold already filters for
   checks past the configured age).

--- a/pod/data/agent-config/codex/commands/plan.md
+++ b/pod/data/agent-config/codex/commands/plan.md
@@ -11,19 +11,26 @@ items as GitHub issues, then exit. You do NOT execute any code changes.
 4. Read the project's roadmap document to understand current phase
 5. Record quality metrics as described in the project's CLAUDE.md
 
-## Step 1b: Check for human oversight directives
+## Step 1b: Check for directives
 
-Before creating any new work, check for open `human-oversight` issues:
+Before creating any new work, check for open `directive` issues:
 ```
-gh issue list --label human-oversight --state open --json number,title,labels \
+gh issue list --label directive --state open --json number,title,labels \
     --jq '.[] | select(.labels | all(.name != "has-pr")) | "#\(.number) \(.title)"'
 ```
 
-These are direct instructions from the project owner. Treat them as highest priority:
-- **Do not create issues that overlap with or supersede a `human-oversight` issue**
-- **Do not close `human-oversight` issues** — only the owner closes them
-- **Do not add `replan` to `human-oversight` issues** — they stay open until done
-- If a `human-oversight` issue is already claimed, continue to Step 2 (workers are on it)
+These are direct instructions from the project owner — work flowing
+*down* from the human, not work awaiting human attention. Treat them as
+highest priority:
+- **Do not create issues that overlap with or supersede a `directive`**
+- **Close a `directive` when its deliverables are merged.** If you
+  decompose it into sub-issues, the parent stays open until every
+  sub-issue closes; close the parent yourself once the chain is done.
+  Do **not** leave a directive open with a "for owner closure" note.
+- **Do not add `replan` to a `directive`** — if it is genuinely blocked,
+  say so in a comment and leave the claim. The replan triage loop
+  intentionally skips directives.
+- If a `directive` is already claimed, continue to Step 2 (workers are on it)
 - If unclaimed, prioritise creating any supporting infrastructure issues first, then exit
   — the next worker will claim the directive itself
 

--- a/pod/data/agent-config/codex/commands/repair.md
+++ b/pod/data/agent-config/codex/commands/repair.md
@@ -28,7 +28,8 @@ each), exit — a fresh dispatch will handle the work later.
 ## Retry Budget
 
 You get at most 3 fix → verify cycles. Do not keep trying variations past
-that limit. Do not escalate to `human-oversight`. If verification keeps
+that limit. Do not author a `directive` to escalate (directives are
+owner-issued only). If verification keeps
 failing, abandon: `coordination close-pr-unsalvageable <pr-number> "<reason>"`.
 That closes the PR and marks the linked issue `replan`, so the planner will
 produce a fresh approach.

--- a/pod/data/agent-config/codex/commands/replan.md
+++ b/pod/data/agent-config/codex/commands/replan.md
@@ -26,9 +26,11 @@ coordination list-replan
 
 Output is one issue per line: `#<number> <title>`. The list goes
 through the same trusted-author gate as `list-unclaimed`. Issues with
-`claimed`, `blocked`, or `has-pr` are filtered out, as are
-`human-oversight` issues (those have an owner-closes-only policy and
-must never be auto-replanned).
+`claimed`, `blocked`, or `has-pr` are filtered out, as are `directive`
+issues — their satisfaction is judgment-laden, so they are closed by
+the worker who completes the deliverables (not by replan triage). If
+a directive's worker chain has stalled, the next planner reading the
+issue retriages manually.
 
 If the list is empty, exit cleanly — pod will release the planner lock.
 

--- a/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/agent-worker-flow/SKILL.md
@@ -69,18 +69,23 @@ coordination orient
 ```
 
 **Priority order:**
-0. **Human oversight directives first**: Check for open `human-oversight` issues before
-   anything else. These are direct instructions from the project owner and take absolute
-   precedence over all other work:
+0. **Directives first**: Check for open `directive` issues before anything else.
+   These are direct instructions from the project owner — work flowing *down* from
+   the human, not work awaiting human attention — and take absolute precedence over
+   all other work:
    ```
-   coordination list-unclaimed --label human-oversight
+   coordination list-unclaimed --label directive
    ```
    If any are open and unclaimed, claim the oldest one immediately.
-   **These issues cannot be skipped or refused because you disagree with the approach.**
-   The only valid exit from a `human-oversight` issue is completing it, or posting a
-   comment explaining a genuine technical blocker (e.g. a missing dependency), then
-   using `coordination skip` with that reason. Do not `skip` because you think a
-   different approach is better — that is the owner's call, not yours.
+   **Directives cannot be skipped or refused because you disagree with the approach.**
+   The valid exits from a `directive` are (a) completing the deliverables and
+   **closing the issue yourself**, (b) opening a partial PR and noting the
+   remaining scope so a successor can pick it up, or (c) posting a comment
+   explaining a genuine technical blocker (e.g. a missing dependency) and
+   `coordination skip` with that reason. Do **not** leave a directive open
+   with a "for owner closure" note — if the deliverables are in, close it.
+   Do not `skip` because you think a different approach is better — that is
+   the owner's call, not yours.
 1. **Oldest unclaimed issue** of your type:
    ```
    coordination list-unclaimed --label <your-label>

--- a/pod/data/agent-config/codex/skills/pr-repair-flow/SKILL.md
+++ b/pod/data/agent-config/codex/skills/pr-repair-flow/SKILL.md
@@ -20,9 +20,10 @@ Repair sessions have exactly two terminal outcomes:
    bounded number of failed attempts. This removes `has-pr` from the linked
    issue and adds `replan`, so a fresh plan can be produced.
 
-**There is no escalation to `human-oversight`.** Complex conflicts become
-re-implementations via `replan`, not human tickets. If verification keeps
-failing, abandon.
+**Repair sessions do not author `directive` issues.** The `directive`
+label flows top-down from the project owner; it is not a place agents
+escalate to. Complex conflicts become re-implementations via `replan`,
+not human tickets. If verification keeps failing, abandon.
 
 ## Coordination Commands
 
@@ -139,7 +140,7 @@ computed on demand by `list-pr-repair`; a label would drift out of sync.
 
 - Open new issues (except as part of a `replan` comment if genuinely
   helpful context).
-- Escalate to `human-oversight`.
+- Author a `directive` to escalate (directives are owner-issued only).
 - Keep trying the same fix with minor variations past the 3-cycle budget.
 - Fight healthy in-progress CI (the stuck threshold already filters for
   checks past the configured age).

--- a/tests/test_dep_state_resolution.py
+++ b/tests/test_dep_state_resolution.py
@@ -171,10 +171,10 @@ class TuiRefreshQueryShapeTests(unittest.TestCase):
             r"\s*direction:\s*DESC\}",
         )
 
-    def test_open_human_oversight_orders_newest_first(self):
+    def test_open_directive_orders_newest_first(self):
         self.assertRegex(
             cli._TUI_REFRESH_QUERY,
-            r"openHumanOversight: issues\([^)]*orderBy:\s*\{field:\s*CREATED_AT,"
+            r"openDirective: issues\([^)]*orderBy:\s*\{field:\s*CREATED_AT,"
             r"\s*direction:\s*DESC\}",
         )
 
@@ -206,8 +206,8 @@ class TuiRefreshQueryShapeTests(unittest.TestCase):
     def test_open_issue_numbers_removed(self):
         self.assertNotIn("openIssueNumbers", cli._TUI_REFRESH_QUERY)
 
-    def test_cache_schema_is_2(self):
-        self.assertEqual(cli._TUI_CACHE_SCHEMA, 2)
+    def test_cache_schema_is_3(self):
+        self.assertEqual(cli._TUI_CACHE_SCHEMA, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_once_mode.py
+++ b/tests/test_once_mode.py
@@ -126,7 +126,7 @@ class CmdOnceTests(unittest.TestCase):
         args = types.SimpleNamespace(issue=3693, work_type=None)
         with mock.patch.object(cli.subprocess, "check_output",
                                return_value=self._gh_view(
-                                   ["human-oversight", "feature"])) as gh, \
+                                   ["directive", "feature"])) as gh, \
              mock.patch.object(cli, "spawn_agent",
                                return_value=12345) as spawn:
             cli.cmd_once(self._config(), args)
@@ -177,7 +177,7 @@ class CmdOnceTests(unittest.TestCase):
 
     def test_falls_back_to_work_when_configured(self):
         """When no label matches a worker_type but `work` is configured,
-        `pod once` defaults to `work` — `human-oversight`-only issues
+        `pod once` defaults to `work` — `directive`-only issues
         (the common case for hand-written work items) shouldn't require
         `--type work` explicitly."""
         config = {
@@ -190,7 +190,7 @@ class CmdOnceTests(unittest.TestCase):
         args = types.SimpleNamespace(issue=3698, work_type=None)
         with mock.patch.object(cli.subprocess, "check_output",
                                return_value=self._gh_view(
-                                   ["human-oversight"])), \
+                                   ["directive"])), \
              mock.patch.object(cli, "spawn_agent",
                                return_value=12345) as spawn:
             cli.cmd_once(config, args)
@@ -218,7 +218,7 @@ class CmdOnceTests(unittest.TestCase):
         args = types.SimpleNamespace(issue=3693, work_type=None)
         with mock.patch.object(cli.subprocess, "check_output",
                                return_value=self._gh_view(
-                                   ["human-oversight", "feature",
+                                   ["directive", "feature",
                                     "claimed"])), \
              mock.patch.object(cli, "spawn_agent",
                                side_effect=AssertionError(

--- a/tests/test_orphan_label_helpers.py
+++ b/tests/test_orphan_label_helpers.py
@@ -92,7 +92,7 @@ class FetchBlockedDepsTests(unittest.TestCase):
             self.assertEqual(cli.fetch_blocked_deps(), {})
 
     def test_includes_blocked_from_any_family_label(self):
-        # The blocked field doesn't filter by agent-plan vs human-oversight,
+        # The blocked field doesn't filter by agent-plan vs directive,
         # so HO-2 (#2565 in the kim-em/hex repo) shows up here too.
         body = ("HO-2 work item.\n\n"
                 "depends-on: #2563\n"
@@ -198,12 +198,12 @@ class FetchIssuesAndPrsTests(unittest.TestCase):
                 _issue(10, title="open agent-plan",
                         labels=["agent-plan"]),
             ]},
-            "openHumanOversight": {"nodes": [
-                _issue(20, title="open ho",
-                        labels=["human-oversight"]),
+            "openDirective": {"nodes": [
+                _issue(20, title="open directive",
+                        labels=["directive"]),
             ]},
             "closedAgentPlan": {"nodes": []},
-            "closedHumanOversight": {"nodes": []},
+            "closedDirective": {"nodes": []},
             "pullRequests": {"nodes": [
                 _pr_node(30, title="pass pr", state="OPEN",
                           checks_state="SUCCESS"),
@@ -234,9 +234,9 @@ class BatchCacheTests(unittest.TestCase):
         from _gh_helpers import fake_response, patch_client
         graphql_body = {"data": {"repository": {
             "openAgentPlan": {"nodes": []},
-            "openHumanOversight": {"nodes": []},
+            "openDirective": {"nodes": []},
             "closedAgentPlan": {"nodes": []},
-            "closedHumanOversight": {"nodes": []},
+            "closedDirective": {"nodes": []},
             "blocked": {"nodes": []},
             "hasPrIssues": {"nodes": []},
             "pullRequests": {"nodes": []},

--- a/tests/test_replan_dispatch.py
+++ b/tests/test_replan_dispatch.py
@@ -70,7 +70,7 @@ class FilteredIssuesTests(unittest.TestCase):
 class ReplanIssuesTests(unittest.TestCase):
     """`_replan_issues` goes through `_filter_trusted_issues` with the
     `agent-plan + replan` label pair, applies `_REPLAN_EXCLUDE`, and
-    never asks for `human-oversight`."""
+    never asks for `directive`."""
 
     def _ctx(self, include_untrusted: bool = False):
         c = mock.MagicMock()
@@ -96,7 +96,7 @@ class ReplanIssuesTests(unittest.TestCase):
                         if a == "--label"]
         self.assertIn("agent-plan", label_values)
         self.assertIn("replan", label_values)
-        self.assertNotIn("human-oversight", label_values)
+        self.assertNotIn("directive", label_values)
         # Explicit limit (not the gh default).
         self.assertIn("--limit", args)
         self.assertEqual(args[args.index("--limit") + 1], "500")

--- a/tests/test_tui_cache.py
+++ b/tests/test_tui_cache.py
@@ -25,9 +25,9 @@ from _gh_helpers import fake_response, patch_client
 
 _VALID_REPO_NODE = {
     "openAgentPlan": {"nodes": []},
-    "openHumanOversight": {"nodes": []},
+    "openDirective": {"nodes": []},
     "closedAgentPlan": {"nodes": []},
-    "closedHumanOversight": {"nodes": []},
+    "closedDirective": {"nodes": []},
     "blocked": {"nodes": []},
     "hasPrIssues": {"nodes": []},
     "pullRequests": {"nodes": []},


### PR DESCRIPTION
This PR renames the GitHub label `human-oversight` to `directive` and rewrites the prompt corpus's closure-policy framing. The trigger was observing planner-triage comments like

> leaving this human-oversight directive open for owner closure

(verbatim on kim-em/hex#2637 May 9, 17:38 and 18:22 UTC, plus several others). The label name and the "owner-closes-only" wording both inverted the actual directionality these issues encode — work flowing *down* from the project owner to the agents, not work awaiting human attention. Agents read those phrases, faithfully repeated them in their own triage comments, and trained the next agent that directives are parked-pending-human, not actively-being-executed.

Coupled changes here:

- Rename `human-oversight` → `directive` (color `CC317C` preserved) in `coordination.py`'s `REQUIRED_LABELS`, the `_unclaimed_issues` union, the `_replan_issues` exclusion comment, the `cmd_orient` banner ("=== DIRECTIVES (highest priority) ===" — was "HUMAN OVERSIGHT DIRECTIVES"), and `cmd_list_replan`'s docstring.
- Rename GraphQL aliases `openHumanOversight` / `closedHumanOversight` → `openDirective` / `closedDirective` in `cli.py`'s `_TUI_REFRESH_QUERY` and its consumers (`fetch_issues_and_prs`, the `required` validation tuple). Bump `_TUI_CACHE_SCHEMA` from 2 to 3 so any on-disk snapshot from the old shape is rejected on load.
- Rewrite both backends' prompts (`pod/data/agent-config/{claude,codex}/{commands,skills}/`) so agents:
  - close a `directive` themselves once the deliverables are merged (parent stays open until every decomposed sub-issue closes, then the worker closes the parent);
  - never leave a directive open with a "for owner closure" note;
  - understand that `directive` is owner-issued, not agent-escalation-target — repair flows do not author directives.

Replan rationale was reframed from "owner-closes-only policy" (which leaks into agent comments) to "satisfaction is judgment-laden, so the worker who completes the deliverables closes them" (which doesn't).

The actual GitHub label rename + per-issue migration on downstream projects (e.g. kim-em/hex) lives outside this repo and is run after this lands.

All 443 tests pass.

🤖 Prepared with Claude Code