### PR TITLE
fix: share the canonical credential when an external manager owns selection

### DIFF
--- a/pod/accounts.py
+++ b/pod/accounts.py
@@ -641,6 +641,43 @@ def preflight_and_mirror(label: str, account_num: int,
         return "ok"
 
 
+def place_shared_credential(claude_config_dir: Path | None, *,
+                            now: float, skew: float = 0.0) -> str:
+    """Point the agent's isolated config dir at the live canonical
+    ``~/.claude/.credentials.json`` via a symlink — no copy, no keychain,
+    no lease.
+
+    This is the credential path when an external account manager owns
+    selection (``~/.claude/.current-account`` present) and keeps the active
+    account mirrored in ``~/.claude/.credentials.json``. pod does not pick,
+    lease, or mirror accounts here: every agent reads whatever the manager
+    has made canonical, and because it is a symlink (not a copy) a later
+    swap of the canonical is picked up by the next launch rather than going
+    stale. Token refreshes land in the agent's per-dir keychain entry, not
+    back through the link, so they cannot clobber the canonical.
+
+    Returns ``"missing"`` / ``"expired"`` / ``"ok"`` like
+    ``preflight_and_mirror``.
+    """
+    canonical = CLAUDE_DIR / ".credentials.json"
+    blob = _read_credential_blob(canonical)
+    if not blob:
+        return "missing"
+    exp = _expires_at(blob)
+    if exp > 0 and exp <= now + skew:
+        return "expired"
+    if claude_config_dir is not None:
+        claude_config_dir.mkdir(parents=True, exist_ok=True)
+        link = claude_config_dir / ".credentials.json"
+        try:
+            if link.is_symlink() or link.exists():
+                link.unlink()
+        except OSError:
+            pass
+        link.symlink_to(canonical)
+    return "ok"
+
+
 def harvest_isolated_to_canonical(label: str, account_num: int,
                                     claude_config_dir: Path) -> bool:
     """If the isolated keychain entry's token is fresher than the

--- a/pod/accounts.py
+++ b/pod/accounts.py
@@ -669,12 +669,14 @@ def place_shared_credential(claude_config_dir: Path | None, *,
     if claude_config_dir is not None:
         claude_config_dir.mkdir(parents=True, exist_ok=True)
         link = claude_config_dir / ".credentials.json"
+        tmp = claude_config_dir / ".credentials.json.tmp"
         try:
-            if link.is_symlink() or link.exists():
-                link.unlink()
+            if tmp.is_symlink() or tmp.exists():
+                tmp.unlink()
         except OSError:
             pass
-        link.symlink_to(canonical)
+        tmp.symlink_to(canonical)
+        os.replace(tmp, link)  # atomic swap, even if `link` already exists
     return "ok"
 
 

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1628,6 +1628,12 @@ def _release_account_lease(state: AgentState,
     label = state.account_label
     if not label:
         return
+    # Shared-credential mode (external account manager owns selection): no
+    # lease was taken and the credential is a symlink to the canonical file,
+    # so there is nothing to harvest or release.
+    if state.lease_acquired_at == 0.0:
+        state.account_label = ""
+        return
     if claude_config_dir is not None:
         for a in accounts.list_claude_accounts():
             if a.label == label:
@@ -1779,45 +1785,60 @@ def acquire_backend(
             l.label for l in accounts.list_leases()
             if l.short_id != short_id
         }
+        # When an external account manager owns selection
+        # (~/.claude/.current-account present), pod defers fully: no
+        # exclusive lease and no keychain. Every agent shares the live
+        # canonical ~/.claude/.credentials.json via a symlink, so any number
+        # run concurrently and a swap of the canonical is picked up by the
+        # next launch. Otherwise keep pod's own per-agent account leasing.
+        shared = accounts.current_account() is not None
         for cand in candidates:
             if cand.backend == "codex":
                 chosen = cand
                 break
-            if cand.label in held_by_others:
-                continue
-            if not accounts.try_acquire_lease(
-                    cand.label, short_id,
-                    project_dir=str(PROJECT_DIR)):
-                continue
+            if not shared:
+                if cand.label in held_by_others:
+                    continue
+                if not accounts.try_acquire_lease(
+                        cand.label, short_id,
+                        project_dir=str(PROJECT_DIR)):
+                    continue
             if not force:
                 fresh = accounts.probe_account(
                     claude_quota_cmd, cand.label, force=True)
                 if (not fresh
                         or accounts.model_tier("claude", fresh)
                         < accounts.model_tier("claude", cand.model)):
+                    if not shared:
+                        accounts.release_lease(cand.label, short_id)
+                    continue
+            # Place the credential the agent will use. Shared mode symlinks
+            # the live canonical (no stale copy, no keychain); otherwise
+            # validate + mirror the leased account as one credential-locked
+            # op. Quota can read fine on a logged-out account — its OAuth
+            # token expired or was cleared — and every session launched on
+            # such an account fails auth at startup (~20s, exit 1); the
+            # status check below guards against re-dispatching it forever.
+            if shared:
+                status = accounts.place_shared_credential(
+                    claude_config_dir, now=time.time(),
+                    skew=_AUTH_EXPIRY_SKEW)
+            else:
+                try:
+                    status = accounts.preflight_and_mirror(
+                        cand.label, cand.account_num, claude_config_dir,
+                        now=time.time(), skew=_AUTH_EXPIRY_SKEW)
+                except (OSError, accounts.CredentialMirrorError) as e:
+                    log(f"acquire_backend: mirror failed for "
+                        f"{cand.label}: {e}")
                     accounts.release_lease(cand.label, short_id)
                     continue
-            # Auth preflight + mirror, as one credential-locked op. Quota
-            # can read fine on an account that is logged out — its OAuth
-            # token expired or was cleared — and every session launched on
-            # such an account fails auth at startup (~20s, 0 tokens, exit
-            # 1); without this guard the agent would re-lease and
-            # re-dispatch it indefinitely. Validating and mirroring under
-            # the same per-account credential lock also closes the TOCTOU
-            # window between checking the token and copying it.
-            try:
-                status = accounts.preflight_and_mirror(
-                    cand.label, cand.account_num, claude_config_dir,
-                    now=time.time(), skew=_AUTH_EXPIRY_SKEW)
-            except (OSError, accounts.CredentialMirrorError) as e:
-                log(f"acquire_backend: mirror failed for {cand.label}: {e}")
-                accounts.release_lease(cand.label, short_id)
-                continue
             if status != "ok":
                 reason = ("no credential (logged out)" if status == "missing"
                           else "token expired")
                 log(f"acquire_backend: skipping {cand.label} — {reason}")
-                accounts.release_lease(cand.label, short_id)
+                if not shared:
+                    accounts.release_lease(cand.label, short_id)
                 continue
             chosen = cand
             break
@@ -1826,7 +1847,9 @@ def acquire_backend(
         return None
     if chosen.backend == "claude":
         state.account_label = chosen.label
-        state.lease_acquired_at = time.time()
+        # Shared mode took no lease; lease_acquired_at == 0.0 marks that so
+        # cleanup skips harvest/release (there is nothing to release).
+        state.lease_acquired_at = 0.0 if shared else time.time()
     else:
         # Picked codex; release any outstanding claude lease.
         if state.account_label:

--- a/pod/cli.py
+++ b/pod/cli.py
@@ -1706,10 +1706,13 @@ def acquire_backend(
     if prefer not in ("claude", "codex"):
         prefer = "codex"
 
-    # Step 1: existing lease still good?
+    # Step 1: existing lease still good? Skipped in shared mode (external
+    # manager owns selection): there is no lease, and we must re-link the
+    # live canonical and re-check the marker every dispatch.
     if (state.account_label
             and not force
             and "claude" in backends_allowed
+            and accounts.current_account() is None
             and (pin_label is None or pin_label == state.account_label)):
         fresh = accounts.probe_account(
             claude_quota_cmd, state.account_label, force=False)
@@ -1791,7 +1794,12 @@ def acquire_backend(
         # canonical ~/.claude/.credentials.json via a symlink, so any number
         # run concurrently and a swap of the canonical is picked up by the
         # next launch. Otherwise keep pod's own per-agent account leasing.
-        shared = accounts.current_account() is not None
+        # Only enter shared mode when the marker resolves to exactly the
+        # account select_for_dispatch pinned; an unresolvable marker falls
+        # back to the full pool, where leasing must still apply.
+        _cur = accounts.current_account()
+        shared = (_cur is not None and len(claude_accts) == 1
+                  and claude_accts[0].number == _cur)
         for cand in candidates:
             if cand.backend == "codex":
                 chosen = cand
@@ -1820,9 +1828,13 @@ def acquire_backend(
             # such an account fails auth at startup (~20s, exit 1); the
             # status check below guards against re-dispatching it forever.
             if shared:
-                status = accounts.place_shared_credential(
-                    claude_config_dir, now=time.time(),
-                    skew=_AUTH_EXPIRY_SKEW)
+                try:
+                    status = accounts.place_shared_credential(
+                        claude_config_dir, now=time.time(),
+                        skew=_AUTH_EXPIRY_SKEW)
+                except OSError as e:
+                    log(f"acquire_backend: shared credential link failed: {e}")
+                    continue
             else:
                 try:
                     status = accounts.preflight_and_mirror(


### PR DESCRIPTION
This PR makes pod defer credential handling entirely to the external account manager when `~/.claude/.current-account` is present, so any number of agents run concurrently on the live `~/.claude/.credentials.json`.

The per-agent dynamic leasing added in #67 enumerates a pool from `credentials{N}.json`, leases the active account **exclusively to one agent**, and mirrors credentials into per-agent keychain entries. With an external `swap-account`/launchd manager owning selection (the case #76 began honoring), that machinery caps concurrency at one agent per usable account and fails dispatch with `accountLabel <none>` whenever the keychain write can't complete — even though the canonical credential is sitting valid in `~/.claude/.credentials.json`.

When `current_account()` is set, this change skips the lease and the keychain mirror and instead symlinks each agent's isolated `.credentials.json` to the live `~/.claude/.credentials.json`. Because it is a symlink rather than a copy, a later swap of the canonical is picked up by the next launch instead of going stale; token refreshes land in the agent's per-dir keychain entry rather than writing back through the link, so they cannot clobber the canonical. `_release_account_lease` skips harvest/release in this mode (no lease was held). The existing pool/lease/keychain path is untouched when no external manager is in control.

Verified on macOS, claude 2.1.172:
- isolated `CLAUDE_CONFIG_DIR` with no credential → `Not logged in · Please run /login` (claude does **not** fall back to `~/.claude`), confirming a symlink is required;
- symlinked `.credentials.json` → authenticates (exit 0), and the symlink is left intact after the run.

🤖 Prepared with Claude Code