### PR TITLE
fix: honor ~/.claude/.current-account so an external account manager owns selection

### DIFF
--- a/pod/accounts.py
+++ b/pod/accounts.py
@@ -290,11 +290,39 @@ class Account:
     path: Path  # ~/.claude/credentials<N>.json
 
 
+def _read_current_account() -> int | None:
+    """Account number an external manager marked active in
+    ``~/.claude/.current-account``.
+
+    A ``swap-account``-style script may own account selection (picking the
+    best account by quota and writing its number here, plus mirroring its
+    credentials into ``.credentials.json``). When that marker is present,
+    pod must defer to it rather than choosing its own account. Returns
+    ``None`` if the file is absent or unparseable.
+    """
+    try:
+        txt = (CLAUDE_DIR / ".current-account").read_text().strip()
+    except OSError:
+        return None
+    try:
+        return int(txt)
+    except ValueError:
+        return None
+
+
 def list_claude_accounts() -> list[Account]:
-    """Return all (label, number, path) accounts from ~/.claude/credentialsN.json.
+    """Return the (label, number, path) Claude accounts pod may use.
 
     Sorted by account number. Files that fail to parse or lack an
     ``accountLabel`` are skipped (logged once).
+
+    If ``~/.claude/.current-account`` names a present, loadable account,
+    **only that account is returned**: an external account manager (e.g. a
+    ``swap-account`` script that picks the best account by remaining quota)
+    owns selection, and pod must use its choice instead of enumerating the
+    ``credentials*.json`` pool and ordering by its own preference. Without
+    that marker pod falls back to the full enumeration, so setups that let
+    pod manage multiple accounts are unaffected.
     """
     out: list[Account] = []
     try:
@@ -316,6 +344,14 @@ def list_claude_accounts() -> list[Account]:
         if not label or label == "?":
             continue
         out.append(Account(label=label, number=num, path=path))
+    # Defer to an external account manager's active-account marker. Only
+    # pin when the marker resolves to an account we actually loaded;
+    # otherwise fall back to the full list rather than returning nothing.
+    current = _read_current_account()
+    if current is not None:
+        pinned = [a for a in out if a.number == current]
+        if pinned:
+            return pinned
     return out
 
 

--- a/pod/accounts.py
+++ b/pod/accounts.py
@@ -290,15 +290,19 @@ class Account:
     path: Path  # ~/.claude/credentials<N>.json
 
 
-def _read_current_account() -> int | None:
+def current_account() -> int | None:
     """Account number an external manager marked active in
     ``~/.claude/.current-account``.
 
     A ``swap-account``-style script may own account selection (picking the
-    best account by quota and writing its number here, plus mirroring its
-    credentials into ``.credentials.json``). When that marker is present,
-    pod must defer to it rather than choosing its own account. Returns
-    ``None`` if the file is absent or unparseable.
+    best account by remaining quota, writing its number here, and mirroring
+    its credentials into ``.credentials.json``). When this marker is present
+    pod must select that account for new dispatches rather than choosing its
+    own from the pool. Returns ``None`` if the file is absent or unparseable.
+
+    This is *selection* policy only — it must not filter the raw account
+    enumeration (``list_claude_accounts``), which lease release/harvest and
+    ``pod accounts list`` rely on to see *all* accounts.
     """
     try:
         txt = (CLAUDE_DIR / ".current-account").read_text().strip()
@@ -310,19 +314,30 @@ def _read_current_account() -> int | None:
         return None
 
 
+def select_for_dispatch(accts: list[Account]) -> list[Account]:
+    """Narrow a raw account list to those pod may pick for a new dispatch.
+
+    If ``current_account()`` names one of ``accts``, return only it (defer to
+    the external account manager's choice). Otherwise return ``accts``
+    unchanged, so setups where pod manages multiple accounts itself — and
+    cases where the marker points at an account pod can't see — keep the full
+    pool to choose from.
+    """
+    current = current_account()
+    if current is not None:
+        pinned = [a for a in accts if a.number == current]
+        if pinned:
+            return pinned
+    return accts
+
+
 def list_claude_accounts() -> list[Account]:
-    """Return the (label, number, path) Claude accounts pod may use.
+    """Return all (label, number, path) accounts from ~/.claude/credentialsN.json.
 
     Sorted by account number. Files that fail to parse or lack an
-    ``accountLabel`` are skipped (logged once).
-
-    If ``~/.claude/.current-account`` names a present, loadable account,
-    **only that account is returned**: an external account manager (e.g. a
-    ``swap-account`` script that picks the best account by remaining quota)
-    owns selection, and pod must use its choice instead of enumerating the
-    ``credentials*.json`` pool and ordering by its own preference. Without
-    that marker pod falls back to the full enumeration, so setups that let
-    pod manage multiple accounts are unaffected.
+    ``accountLabel`` are skipped (logged once). This is the full enumeration
+    used by lease release/harvest and ``pod accounts list``; dispatch
+    selection narrows it via ``select_for_dispatch``.
     """
     out: list[Account] = []
     try:
@@ -344,14 +359,6 @@ def list_claude_accounts() -> list[Account]:
         if not label or label == "?":
             continue
         out.append(Account(label=label, number=num, path=path))
-    # Defer to an external account manager's active-account marker. Only
-    # pin when the marker resolves to an account we actually loaded;
-    # otherwise fall back to the full list rather than returning nothing.
-    current = _read_current_account()
-    if current is not None:
-        pinned = [a for a in out if a.number == current]
-        if pinned:
-            return pinned
     return out
 
 

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1727,8 +1727,15 @@ def acquire_backend(
         _release_account_lease(state, claude_config_dir)
 
     # Step 2: bulk-probe all accounts + codex once per pass.
+    # Narrow to the account an external manager (e.g. a `swap-account` script,
+    # via ~/.claude/.current-account) marked active — pod must use its choice
+    # for new dispatches instead of ordering the whole pool by its own
+    # preference. No-op when the marker is absent. Selection only: the raw
+    # `list_claude_accounts()` enumeration is left intact for lease
+    # release/harvest and `pod accounts list`.
     claude_accts = (
-        accounts.list_claude_accounts() if "claude" in backends_allowed else [])
+        accounts.select_for_dispatch(accounts.list_claude_accounts())
+        if "claude" in backends_allowed else [])
     available_by_label: dict[str, str | None] = {}
     if "claude" in backends_allowed and not force:
         for a in claude_accts:

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -73,34 +73,52 @@ class ListClaudeAccountsTests(_IsolatedHome):
     def test_empty_directory_returns_empty_list(self):
         self.assertEqual(accounts.list_claude_accounts(), [])
 
-    def test_current_account_marker_pins_single_account(self):
-        # An external swap-account script marks account 4 active; pod must
-        # defer to it and ignore the rest of the pool (the bug: pod used to
-        # enumerate all and pick by its own order, overriding the choice).
+    def test_list_claude_accounts_ignores_current_account_marker(self):
+        # The raw enumeration must NOT be filtered by .current-account —
+        # lease release/harvest and `pod accounts list` rely on the full map.
         (self.tmp / "credentials2.json").write_text(_make_creds("alpha", "2026-12-31T00:00:00Z"))
-        (self.tmp / "credentials3.json").write_text(_make_creds("beta", "2026-12-31T00:00:00Z"))
         (self.tmp / "credentials4.json").write_text(_make_creds("gamma", "2026-12-31T00:00:00Z"))
         (self.tmp / ".current-account").write_text("4\n")
 
         accts = accounts.list_claude_accounts()
-        self.assertEqual([(a.number, a.label) for a in accts], [(4, "gamma")])
-
-    def test_current_account_marker_unresolvable_falls_back_to_full_list(self):
-        # Marker points at an account that isn't loadable → don't return
-        # nothing; fall back to the full enumeration.
-        (self.tmp / "credentials2.json").write_text(_make_creds("alpha", "2026-12-31T00:00:00Z"))
-        (self.tmp / "credentials4.json").write_text(_make_creds("gamma", "2026-12-31T00:00:00Z"))
-        (self.tmp / ".current-account").write_text("9\n")
-
-        accts = accounts.list_claude_accounts()
         self.assertEqual([(a.number, a.label) for a in accts], [(2, "alpha"), (4, "gamma")])
 
-    def test_current_account_marker_unparseable_falls_back(self):
-        (self.tmp / "credentials2.json").write_text(_make_creds("alpha", "2026-12-31T00:00:00Z"))
-        (self.tmp / ".current-account").write_text("not-a-number")
 
-        accts = accounts.list_claude_accounts()
-        self.assertEqual([(a.number, a.label) for a in accts], [(2, "alpha")])
+# --- current_account / select_for_dispatch ----------------------------------
+
+
+class CurrentAccountSelectionTests(_IsolatedHome):
+    def _accts(self):
+        (self.tmp / "credentials2.json").write_text(_make_creds("alpha", "2026-12-31T00:00:00Z"))
+        (self.tmp / "credentials3.json").write_text(_make_creds("beta", "2026-12-31T00:00:00Z"))
+        (self.tmp / "credentials4.json").write_text(_make_creds("gamma", "2026-12-31T00:00:00Z"))
+        return accounts.list_claude_accounts()
+
+    def test_current_account_parsing(self):
+        self.assertIsNone(accounts.current_account())
+        (self.tmp / ".current-account").write_text("4\n")
+        self.assertEqual(accounts.current_account(), 4)
+        (self.tmp / ".current-account").write_text("not-a-number")
+        self.assertIsNone(accounts.current_account())
+
+    def test_select_for_dispatch_pins_to_marked_account(self):
+        accts = self._accts()
+        (self.tmp / ".current-account").write_text("4\n")
+        picked = accounts.select_for_dispatch(accts)
+        self.assertEqual([(a.number, a.label) for a in picked], [(4, "gamma")])
+
+    def test_select_for_dispatch_no_marker_returns_all(self):
+        accts = self._accts()
+        picked = accounts.select_for_dispatch(accts)
+        self.assertEqual([a.number for a in picked], [2, 3, 4])
+
+    def test_select_for_dispatch_unresolvable_marker_returns_all(self):
+        # Marker names an account not in the (probed/loadable) list → keep the
+        # full pool rather than collapsing to nothing.
+        accts = self._accts()
+        (self.tmp / ".current-account").write_text("9\n")
+        picked = accounts.select_for_dispatch(accts)
+        self.assertEqual([a.number for a in picked], [2, 3, 4])
 
 
 # --- Keychain service name --------------------------------------------------

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -73,6 +73,35 @@ class ListClaudeAccountsTests(_IsolatedHome):
     def test_empty_directory_returns_empty_list(self):
         self.assertEqual(accounts.list_claude_accounts(), [])
 
+    def test_current_account_marker_pins_single_account(self):
+        # An external swap-account script marks account 4 active; pod must
+        # defer to it and ignore the rest of the pool (the bug: pod used to
+        # enumerate all and pick by its own order, overriding the choice).
+        (self.tmp / "credentials2.json").write_text(_make_creds("alpha", "2026-12-31T00:00:00Z"))
+        (self.tmp / "credentials3.json").write_text(_make_creds("beta", "2026-12-31T00:00:00Z"))
+        (self.tmp / "credentials4.json").write_text(_make_creds("gamma", "2026-12-31T00:00:00Z"))
+        (self.tmp / ".current-account").write_text("4\n")
+
+        accts = accounts.list_claude_accounts()
+        self.assertEqual([(a.number, a.label) for a in accts], [(4, "gamma")])
+
+    def test_current_account_marker_unresolvable_falls_back_to_full_list(self):
+        # Marker points at an account that isn't loadable → don't return
+        # nothing; fall back to the full enumeration.
+        (self.tmp / "credentials2.json").write_text(_make_creds("alpha", "2026-12-31T00:00:00Z"))
+        (self.tmp / "credentials4.json").write_text(_make_creds("gamma", "2026-12-31T00:00:00Z"))
+        (self.tmp / ".current-account").write_text("9\n")
+
+        accts = accounts.list_claude_accounts()
+        self.assertEqual([(a.number, a.label) for a in accts], [(2, "alpha"), (4, "gamma")])
+
+    def test_current_account_marker_unparseable_falls_back(self):
+        (self.tmp / "credentials2.json").write_text(_make_creds("alpha", "2026-12-31T00:00:00Z"))
+        (self.tmp / ".current-account").write_text("not-a-number")
+
+        accts = accounts.list_claude_accounts()
+        self.assertEqual([(a.number, a.label) for a in accts], [(2, "alpha")])
+
 
 # --- Keychain service name --------------------------------------------------
 


### PR DESCRIPTION
This PR makes pod defer Claude account selection to an external account manager when one is in charge.

`list_claude_accounts()` globbed every `~/.claude/credentials*.json` and returned the whole pool, leaving pod to order and pick by its own preference. That overrides a `swap-account`-style script that picks the best account by remaining quota, records its number in `~/.claude/.current-account`, and mirrors it into `.credentials.json`. In practice pod kept selecting a different numbered account from the pool — including a logged-out one — so `pod once` dispatches resolved that account's stale token, failed auth, and aborted as a rapid failure, never falling through to the account the user had actually made active.

With this change, when `~/.claude/.current-account` names a present, loadable account, `list_claude_accounts()` returns only that account, so pod uses the externally-chosen active account everywhere (lease selection and dispatch). Without the marker it falls back to the full enumeration, so setups where pod manages multiple accounts itself are unchanged. A marker that points at an account pod can't load is ignored (falls back to the full list rather than returning an empty one).

Adds three `ListClaudeAccountsTests` cases (marker pins single account; unresolvable marker falls back; unparseable marker falls back). Full suite green (466 tests).