### PR TITLE
fix: surface keychain mirror failures so a stale entry can't shadow the file fallback

### DIFF
--- a/pod/accounts.py
+++ b/pod/accounts.py
@@ -229,6 +229,26 @@ def _keychain_write(service: str, blob: str) -> bool:
         return False
 
 
+def _keychain_delete(service: str) -> None:
+    """Best-effort delete of a keychain entry. Doesn't raise.
+
+    Caller must verify deletion via ``_keychain_read`` if it matters —
+    ``security delete-generic-password`` returns non-zero both when the
+    entry is missing (already gone) and when deletion was refused, and
+    we don't try to disambiguate.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        subprocess.run(
+            ["security", "delete-generic-password",
+             "-s", service, "-a", os.getenv("USER", "")],
+            capture_output=True, timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+
+
 def resolve_claude_credential(claude_config_dir: Path | None) -> dict:
     """Resolve the credential Claude Code will actually use at launch time.
 
@@ -316,6 +336,18 @@ class Lease:
 
 class LeaseError(Exception):
     pass
+
+
+class CredentialMirrorError(Exception):
+    """Raised when ``mirror_canonical_to_isolated`` cannot guarantee the
+    isolated keychain entry has been updated or removed.
+
+    Claude Code reads the per-config-dir keychain entry before falling
+    back to ``.credentials.json``. If we can't overwrite a stale entry
+    *and* can't delete it, the agent would silently launch under the
+    wrong account. The caller (``acquire_backend``) treats this as a
+    hard failure: release the lease, try the next candidate.
+    """
 
 
 def _read_lease(path: Path) -> Lease | None:
@@ -468,6 +500,11 @@ def mirror_canonical_to_isolated(label: str, account_num: int,
     to call concurrently with ``harvest_isolated_to_canonical`` for
     other agents on the same account because the lock is exclusive
     per-account.
+
+    Raises ``CredentialMirrorError`` if the keychain write fails *and*
+    a stale entry persists that we can't delete: Claude Code reads the
+    keychain before the file fallback, so a stale entry would silently
+    launch the agent under the wrong account.
     """
     with credential_lock(label):
         canonical = _read_credential_blob(_credentials_path(account_num))
@@ -493,6 +530,18 @@ def mirror_canonical_to_isolated(label: str, account_num: int,
         tmp.rename(cred_file)
         if wrote_kc:
             _log(f"accounts: mirrored canonical {label} → keychain {service}")
+            return True
+        # Keychain write failed. The file fallback we just wrote is only
+        # consulted if the keychain entry is absent; force-clear any
+        # stale entry and verify it's gone before reporting success.
+        _keychain_delete(service)
+        if _keychain_read(service) is not None:
+            raise CredentialMirrorError(
+                f"keychain write to {service} failed for account {label} "
+                f"and stale entry persists; Claude Code would load a "
+                f"different credential than {cred_file}")
+        _log(f"accounts: keychain write to {service} failed; cleared "
+             f"stale entry — Claude Code will use {cred_file.name} fallback")
         return True
 
 

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1793,7 +1793,7 @@ def acquire_backend(
                 try:
                     accounts.mirror_canonical_to_isolated(
                         cand.label, cand.account_num, claude_config_dir)
-                except OSError as e:
+                except (OSError, accounts.CredentialMirrorError) as e:
                     log(f"acquire_backend: mirror failed for "
                         f"{cand.label}: {e}")
                     accounts.release_lease(cand.label, short_id)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -271,6 +271,46 @@ class MirrorHarvestTests(_IsolatedHome):
         # Canonical untouched.
         self.assertIn("2026", path.read_text())
 
+    def test_mirror_clears_stale_when_keychain_write_fails(self):
+        # Stale isolated entry (older expiry) + write failure → we delete
+        # the stale entry so Claude Code falls through to the file we
+        # just wrote. mirror returns True; no exception.
+        self._write_canonical(4, "lean-fro", "2027-01-01T00:00:00Z")
+        config_dir = self.tmp / "claude-config" / "abcd1234"
+        service = accounts.claude_keychain_service(config_dir)
+        self._kc[service] = _make_creds(
+            "qim", "2026-01-01T00:00:00Z")  # wrong account, older
+        # Override write to fail; delete uses the fake_kc dict so
+        # patching it is enough to simulate "delete works".
+        self._kc_write.stop()
+        with mock.patch.object(accounts, "_keychain_write", return_value=False), \
+             mock.patch.object(accounts, "_keychain_delete",
+                                side_effect=lambda s: self._kc.pop(s, None)):
+            wrote = accounts.mirror_canonical_to_isolated(
+                "lean-fro", 4, config_dir)
+        self.assertTrue(wrote)
+        self.assertNotIn(service, self._kc)
+        # File fallback exists with the right account.
+        self.assertIn("lean-fro",
+                      (config_dir / ".credentials.json").read_text())
+
+    def test_mirror_raises_when_stale_entry_persists(self):
+        # Write fails AND delete is a no-op → stale entry persists →
+        # raise so the caller releases the lease and tries another
+        # candidate instead of launching the agent under qim's token
+        # while believing it's lean-fro.
+        self._write_canonical(4, "lean-fro", "2027-01-01T00:00:00Z")
+        config_dir = self.tmp / "claude-config" / "abcd1234"
+        service = accounts.claude_keychain_service(config_dir)
+        self._kc[service] = _make_creds("qim", "2026-01-01T00:00:00Z")
+        self._kc_write.stop()
+        with mock.patch.object(accounts, "_keychain_write", return_value=False), \
+             mock.patch.object(accounts, "_keychain_delete",
+                                side_effect=lambda s: None):
+            with self.assertRaises(accounts.CredentialMirrorError):
+                accounts.mirror_canonical_to_isolated(
+                    "lean-fro", 4, config_dir)
+
 
 # --- probe_account / probe_codex --------------------------------------------
 


### PR DESCRIPTION
This PR fixes a silent-failure mode in per-agent credential mirroring. `mirror_canonical_to_isolated` was treating a failed `security add-generic-password` as best-effort: it logged "keychain write failed" and returned True because the `.credentials.json` fallback had been written. But Claude Code reads the per-config-dir keychain entry *before* falling back to the file, so a stale keychain entry from a previous account would silently shadow the fresh file and the agent would launch under the wrong credential.

When the keychain write fails, we now force-delete any existing entry and verify it's gone. If a stale entry persists, we raise `CredentialMirrorError` so `acquire_backend` releases the lease and moves to the next candidate instead of launching the agent under the wrong account.

Found in the wild: a host with three pod agents repeatedly hit `Failed to mirror credential to Claude Code-credentials-d9b1be20: ... exit status 36`, then `no quota for any backend, sleeping 60s` — even though two accounts had healthy quota. The agents were running pre-#67 code that shared one `claude_config_dir`, but the silent-failure pattern would apply equally under #67 if any keychain race or ACL change ever caused a write to fail.

🤖 Prepared with Claude Code