### PR TITLE
fix(tui): keep [account] prefix when an agent is shown as 'thinking'

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -7354,17 +7354,18 @@ def _tui_main(stdscr, config: dict):
                 activity = agent.last_text or agent.status
             else:
                 activity = agent.status
-            # Prefix with which Claude account holds the lease (if any),
-            # so operators can see at a glance which account each agent
-            # is burning quota on.
-            if agent.account_label:
-                activity = f"[{agent.account_label}] {activity}"
             # Thinking detection: if JSONL is stale but process is alive
             if (agent.last_activity > 0 and
                     time.time() - agent.last_activity > 10 and
                     agent.status == "running"):
                 stale = int(time.time() - agent.last_activity)
                 activity = f"thinking {human_duration(stale)}"
+            # Prefix with which Claude account holds the lease (if any),
+            # so operators can see at a glance which account each agent
+            # is burning quota on. Applied last so it survives the
+            # thinking-detection overwrite above.
+            if agent.account_label:
+                activity = f"[{agent.account_label}] {activity}"
 
             # Sanitize: collapse newlines/tabs to spaces
             activity = " ".join(activity.split())


### PR DESCRIPTION
This PR fixes the activity column in the TUI dropping the `[<account_label>]` prefix whenever the agent's JSONL went stale long enough to flip into the "thinking" display: the prefix was applied first and the thinking-detection branch then overwrote `activity` outright. Reorder so thinking detection runs first and the prefix is applied last, surviving both branches.

🤖 Prepared with Claude Code