### PR TITLE
feat: drive the external account manager from pod so a wedged timer can't strand agents

### DIFF
--- a/pod/cli.py
+++ b/pod/cli.py
@@ -102,6 +102,8 @@ CLAIM_HISTORY_PATH = POD_DIR / "claim-history.json"
 PR_CLAIM_HISTORY_PATH = POD_DIR / "pr-claim-history.json"
 HOUSEKEEPING_LOCK_PATH = POD_DIR / "housekeeping.lock"
 HOUSEKEEPING_STAMP_PATH = POD_DIR / "housekeeping.stamp"
+SHARED_ROTATE_LOCK_PATH = POD_DIR / "shared-account-rotate.lock"
+SHARED_ROTATE_STAMP_PATH = POD_DIR / "shared-account-rotate.stamp"
 ISOLATED_CONFIG_DIR = POD_DIR / "claude-config"
 TARGET_FILE = POD_DIR / "target"  # Target agent count (int, one per line)
 PLANNER_TARGET_FILE = POD_DIR / "planner-target"  # Planner-recommended target agent count
@@ -180,6 +182,21 @@ isolated_config = true             # Use strict pod-managed CODEX_HOME (no ~/.co
 # `[agent.claude] isolated_config` is ignored: transcripts land in
 # ~/.bubble/ai-projects/<bubble-name>/ and are read from there.
 enabled = false
+
+[quota]
+# When an external account manager owns account selection — signalled by
+# ~/.claude/.current-account, which pins pod to one account (see
+# accounts.select_for_dispatch) — pod drives that manager itself rather than
+# relying on its (typically systemd-user-timer) schedule, which can wedge on
+# an unprivileged host across a `nixos-rebuild switch`. On the housekeeping
+# cadence, and before sleeping on `waiting_quota`, pod runs `<cmd> best` to
+# re-pick the best-quota account and refresh tokens, and un-wedges a stuck
+# `systemd --user` rotation timer via `daemon-reexec`. Set to "" to disable;
+# a no-op when ~/.claude/.current-account is absent or the command is missing.
+account_manager_cmd = "~/.claude/swap-account"
+# Max seconds a resuming agent will hold its claim/worktree while waiting for
+# quota to return before giving up and releasing them.
+max_pause_secs = 5400
 
 # Dollars per million tokens.
 # Resolution order when pricing an agent (see `_pricing_for`):
@@ -717,6 +734,150 @@ def _housekeeping_mark_done():
         HOUSEKEEPING_STAMP_PATH.write_text(f"{time.time()}\n")
     except OSError as e:
         log(f"Failed to update housekeeping stamp: {e}")
