### PR TITLE
feat: name the account in the log when a session fails authentication

### DIFF
--- a/.pod/tui-cache.json
+++ b/.pod/tui-cache.json
@@ -1,1 +1,1 @@
-{"schema": 3, "repo": "o/r", "fetched_at": 1780138513.460603, "body": {"openAgentPlan": {"nodes": []}, "openDirective": {"nodes": []}, "closedAgentPlan": {"nodes": []}, "closedDirective": {"nodes": []}, "blocked": {"nodes": []}, "hasPrIssues": {"nodes": []}, "pullRequests": {"nodes": []}}}
+{"schema": 3, "repo": "o/r", "fetched_at": 1780139250.893441, "body": {"openAgentPlan": {"nodes": []}, "openDirective": {"nodes": []}, "closedAgentPlan": {"nodes": []}, "closedDirective": {"nodes": []}, "blocked": {"nodes": []}, "hasPrIssues": {"nodes": []}, "pullRequests": {"nodes": []}}}

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -6736,23 +6736,12 @@ def agent_process_main(config: dict, agent_id: str | None = None,
         # Must run BEFORE claim cleanup: coordination skip marks issues as
         # "replan", but quota exhaustion is temporary — the issue is fine,
         # only the quota is depleted.  Release the claim without replan.
-        _is_quota_exhausted = False
-        if exit_code != 0:
-            try:
-                _stdout_path = (PROJECT_DIR
-                    / cfg_get(config, "project", "session_dir", default="sessions")
-                    / f"{session_uuid}.stdout")
-                with open(_stdout_path, "rb") as f:
-                    f.seek(0, 2)  # end
-                    tail_start = max(0, f.tell() - 4096)
-                    f.seek(tail_start)
-                    tail = f.read().decode(errors="replace").lower()
-                if ("hit your limit" in tail
-                        or "rate limit" in tail
-                        or "quota exceeded" in tail):
-                    _is_quota_exhausted = True
-            except OSError:
-                pass
+        # Read the session stdout tail once and reuse it to classify the
+        # failure: quota exhaustion here, auth failure in the circuit
+        # breaker below.
+        stdout_tail = (_read_session_stdout_tail(session_uuid, config)
+                       if exit_code != 0 else "")
+        _is_quota_exhausted = any(m in stdout_tail for m in _QUOTA_MARKERS)
 
         if _is_quota_exhausted:
             log(f"Agent {short_id}: session stdout indicates quota exhaustion, "
@@ -6851,8 +6840,16 @@ def agent_process_main(config: dict, agent_id: str | None = None,
             rapid_failures = getattr(state, '_rapid_failures', 0) + 1
             state._rapid_failures = rapid_failures
             backoff = min(60 * rapid_failures, 300)
-            log(f"Agent {short_id}: session exited in {elapsed:.0f}s with 0 tokens "
-                f"(rapid failure #{rapid_failures}), backing off {backoff}s")
+            if exit_code != 0 and _looks_like_auth_failure(stdout_tail):
+                log(f"Agent {short_id}: authentication failed on account "
+                    f"'{state.account_label or '<none>'}' (exit {exit_code}, "
+                    f"0 tokens) — the account is likely logged out; re-login "
+                    f"or check `pod accounts`. Backing off {backoff}s "
+                    f"(failure #{rapid_failures})")
+            else:
+                log(f"Agent {short_id}: session exited in {elapsed:.0f}s with "
+                    f"0 tokens (rapid failure #{rapid_failures}), backing off "
+                    f"{backoff}s")
             cleanup_worktree(wt_dir, branch)
             state.worktree = ""
             state.branch = ""
@@ -6932,6 +6929,53 @@ def _session_is_broken(exit_code: int, tokens_in: int, tokens_out: int,
     if tokens_in or tokens_out:
         return False
     return exit_code != 0 or elapsed < 15
+
+
+# Substrings in a failed session's stdout tail that mean "quota depleted"
+# (temporary; the account is fine) rather than a broken account.
+_QUOTA_MARKERS = ("hit your limit", "rate limit", "quota exceeded")
+
+# Substrings that mean the failure was authentication — a logged-out /
+# expired / cleared OAuth token or bad API key — rather than quota or a
+# code crash. Matched case-insensitively against the lowercased tail.
+_AUTH_FAILURE_MARKERS = (
+    "invalid api key",
+    "please run /login",
+    "oauth token has expired",
+    "token has expired",
+    "token expired",
+    "authentication failed",
+    "authentication error",
+    "unauthorized",
+    "not logged in",
+    "login required",
+    "invalid bearer token",
+    "401",
+)
+
+
+def _read_session_stdout_tail(session_uuid: str, config: dict,
+                              nbytes: int = 4096) -> str:
+    """Return the last ``nbytes`` of a session's stdout, lowercased.
+
+    Empty string on any read error. Used to classify why a failed session
+    exited (quota exhaustion vs authentication failure).
+    """
+    try:
+        path = (PROJECT_DIR
+                / cfg_get(config, "project", "session_dir", default="sessions")
+                / f"{session_uuid}.stdout")
+        with open(path, "rb") as f:
+            f.seek(0, 2)  # end
+            f.seek(max(0, f.tell() - nbytes))
+            return f.read().decode(errors="replace").lower()
+    except OSError:
+        return ""
+
+
+def _looks_like_auth_failure(stdout_tail: str) -> bool:
+    """True if the lowercased stdout tail contains an auth-failure marker."""
+    return any(m in stdout_tail for m in _AUTH_FAILURE_MARKERS)
 
 
 def _git_rev(wt_dir: str) -> str:

--- a/tests/test_auth_failure_log.py
+++ b/tests/test_auth_failure_log.py
@@ -1,0 +1,50 @@
+"""Tests for the auth-failure classifier used in the agent-loop circuit
+breaker.
+
+When a broken session (zero tokens, non-zero exit) was caused by an
+authentication problem — a logged-out / expired account — the loop logs
+"authentication failed on account '<label>'" instead of a generic
+backoff line, so the operator can see *which* account to re-login.
+"""
+
+from __future__ import annotations
+
+from pod import cli
+from pod.cli import _looks_like_auth_failure
+
+
+def test_auth_markers_are_detected():
+    for tail in [
+        "error: invalid api key provided",
+        "please run /login to authenticate",
+        "oauth token has expired",
+        "http 401 unauthorized",
+        "authentication failed: not logged in",
+    ]:
+        assert _looks_like_auth_failure(tail) is True, tail
+
+
+def test_non_auth_failures_are_not_flagged():
+    for tail in [
+        "hit your limit; resets at 5pm",        # quota, not auth
+        "rate limit exceeded",                  # quota, not auth
+        "segmentation fault (core dumped)",     # crash
+        "traceback (most recent call last):",   # crash
+        "",                                     # no output
+    ]:
+        assert _looks_like_auth_failure(tail) is False, tail
+
+
+def test_read_session_stdout_tail_lowercases_and_matches(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "PROJECT_DIR", tmp_path)
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    (sessions / "U123.stdout").write_text("startup...\nOAuth Token Has Expired\n")
+    tail = cli._read_session_stdout_tail("U123", {})
+    assert "oauth token has expired" in tail  # lowercased
+    assert _looks_like_auth_failure(tail) is True
+
+
+def test_read_session_stdout_tail_missing_file_is_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "PROJECT_DIR", tmp_path)
+    assert cli._read_session_stdout_tail("nonexistent", {}) == ""


### PR DESCRIPTION
This PR makes a session that fails because its account is logged out (or its OAuth token expired/was cleared, or the API key is bad) log a clear, account-named line instead of a generic backoff message. When the circuit breaker trips on a zero-token, non-zero-exit session, it now classifies the stdout tail and, on an auth marker, logs `authentication failed on account '<label>' … re-login or check pod accounts` so the operator can see exactly which account to fix.

This is the diagnostics follow-up to the preflight/circuit-breaker fix in #73: the preflight stops a logged-out account from being dispatched in the first place, and this makes the rare auth failure that still reaches a session legible at a glance rather than reading as a generic rapid-failure backoff.

The session stdout tail is now read once and reused for both the existing quota-exhaustion check and the new auth check; the quota substrings move into `_QUOTA_MARKERS`, the auth substrings into `_AUTH_FAILURE_MARKERS`, and the read into `_read_session_stdout_tail`. Pure diagnostics — no control-flow change. Adds unit tests for the classifier and the tail reader. Full suite: 463 passing.

🤖 Prepared with Claude Code