### PR TITLE
fix: never apply the replan label to directive issues

### DIFF
--- a/pod/coordination.py
+++ b/pod/coordination.py
@@ -449,6 +449,9 @@ def _replan_issues(ctx: CoordinationContext) -> list[dict]:
     author gate. `directive` issues are intentionally excluded — their
     satisfaction is judgment-laden, so the worker who completes the
     deliverables closes them; they are not bounced through replan triage.
+    They are also never given the `replan` label in the first place (see
+    `_mark_replan_unless_directive`), so the `agent-plan` requirement here
+    is belt-and-braces rather than the sole guard.
     """
     include = ["--include-untrusted"] if ctx.include_untrusted else []
     args = ["--label", "agent-plan", "--label", "replan",
@@ -471,6 +474,49 @@ def _safe_json(s: str, default=None):
         return _json.loads(s)
     except ValueError:
         return default
+
+
+def _issue_has_label(client, repo: str, issue_num, label: str) -> bool:
+    """True if issue #issue_num currently carries `label`.
+
+    A lookup failure is treated as "label absent" (False)."""
+    r = client.gh_cli(
+        "issue", "view", str(issue_num), "--repo", repo,
+        "--json", "labels", "--jq", "[.labels[].name] | join(\",\")",
+        timeout=15,
+    )
+    if r.returncode != 0:
+        return False
+    return re.search(rf"\b{re.escape(label)}\b", r.stdout or "") is not None
+
+
+def _mark_replan_unless_directive(client, repo: str, issue_num, *,
+                                   remove_labels: list[str],
+                                   replan_comment: str | None,
+                                   directive_comment: str | None) -> bool:
+    """Add the `replan` label to issue #issue_num and strip `remove_labels`.
+
+    Exception: a `directive` issue is never given the `replan` label.
+    `replan` would strand it — `list-replan` only returns issues that also
+    carry `agent-plan`, and `list-unclaimed` excludes anything labelled
+    `replan`, so a `directive`+`replan` issue is invisible to every
+    dispatch path. For a directive we only strip `remove_labels`, leaving
+    it claimable by a fresh worker.
+
+    Returns True iff the issue was a directive (no `replan` applied)."""
+    issue_num = str(issue_num)
+    is_directive = _issue_has_label(client, repo, issue_num, "directive")
+    if not is_directive:
+        client.gh_cli("issue", "edit", issue_num, "--repo", repo,
+                       "--add-label", "replan", timeout=15)
+    for lbl in remove_labels:
+        client.gh_cli("issue", "edit", issue_num, "--repo", repo,
+                       "--remove-label", lbl, timeout=15)
+    comment = directive_comment if is_directive else replan_comment
+    if comment:
+        client.gh_cli("issue", "comment", issue_num, "--repo", repo,
+                       "--body", comment, timeout=30)
+    return is_directive
 
 
 # ---------------------------------------------------------------------------
@@ -779,11 +825,21 @@ def cmd_create_pr(ctx: CoordinationContext, argv: list[str]) -> int:
             print("warning: auto-merge not available "
                   "(branch protection may not be set up)")
         if partial:
-            client.gh_cli("issue", "edit", issue_num, "--repo", ctx.repo,
-                           "--add-label", "replan", timeout=15)
-            client.gh_cli("issue", "edit", issue_num, "--repo", ctx.repo,
-                           "--remove-label", "claimed", timeout=15)
-            print(f"Issue #{issue_num} marked replan (partial completion)")
+            is_directive = _mark_replan_unless_directive(
+                client, ctx.repo, issue_num,
+                remove_labels=["claimed"],
+                replan_comment=None,
+                directive_comment=(
+                    f"PR #{existing_pr} created with partial completion. "
+                    "Directive left claimable for a fresh worker to "
+                    "continue (directives are not bounced through replan "
+                    "triage)."),
+            )
+            if is_directive:
+                print(f"Issue #{issue_num} left claimable "
+                      "(directive, partial completion — no replan label)")
+            else:
+                print(f"Issue #{issue_num} marked replan (partial completion)")
         else:
             client.gh_cli("issue", "edit", issue_num, "--repo", ctx.repo,
                            "--add-label", "has-pr", timeout=15)
@@ -825,11 +881,20 @@ def cmd_create_pr(ctx: CoordinationContext, argv: list[str]) -> int:
                   "(branch protection may not be set up)")
 
     if partial:
-        client.gh_cli("issue", "edit", issue_num, "--repo", ctx.repo,
-                       "--add-label", "replan", timeout=15)
-        client.gh_cli("issue", "edit", issue_num, "--repo", ctx.repo,
-                       "--remove-label", "claimed", timeout=15)
-        print(f"Issue #{issue_num} marked replan (partial completion)")
+        is_directive = _mark_replan_unless_directive(
+            client, ctx.repo, issue_num,
+            remove_labels=["claimed"],
+            replan_comment=None,
+            directive_comment=(
+                f"PR #{pr_num} created with partial completion. "
+                "Directive left claimable for a fresh worker to continue "
+                "(directives are not bounced through replan triage)."),
+        )
+        if is_directive:
+            print(f"Issue #{issue_num} left claimable "
+                  "(directive, partial completion — no replan label)")
+        else:
+            print(f"Issue #{issue_num} marked replan (partial completion)")
     else:
         client.gh_cli("issue", "edit", issue_num, "--repo", ctx.repo,
                        "--add-label", "has-pr", timeout=15)
@@ -1224,19 +1289,19 @@ def cmd_close_pr_unsalvageable(ctx: CoordinationContext,
     if linked:
         updated = []
         for inum in linked:
-            client.gh_cli("issue", "edit", str(inum), "--repo", ctx.repo,
-                           "--add-label", "replan", timeout=15)
-            client.gh_cli("issue", "edit", str(inum), "--repo", ctx.repo,
-                           "--remove-label", "has-pr", timeout=15)
-            client.gh_cli(
-                "issue", "comment", str(inum), "--repo", ctx.repo,
-                "--body",
-                f"PR #{pr_num} closed as unsalvageable: {reason}. "
-                "Marked replan so a new plan can be produced.",
-                timeout=30,
+            _mark_replan_unless_directive(
+                client, ctx.repo, inum,
+                remove_labels=["has-pr"],
+                replan_comment=(
+                    f"PR #{pr_num} closed as unsalvageable: {reason}. "
+                    "Marked replan so a new plan can be produced."),
+                directive_comment=(
+                    f"PR #{pr_num} closed as unsalvageable: {reason}. "
+                    "Directive left claimable for a fresh worker "
+                    "(directives are not bounced through replan triage)."),
             )
             updated.append(f"#{inum}")
-        print(f"PR #{pr_num} closed; linked issue(s) marked replan: "
+        print(f"PR #{pr_num} closed; linked issue(s) re-triaged: "
               + " ".join(updated))
     else:
         br = client.gh_cli(
@@ -1249,19 +1314,20 @@ def cmd_close_pr_unsalvageable(ctx: CoordinationContext,
             body, re.IGNORECASE)))
         if fallback:
             for inum in fallback:
-                client.gh_cli("issue", "edit", str(inum), "--repo", ctx.repo,
-                               "--add-label", "replan", timeout=15)
-                client.gh_cli("issue", "edit", str(inum), "--repo", ctx.repo,
-                               "--remove-label", "has-pr", timeout=15)
-                client.gh_cli(
-                    "issue", "comment", str(inum), "--repo", ctx.repo,
-                    "--body",
-                    f"PR #{pr_num} closed as unsalvageable: {reason}. "
-                    "Marked replan so a new plan can be produced.",
-                    timeout=30,
+                _mark_replan_unless_directive(
+                    client, ctx.repo, inum,
+                    remove_labels=["has-pr"],
+                    replan_comment=(
+                        f"PR #{pr_num} closed as unsalvageable: {reason}. "
+                        "Marked replan so a new plan can be produced."),
+                    directive_comment=(
+                        f"PR #{pr_num} closed as unsalvageable: {reason}. "
+                        "Directive left claimable for a fresh worker "
+                        "(directives are not bounced through replan "
+                        "triage)."),
                 )
-            print(f"PR #{pr_num} closed; fallback-resolved issue(s) marked "
-                  f"replan: {' '.join(str(n) for n in fallback)}")
+            print(f"PR #{pr_num} closed; fallback-resolved issue(s) "
+                  f"re-triaged: {' '.join(str(n) for n in fallback)}")
         else:
             print(f"PR #{pr_num} closed; no linked issue found "
                   "(closingIssuesReferences empty, body grep empty).")
@@ -1478,17 +1544,21 @@ def cmd_skip(ctx: CoordinationContext, argv: list[str]) -> int:
         die('usage: coordination skip N "reason"')
     issue_num, reason = argv[0], argv[1]
     client = gh.get_client()
-    client.gh_cli(
-        "issue", "edit", issue_num, "--repo", ctx.repo,
-        "--remove-label", "claimed", "--add-label", "replan", timeout=15,
+    is_directive = _mark_replan_unless_directive(
+        client, ctx.repo, issue_num,
+        remove_labels=["claimed"],
+        replan_comment=(
+            f"Skipped by session `{ctx.session_id}` (needs replan): {reason}"),
+        directive_comment=(
+            f"Skipped by session `{ctx.session_id}`: {reason}. "
+            "Directive left claimable for a fresh worker (directives are "
+            "not bounced through replan triage)."),
     )
-    client.gh_cli(
-        "issue", "comment", issue_num, "--repo", ctx.repo,
-        "--body",
-        f"Skipped by session `{ctx.session_id}` (needs replan): {reason}",
-        timeout=30,
-    )
-    print(f"Skipped issue #{issue_num} (marked replan): {reason}")
+    if is_directive:
+        print(f"Skipped issue #{issue_num} "
+              f"(directive, left claimable): {reason}")
+    else:
+        print(f"Skipped issue #{issue_num} (marked replan): {reason}")
     return 0
 
 

--- a/pod/data/agent-config/claude/commands/replan.md
+++ b/pod/data/agent-config/claude/commands/replan.md
@@ -26,11 +26,14 @@ coordination list-replan
 
 Output is one issue per line: `#<number> <title>`. The list goes
 through the same trusted-author gate as `list-unclaimed`. Issues with
-`claimed`, `blocked`, or `has-pr` are filtered out, as are `directive`
-issues — their satisfaction is judgment-laden, so they are closed by
-the worker who completes the deliverables (not by replan triage). If
-a directive's worker chain has stalled, the next planner reading the
-issue retriages manually.
+`claimed`, `blocked`, or `has-pr` are filtered out. `directive` issues
+never appear here: the skip / partial-PR / unsalvageable-close paths
+deliberately do not apply the `replan` label to a directive (that
+label would strand it — invisible to both this list and
+`list-unclaimed`). A stalled directive instead stays claimable via
+`list-unclaimed` so a fresh worker picks it up again; its satisfaction
+is judgment-laden and is decided by the worker who completes the
+deliverables, not by replan triage.
 
 If the list is empty, exit cleanly — pod will release the planner lock.
 

--- a/pod/data/agent-config/codex/commands/replan.md
+++ b/pod/data/agent-config/codex/commands/replan.md
@@ -26,11 +26,14 @@ coordination list-replan
 
 Output is one issue per line: `#<number> <title>`. The list goes
 through the same trusted-author gate as `list-unclaimed`. Issues with
-`claimed`, `blocked`, or `has-pr` are filtered out, as are `directive`
-issues — their satisfaction is judgment-laden, so they are closed by
-the worker who completes the deliverables (not by replan triage). If
-a directive's worker chain has stalled, the next planner reading the
-issue retriages manually.
+`claimed`, `blocked`, or `has-pr` are filtered out. `directive` issues
+never appear here: the skip / partial-PR / unsalvageable-close paths
+deliberately do not apply the `replan` label to a directive (that
+label would strand it — invisible to both this list and
+`list-unclaimed`). A stalled directive instead stays claimable via
+`list-unclaimed` so a fresh worker picks it up again; its satisfaction
+is judgment-laden and is decided by the worker who completes the
+deliverables, not by replan triage.
 
 If the list is empty, exit cleanly — pod will release the planner lock.
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -388,6 +388,71 @@ class SkipTests(unittest.TestCase):
         self.assertIn(("issue", "edit"), verbs)
         self.assertIn(("issue", "comment"), verbs)
 
+    def test_skip_directive_does_not_mark_replan(self):
+        """A `directive` issue must never receive the `replan` label —
+        that would strand it (invisible to both list-replan and
+        list-unclaimed). Skip only strips `claimed`, leaving it
+        claimable."""
+        calls: list[tuple] = []
+
+        def handler(*argv):
+            calls.append(argv)
+            if argv[:2] == ("issue", "view"):
+                return _gh_result(stdout="directive,claimed")
+            return _gh_result()
+
+        with _capture_stdout() as buf, patch_client(gh_cli_handler=handler):
+            rc = coordination.cmd_skip(_make_ctx(), ["42", "needs human"])
+        self.assertEqual(rc, 0)
+        self.assertIn("directive, left claimable", buf.getvalue())
+        add_label_calls = [a for a in calls
+                           if a[:2] == ("issue", "edit")
+                           and "--add-label" in a]
+        self.assertEqual(add_label_calls, [])
+        self.assertTrue(any(a[:2] == ("issue", "edit")
+                            and "--remove-label" in a and "claimed" in a
+                            for a in calls))
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: close-pr-unsalvageable
+# ---------------------------------------------------------------------------
+
+class ClosePrUnsalvageableTests(unittest.TestCase):
+    def _run(self, issue_labels: str):
+        calls: list[tuple] = []
+
+        def handler(*argv):
+            calls.append(argv)
+            if argv[:2] == ("pr", "view"):
+                return _gh_result(stdout="77\n")
+            if argv[:2] == ("issue", "view"):
+                return _gh_result(stdout=issue_labels)
+            return _gh_result()
+
+        with _capture_stdout() as buf, patch_client(gh_cli_handler=handler):
+            rc = coordination.cmd_close_pr_unsalvageable(
+                _make_ctx(), ["55", "broken approach"])
+        return rc, calls
+
+    def test_directive_linked_issue_not_marked_replan(self):
+        rc, calls = self._run("directive,has-pr")
+        self.assertEqual(rc, 0)
+        add_label_calls = [a for a in calls
+                           if a[:2] == ("issue", "edit")
+                           and "--add-label" in a]
+        self.assertEqual(add_label_calls, [])
+        self.assertTrue(any(a[:2] == ("issue", "edit")
+                            and "--remove-label" in a and "has-pr" in a
+                            for a in calls))
+
+    def test_non_directive_linked_issue_marked_replan(self):
+        rc, calls = self._run("agent-plan,has-pr")
+        self.assertEqual(rc, 0)
+        self.assertTrue(any(a[:2] == ("issue", "edit")
+                            and "--add-label" in a and "replan" in a
+                            for a in calls))
+
 
 # ---------------------------------------------------------------------------
 # Subcommand: queue-depth


### PR DESCRIPTION
This PR fixes a dispatch dead zone in which a `directive` issue that received the `replan` label became unreachable by every automated path. `list-replan` only returns issues that also carry `agent-plan` (directives lack it), and `list-unclaimed` excludes anything labelled `replan`, so a `directive`+`replan` issue was invisible to replan triage, plan agents, and work agents alike — only manual human triage could recover it. In one repository five directive issues had been stranded this way for two days.

The three sites that apply the `replan` label — `skip`, `create-pr --partial`, and `close-pr-unsalvageable` — now route through a new `_mark_replan_unless_directive` helper. For a `directive` issue the helper strips the transient label (`claimed` / `has-pr`) and posts an explanatory comment but withholds `replan`, leaving the issue claimable via `list-unclaimed` so a fresh worker picks it up again. Non-directive issues behave exactly as before. The `replan` command docs (Claude and Codex variants) are updated to describe the new invariant.

Adds tests for the directive carve-out on `skip` and `close-pr-unsalvageable`, plus a non-directive regression test. Full suite: 448 passing.

🤖 Prepared with Claude Code