+
+
+# --- Shared-mode credential rotation ----------------------------------------
+#
+# When pod defers account choice to an external manager (a `swap-account`-style
+# script, signalled by ``~/.claude/.current-account`` — see
+# ``accounts.select_for_dispatch``), that manager is normally driven by a
+# periodic ``systemd --user`` timer. On an unprivileged host that timer is
+# fragile: a ``nixos-rebuild switch`` reexecs the user manager and can wedge
+# its timer clock (next-elapse computed to ``infinity``, no future trigger),
+# and the only durable fix — ``loginctl enable-linger`` — needs root. When that
+# happens the pinned account goes stale: every agent sits in ``waiting_quota``
+# even though a sibling account still has headroom.
+#
+# pod is itself an always-on unprivileged process, so it *drives* the manager
+# instead of depending on the timer: it re-runs ``<manager> best`` (which
+# re-picks the best-quota account and refreshes tokens) on the housekeeping
+# cadence and whenever an agent would otherwise sleep on ``waiting_quota`` —
+# and, since ``systemctl --user daemon-reexec`` needs no privilege, it
+# un-wedges the timer when it detects it stuck. Every path is rate-limited to
+# one run per interval across the whole fleet, and the whole feature is a no-op
+# unless pod is in shared mode with the manager command present.
+
+_USER_ROTATE_TIMERS = (
+    "claude-credential-swap.timer",
+    "claude-keep-alive.timer",
+)
+
+
+@contextlib.contextmanager
+def _shared_rotate_filelock():
+    """Non-blocking lock so only one agent rotates per window (others skip)."""
+    POD_DIR.mkdir(parents=True, exist_ok=True)
+    SHARED_ROTATE_LOCK_PATH.touch()
+    fd = open(SHARED_ROTATE_LOCK_PATH)
+    acquired = False
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            acquired = True
+        except (BlockingIOError, OSError):
+            yield False
+            return
+        yield True
+    finally:
+        if acquired:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        fd.close()
+
+
+def _shared_account_manager_cmd(config: dict) -> str | None:
+    """Path to the external account manager to drive, or None when disabled.
+
+    Enabled only when pod is deferring account choice to an external manager
+    (``~/.claude/.current-account`` present) and the manager command exists on
+    disk. The command defaults to ``~/.claude/swap-account`` and can be
+    overridden — or disabled with ``""`` — via ``[quota] account_manager_cmd``.
+    """
+    if accounts.current_account() is None:
+        return None
+    cmd = cfg_get(config, "quota", "account_manager_cmd",
+                  default="~/.claude/swap-account")
+    if not cmd:
+        return None
+    path = os.path.expanduser(cmd)
+    return path if os.path.exists(path) else None
+
+
+def _user_rotate_timers_wedged() -> bool:
+    """True if a ``systemd --user`` rotation timer is active but has no future
+    trigger — the post-reexec wedge a ``daemon-reexec`` clears. Fail-safe to
+    False on any error or non-systemd host."""
+    for timer in _USER_ROTATE_TIMERS:
+        try:
+            r = subprocess.run(
+                ["systemctl", "--user", "show", timer,
+                 "-p", "ActiveState",
+                 "-p", "NextElapseUSecRealtime",
+                 "-p", "NextElapseUSecMonotonic"],
+                capture_output=True, text=True, timeout=5)
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        if r.returncode != 0:
+            continue
+        props = dict(
+            ln.split("=", 1) for ln in r.stdout.splitlines() if "=" in ln)
+        if props.get("ActiveState") != "active":
+            continue
+        # A healthy active timer has a finite next elapse on at least one clock.
+        real = props.get("NextElapseUSecRealtime", "").strip()
+        mono = props.get("NextElapseUSecMonotonic", "").strip()
+        if not real and mono in ("", "infinity"):
+            return True
+    return False
+
+
+def _heal_wedged_user_timers() -> None:
+    """Un-wedge ``systemd --user`` rotation timers via ``daemon-reexec``.
+
+    No-op unless ``_user_rotate_timers_wedged()``. ``daemon-reexec`` needs no
+    privilege and preserves running units — pod agents are plain subprocesses,
+    not user units, so they are unaffected."""
+    if not _user_rotate_timers_wedged():
+        return
+    log("shared-account: user rotation timer wedged — running "
+        "`systemctl --user daemon-reexec` to re-arm it")
+    for argv in (["systemctl", "--user", "daemon-reexec"],
+                 ["systemctl", "--user", "restart", *_USER_ROTATE_TIMERS]):
+        try:
+            subprocess.run(argv, capture_output=True, timeout=10)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+
+def _maybe_rotate_shared_account(config: dict, *, min_interval: float) -> None:
+    """Drive the external account manager to re-pick the best-quota account and
+    refresh tokens, at most once per ``min_interval`` seconds across all agents.
+    No-op outside shared mode. See the section comment above."""
+    cmd = _shared_account_manager_cmd(config)
+    if cmd is None:
+        return
+
+    def _recent() -> bool:
+        try:
+            last = float(SHARED_ROTATE_STAMP_PATH.read_text().strip())
+        except (OSError, ValueError):
+            return False
+        return (time.time() - last) < min_interval
+
+    if _recent():
+        return
+    with _shared_rotate_filelock() as owns:
+        if not owns or _recent():
+            return
+        try:
+            subprocess.run([cmd, "best"], capture_output=True, timeout=180)
+        except (OSError, subprocess.TimeoutExpired) as e:
+            log(f"shared-account: `{cmd} best` failed: {e}")
+        else:
+            _heal_wedged_user_timers()
+        try:
+            SHARED_ROTATE_STAMP_PATH.write_text(f"{time.time()}\n")
+        except OSError:
+            pass
 
 
 def load_claim_history() -> dict:
