### PR TITLE
fix: send template-diff banners to stderr so they don't corrupt coordination JSON

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -406,16 +406,16 @@ def _agent_config_sync_check():
 
     if updated:
         print(f"pod: updated {len(updated)} file(s) from new pod version: "
-              f"{', '.join(updated)}")
+              f"{', '.join(updated)}", file=sys.stderr)
     if custom:
         print(f"pod: {len(custom)} project-customised file(s) differ from pod template: "
-              f"{', '.join(custom)}")
+              f"{', '.join(custom)}", file=sys.stderr)
     if conflicts and not first_run:
         print(f"pod: WARNING: {len(conflicts)} file(s) modified in both pod template and "
-              f"project .claude/ — not auto-updating: {', '.join(conflicts)}")
+              f"project .claude/ — not auto-updating: {', '.join(conflicts)}", file=sys.stderr)
     elif conflicts and first_run:
         print(f"pod: {len(conflicts)} file(s) differ from pod template "
-              f"(origin unknown, tracking from now): {', '.join(conflicts)}")
+              f"(origin unknown, tracking from now): {', '.join(conflicts)}", file=sys.stderr)
 
 
 def ensure_config() -> dict:


### PR DESCRIPTION
This PR routes the four informational template-diff banners in `_agent_config_sync_check` (pod/cli.py) to stderr instead of stdout, resolving a dispatcher deadlock in which the dispatcher sees an empty queue and spins planners forever. `coordination.py`'s `_unclaimed_issues` re-invokes `pod _filter-trusted-issues` as a subprocess and parses its stdout as JSON; when a banner such as `pod: N project-customised file(s) differ from pod template: ...` fires, it is prepended to the JSON payload, `_safe_json` fails to parse it, the dispatcher reads queue_depth=0, and it dispatches planners endlessly instead of workers. Sending the banners to stderr keeps stdout clean JSON for internal callers while leaving the messages visible to humans.

🤖 Prepared with Claude Code