@@ -6476,6 +6637,12 @@ def agent_process_main(config: dict, agent_id: str | None = None,
             target = resume_pin_backend or "any backend"
             if resume_pin_label:
                 target += f"/{resume_pin_label}"
+            # In shared mode a stale external pin (e.g. a wedged swap-account
+            # timer) is the usual reason there's no quota here. Drive the
+            # manager to re-pick before sleeping so we recover within one cycle
+            # instead of waiting on the (possibly dead) timer. Rate-limited and
+            # a no-op outside shared mode.
+            _maybe_rotate_shared_account(config, min_interval=quota_retry)
             log(f"Agent {short_id}: no quota for {target}, sleeping {quota_retry}s")
             time.sleep(quota_retry)
         if state.finishing or selection is None:
@@ -6552,6 +6719,15 @@ def agent_process_main(config: dict, agent_id: str | None = None,
                         live = {a.short_id for a in read_all_agents()}
                         live.add(short_id)
                         accounts.evict_orphan_leases(live)
+                except Exception:
+                    pass
+                # Keep the shared-mode account pin fresh (rotation + token
+                # refresh) even when no agent is currently starved — this is
+                # what replaces the external systemd timer pod must not depend
+                # on. No-op outside shared mode.
+                try:
+                    _maybe_rotate_shared_account(
+                        config, min_interval=HOUSEKEEPING_INTERVAL)
                 except Exception:
                     pass
                 _housekeeping_mark_done()

--- a/tests/test_shared_account_rotate.py
+++ b/tests/test_shared_account_rotate.py
@@ -1,0 +1,181 @@
+"""Tests for pod's shared-mode credential rotation.
+
+When pod defers account selection to an external manager (signalled by
+``~/.claude/.current-account``), it must drive that manager itself — a
+``systemd --user`` timer can wedge on an unprivileged host — rather than
+sit in ``waiting_quota`` forever. These cover the gating, rate-limiting,
+and wedge-heal helpers in ``pod.cli``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pod import accounts, cli
+
+
+class _Harness(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="pod-rotate-test-"))
+        # accounts.current_account() reads accounts.CLAUDE_DIR/.current-account
+        self._orig_claude_dir = accounts.CLAUDE_DIR
+        accounts.CLAUDE_DIR = self.tmp / ".claude"
+        accounts.CLAUDE_DIR.mkdir(parents=True)
+        # cli stamp/lock live under POD_DIR
+        self._orig_pod_dir = cli.POD_DIR
+        self._orig_lock = cli.SHARED_ROTATE_LOCK_PATH
+        self._orig_stamp = cli.SHARED_ROTATE_STAMP_PATH
+        cli.POD_DIR = self.tmp / ".pod"
+        cli.POD_DIR.mkdir(parents=True)
+        cli.SHARED_ROTATE_LOCK_PATH = cli.POD_DIR / "shared-account-rotate.lock"
+        cli.SHARED_ROTATE_STAMP_PATH = cli.POD_DIR / "shared-account-rotate.stamp"
+        # A real, on-disk manager command (its contents never run — subprocess
+        # is mocked) so the exists() check passes.
+        self.manager = self.tmp / ".claude" / "swap-account"
+        self.manager.write_text("#!/bin/sh\n")
+        self.config = {"quota": {"account_manager_cmd": str(self.manager)}}
+
+    def tearDown(self) -> None:
+        import shutil
+        accounts.CLAUDE_DIR = self._orig_claude_dir
+        cli.POD_DIR = self._orig_pod_dir
+        cli.SHARED_ROTATE_LOCK_PATH = self._orig_lock
+        cli.SHARED_ROTATE_STAMP_PATH = self._orig_stamp
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _mark_shared(self) -> None:
+        (accounts.CLAUDE_DIR / ".current-account").write_text("3\n")
+
+
+class ManagerCmdGatingTests(_Harness):
+    def test_none_without_current_account_marker(self):
+        # No .current-account → pod manages accounts itself → don't invoke.
+        self.assertIsNone(cli._shared_account_manager_cmd(self.config))
+
+    def test_resolves_when_shared_and_present(self):
+        self._mark_shared()
+        self.assertEqual(
+            cli._shared_account_manager_cmd(self.config), str(self.manager))
+
+    def test_none_when_command_missing_on_disk(self):
+        self._mark_shared()
+        self.manager.unlink()
+        self.assertIsNone(cli._shared_account_manager_cmd(self.config))
+
+    def test_disabled_by_empty_config(self):
+        self._mark_shared()
+        self.assertIsNone(
+            cli._shared_account_manager_cmd({"quota": {"account_manager_cmd": ""}}))
+
+    def test_default_path_used_when_config_absent(self):
+        # No [quota] override → defaults to ~/.claude/swap-account, resolved
+        # against the (patched) accounts.CLAUDE_DIR home.
+        self._mark_shared()
+        with mock.patch("os.path.expanduser", return_value=str(self.manager)):
+            self.assertEqual(cli._shared_account_manager_cmd({}), str(self.manager))
+
+
+class RotateTests(_Harness):
+    def test_noop_outside_shared_mode(self):
+        with mock.patch.object(cli.subprocess, "run") as run:
+            cli._maybe_rotate_shared_account(self.config, min_interval=60)
+        run.assert_not_called()
+
+    def test_runs_manager_best_in_shared_mode(self):
+        self._mark_shared()
+        with mock.patch.object(cli.subprocess, "run") as run, \
+                mock.patch.object(cli, "_heal_wedged_user_timers"):
+            run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            cli._maybe_rotate_shared_account(self.config, min_interval=60)
+        self.assertEqual(run.call_count, 1)
+        self.assertEqual(run.call_args.args[0], [str(self.manager), "best"])
+        self.assertTrue(cli.SHARED_ROTATE_STAMP_PATH.exists())
+
+    def test_rate_limited_within_interval(self):
+        self._mark_shared()
+        with mock.patch.object(cli.subprocess, "run") as run, \
+                mock.patch.object(cli, "_heal_wedged_user_timers"):
+            run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            cli._maybe_rotate_shared_account(self.config, min_interval=600)
+            cli._maybe_rotate_shared_account(self.config, min_interval=600)
+        self.assertEqual(run.call_count, 1)  # second call short-circuited
+
+    def test_runs_again_after_interval_elapses(self):
+        self._mark_shared()
+        with mock.patch.object(cli.subprocess, "run") as run, \
+                mock.patch.object(cli, "_heal_wedged_user_timers"):
+            run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            cli._maybe_rotate_shared_account(self.config, min_interval=600)
+            # Backdate the stamp beyond the window.
+            cli.SHARED_ROTATE_STAMP_PATH.write_text("1.0\n")
+            cli._maybe_rotate_shared_account(self.config, min_interval=600)
+        self.assertEqual(run.call_count, 2)
+
+    def test_manager_failure_is_swallowed_and_stamped(self):
+        self._mark_shared()
+        with mock.patch.object(
+                cli.subprocess, "run",
+                side_effect=subprocess.TimeoutExpired("swap-account", 180)), \
+                mock.patch.object(cli, "log"):
+            cli._maybe_rotate_shared_account(self.config, min_interval=60)
+        # Stamp is written even on failure so a hung manager can't be retried
+        # every 60s across the fleet.
+        self.assertTrue(cli.SHARED_ROTATE_STAMP_PATH.exists())
+
+
+class WedgeDetectionTests(_Harness):
+    def _run_returning(self, stdout: str, rc: int = 0):
+        return subprocess.CompletedProcess([], rc, stdout, "")
+
+    def test_healthy_realtime_timer_not_wedged(self):
+        out = ("ActiveState=active\n"
+               "NextElapseUSecRealtime=Wed 2026-07-08 04:00:00 UTC\n"
+               "NextElapseUSecMonotonic=0\n")
+        with mock.patch.object(cli.subprocess, "run",
+                               return_value=self._run_returning(out)):
+            self.assertFalse(cli._user_rotate_timers_wedged())
+
+    def test_infinity_monotonic_and_no_realtime_is_wedged(self):
+        out = ("ActiveState=active\n"
+               "NextElapseUSecRealtime=\n"
+               "NextElapseUSecMonotonic=infinity\n")
+        with mock.patch.object(cli.subprocess, "run",
+                               return_value=self._run_returning(out)):
+            self.assertTrue(cli._user_rotate_timers_wedged())
+
+    def test_inactive_timer_ignored(self):
+        out = ("ActiveState=inactive\n"
+               "NextElapseUSecRealtime=\n"
+               "NextElapseUSecMonotonic=infinity\n")
+        with mock.patch.object(cli.subprocess, "run",
+                               return_value=self._run_returning(out)):
+            self.assertFalse(cli._user_rotate_timers_wedged())
+
+    def test_missing_systemctl_is_not_wedged(self):
+        with mock.patch.object(cli.subprocess, "run",
+                               side_effect=FileNotFoundError):
+            self.assertFalse(cli._user_rotate_timers_wedged())
+
+    def test_heal_reexecs_only_when_wedged(self):
+        with mock.patch.object(cli, "_user_rotate_timers_wedged",
+                               return_value=True), \
+                mock.patch.object(cli.subprocess, "run") as run, \
+                mock.patch.object(cli, "log"):
+            cli._heal_wedged_user_timers()
+        argvs = [c.args[0] for c in run.call_args_list]
+        self.assertIn(["systemctl", "--user", "daemon-reexec"], argvs)
+
+    def test_heal_noop_when_healthy(self):
+        with mock.patch.object(cli, "_user_rotate_timers_wedged",
+                               return_value=False), \
+                mock.patch.object(cli.subprocess, "run") as run:
+            cli._heal_wedged_user_timers()
+        run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR makes pod drive its external account manager instead of passively depending on the manager's own schedule. When pod defers account selection to a `swap-account`-style script — signalled by `~/.claude/.current-account`, which pins every agent to one account (see `accounts.select_for_dispatch`) — rotation to a sibling account with headroom is left entirely to that manager's timer, typically an unprivileged `systemd --user` timer. That timer is fragile: a `nixos-rebuild switch` reexecs the user manager and can freeze its clock so every timer computes its next elapse in the past and never fires again, and the only durable fix, `loginctl enable-linger`, needs root. When that happens the pinned account goes stale and the whole fleet sits in `waiting_quota` while another account still has Opus quota.

pod is itself an always-on unprivileged process, so it now drives the manager: on the housekeeping cadence, and before sleeping on `waiting_quota`, it runs `<manager> best` to re-pick the best-quota account and refresh tokens, and — since `systemctl --user daemon-reexec` needs no privilege — it un-wedges a stuck rotation timer when it detects one (active with no future elapse). Every path is rate-limited to one run per interval across the whole fleet via a filelock and stamp, and the whole feature is a no-op unless pod is in shared mode with the manager command present. The command defaults to `~/.claude/swap-account` and is configurable, or disable-able with `""`, via `[quota] account_manager_cmd`.

🤖 Prepared with Claude Code